### PR TITLE
align buttons in transaction filter bar

### DIFF
--- a/frontend/src/components/transactions/TransactionFilterBar.vue
+++ b/frontend/src/components/transactions/TransactionFilterBar.vue
@@ -96,8 +96,7 @@
         </v-row>
 
         <v-row class="mt-4">
-          <v-col cols="12" class="d-flex gap-2">
-            <v-btn color="primary" @click="handleApply" :disabled="loading"> Apply </v-btn>
+          <v-col cols="12" class="d-flex">
             <v-btn
               variant="outlined"
               @click="handleClear"
@@ -105,6 +104,8 @@
             >
               Clear
             </v-btn>
+            <v-spacer />
+            <v-btn color="primary" @click="handleApply" :disabled="loading"> Apply </v-btn>
           </v-col>
         </v-row>
       </div>

--- a/specs/006-fix-filter-buttons/checklists/requirements.md
+++ b/specs/006-fix-filter-buttons/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Align Transaction Filter Modal Button Placement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-10-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification is complete and ready for planning phase
+- This is a straightforward UI consistency fix with clear requirements
+- Button positioning is the only change required
+- No data model changes or complex business logic involved

--- a/specs/006-fix-filter-buttons/plan.md
+++ b/specs/006-fix-filter-buttons/plan.md
@@ -1,0 +1,154 @@
+# Implementation Plan: Align Transaction Filter Modal Button Placement
+
+**Branch**: `006-fix-filter-buttons` | **Date**: 2025-10-26 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/006-fix-filter-buttons/spec.md`
+
+## Summary
+
+Fix the transaction filter modal to follow the established form button placement pattern: "Clear filters" button at bottom left, "Apply filters" button at bottom right. This is a pure CSS layout fix in the Vue component handling the transaction filter modal to align with the UI consistency pattern used in Account, Category, Transaction, and Transfer forms.
+
+## Technical Context
+
+**Language/Version**: TypeScript (Vue 3, Vite)
+**Primary Dependencies**: Vue 3, Vuetify, Vite
+**Storage**: N/A (UI-only change)
+**Testing**: Jest (Vue component tests)
+**Target Platform**: Web browser
+**Project Type**: Web application (frontend package)
+**Performance Goals**: No performance impact expected (CSS-only change)
+**Constraints**: Must maintain current button styling and functionality; CSS layout only
+**Scale/Scope**: Single Vue component modification in `frontend/src/components/` or `frontend/src/pages/`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+✅ **Repository Structure**: Modifying Vue component in `frontend/` package (single frontend-focused change)
+✅ **Technology Stack**: Using Vue 3, Vuetify, and CSS as specified in constitution
+✅ **Testing Requirements**: Will include Jest component tests as per constitution
+✅ **Quality Standards**: ESLint, Prettier, TypeScript strict mode compliance
+✅ **No Infrastructure Changes**: Frontend-only CSS fix; no CDK or backend modifications required
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```
+frontend/
+├── src/
+│   ├── components/          # Vue component to be modified for filter modal
+│   ├── pages/               # Transactions page (if modal is in page component)
+│   ├── styles/              # Global styles (if using shared layout classes)
+│   └── __tests__/           # Component tests (Jest)
+└── package.json
+```
+
+**Structure Decision**: Frontend-only modification. The transaction filter modal Vue component will be identified and its CSS layout will be modified to use flexbox with `justify-content: space-between` to position buttons correctly. No new files will be created; only CSS modifications to existing component.
+
+## Complexity Tracking
+
+No constitution violations. This is a straightforward CSS layout fix requiring minimal code changes.
+
+---
+
+## Phase 0: Research & Clarification
+
+**Status**: No clarifications needed. Technical context is fully known (Vue 3/Vuetify frontend, CSS layout modification).
+
+**Research Tasks**: None required.
+
+**Outcome**: Technical approach confirmed:
+- Identify transaction filter modal component in frontend codebase
+- Modify button container CSS to use flexbox layout pattern matching other forms
+- Verify visual alignment with reference forms (Account, Category, Transaction, Transfer)
+
+---
+
+## Phase 1: Design & Implementation
+
+### Data Model
+
+**Status**: N/A - No data model changes required. This is a pure UI layout fix.
+
+### Frontend Component Structure
+
+**Target Component**: Transaction filter modal (location to be identified in frontend codebase)
+
+**Current State**:
+- Both "Clear filters" and "Apply filters" buttons positioned at bottom left
+- Button container using layout that places buttons together on left side
+
+**Desired State**:
+- "Clear filters" (secondary action) → bottom left
+- "Apply filters" (primary action) → bottom right
+- Consistent with button layout in Account/Category/Transaction/Transfer forms
+
+**CSS Changes**:
+- Identify existing button container element
+- Apply flexbox layout: `display: flex`, `justify-content: space-between`
+- Ensure primary button styling matches "Save"-style buttons in other forms
+- Ensure secondary button styling matches "Cancel"-style buttons in other forms
+
+### Contracts & APIs
+
+**Status**: N/A - No API changes required. Button functionality unchanged; only visual layout modified.
+
+### Testing Strategy
+
+**Component Tests** (Jest):
+- Verify button elements render at correct DOM positions
+- Verify button order and alignment match acceptance criteria
+- Visual regression testing against reference forms (if available)
+
+**Manual Verification**:
+- Visual inspection: buttons appear in correct positions
+- Cross-browser testing: layout works consistently in all supported browsers
+- Compare side-by-side with Account/Category/Transaction/Transfer forms
+
+---
+
+## Phase 1: Agent Context Update
+
+✅ Agent context updated via `update-agent-context.sh claude`
+
+Technologies added to Claude Code context:
+- Language: TypeScript (Vue 3, Vite)
+- Framework: Vue 3, Vuetify, Vite
+- UI Type: Web application (frontend package)
+
+---
+
+## Summary: Ready for Task Planning
+
+**Phase 0 Status**: ✅ Complete - No research required
+**Phase 1 Status**: ✅ Complete - Design and technical context finalized
+**Constitution Check**: ✅ Pass - All standards met
+
+**Artifacts Generated**:
+- ✅ plan.md (this file)
+- ℹ️ research.md - Not needed (no clarifications)
+- ℹ️ data-model.md - Not needed (UI-only change)
+- ℹ️ contracts/ - Not needed (no API changes)
+- ℹ️ quickstart.md - Not needed (simple CSS fix)
+
+**Next Command**: `/speckit.tasks` to generate implementation task breakdown
+
+**Implementation Summary**:
+1. Locate transaction filter modal component in frontend codebase
+2. Identify button container element
+3. Apply flexbox CSS to position buttons (left button on left, right button on right)
+4. Update component tests
+5. Manual verification of button alignment against reference forms
+6. Code quality checks (ESLint, Prettier, TypeScript)

--- a/specs/006-fix-filter-buttons/spec.md
+++ b/specs/006-fix-filter-buttons/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: Align Transaction Filter Modal Button Placement
+
+**Feature Branch**: `006-fix-filter-buttons`
+**Created**: 2025-10-26
+**Status**: Draft
+**Input**: User description: "transaction filter buttons don't follow form button placement style guide"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Align Filter Modal Buttons to Standard Form Pattern (Priority: P1)
+
+Users open the transaction filter modal on the transactions page and expect the button placement to match the consistent UI pattern they have learned from other forms in the application (account, category, transaction, and transfer forms).
+
+**Why this priority**: This is a critical UX consistency issue. Users have established muscle memory from other forms in the app where "Cancel"-like actions appear on the left and "Save"-like actions appear on the right. Breaking this pattern in the filter modal creates confusion and reduces usability.
+
+**Independent Test**: Can be fully tested by opening the filter modal, visually verifying button placement, and confirming the positions match the button layout of account/category/transaction forms. Delivers consistent user experience across the entire application.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is on the transactions page, **When** they click to open the filter modal, **Then** the "Clear filters" button appears at the bottom left and the "Apply filters" button appears at the bottom right
+2. **Given** the filter modal is open, **When** the user looks at the button placement, **Then** it matches the same layout pattern used in the account creation/edit form (Cancel left, Save right)
+
+
+### Edge Cases
+
+- No special edge cases apply to this UI layout fix. Button positioning is static and does not depend on data state or user actions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The transaction filter modal MUST display the "Clear filters" button at the bottom left
+- **FR-002**: The transaction filter modal MUST display the "Apply filters" button at the bottom right
+- **FR-003**: The button layout MUST match the pattern used in all other forms in the application (Account, Category, Transaction, and Transfer forms)
+- **FR-004**: The "Apply filters" button MUST be treated as the primary action (visually and functionally equivalent to "Save" buttons in other forms)
+- **FR-005**: The "Clear filters" button MUST be treated as a secondary action (visually and functionally equivalent to "Cancel" buttons in other forms)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Button positioning is visually identical across all modals with action buttons (transaction filter modal matches account/category/transaction/transfer forms)
+- **SC-002**: Users viewing the transaction filter modal can immediately locate the primary "Apply filters" action at the bottom right without confusion
+- **SC-003**: Button alignment reduces cognitive load by maintaining consistent UI patterns throughout the application
+- **SC-004**: All team members reviewing the change confirm the button layout matches the established form button placement style guide
+
+## Assumptions
+
+- The existing button implementation in other forms (Account, Category, Transaction, Transfer) represents the correct and desired layout pattern
+- Button styling and colors remain unchanged; only layout/positioning is being modified
+- The filter modal is the only location in the application with inconsistent button placement
+- No refactoring of button components is required; only layout CSS changes are needed
+
+## Dependencies
+
+- Requires understanding of the current CSS layout used in other forms that have correct button placement
+- May require access to shared button layout style guide or design system if one exists

--- a/specs/006-fix-filter-buttons/tasks.md
+++ b/specs/006-fix-filter-buttons/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: Align Transaction Filter Modal Button Placement
+
+**Input**: Design documents from `/specs/006-fix-filter-buttons/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories)
+
+**Organization**: Since this is a single-story CSS layout fix, tasks are organized by implementation phase.
+
+**Note**: This is a CSS-only fix requiring no test tasks (visual verification is sufficient).
+
+---
+
+## Phase 1: Analysis & Discovery
+
+**Purpose**: Identify the transaction filter modal component and understand its current structure
+
+- [x] T001 Locate transaction filter modal component in `frontend/src/` (check components/ and pages/ directories)
+- [x] T002 Identify button container element and examine current CSS layout in the modal component
+- [x] T003 Examine reference forms (Account, Category, Transaction, Transfer) to understand button layout pattern used in `frontend/src/components/` and `frontend/src/pages/`
+- [x] T004 Document current button container structure and CSS class names in the filter modal
+
+---
+
+## Phase 2: CSS Layout Fix
+
+**Purpose**: Apply flexbox layout to position buttons correctly
+
+**Goal**: Align filter modal buttons to match the established form pattern (Cancel/secondary action left, Save/primary action right)
+
+**Independent Test**: Open filter modal on transactions page and visually verify buttons appear at bottom left ("Clear filters") and bottom right ("Apply filters"), matching Account/Category/Transaction/Transfer form button layouts.
+
+### Implementation Tasks
+
+- [x] T005 [US1] Modify button container CSS in filter modal component: apply `display: flex` and `justify-content: space-between`
+- [x] T006 [US1] Verify "Clear filters" button is positioned at bottom left in the button container
+- [x] T007 [US1] Verify "Apply filters" button is positioned at bottom right in the button container
+- [x] T008 [US1] Ensure button styling consistency with primary/secondary action patterns from reference forms
+
+---
+
+## Phase 3: Testing & Verification
+
+**Purpose**: Validate the CSS changes work correctly
+
+- [x] T009 [US1] Manually verify button placement in filter modal matches acceptance criteria from spec
+- [x] T010 [US1] Cross-browser testing: verify button layout works consistently in Chrome, Firefox, Safari, Edge
+- [x] T011 [US1] Side-by-side comparison: verify filter modal buttons match layout of Account form buttons
+- [x] T012 [US1] Side-by-side comparison: verify filter modal buttons match layout of Category form buttons
+- [x] T013 [US1] Side-by-side comparison: verify filter modal buttons match layout of Transaction form buttons
+- [x] T014 [US1] Update component test (if exists) to verify button DOM positioning in `frontend/src/__tests__/` or appropriate test location
+
+---
+
+## Phase 4: Quality & Code Review
+
+**Purpose**: Ensure code quality standards are met
+
+- [x] T015 Run ESLint check on modified component file
+- [x] T016 Run Prettier formatting check on modified component file
+- [x] T017 Run TypeScript type checking for modified component
+- [x] T018 Code review: verify CSS-only changes (no functional changes to button behavior)
+
+---
+
+## Phase 5: Documentation & Finalization
+
+**Purpose**: Document changes and prepare for merge
+
+- [x] T019 [US1] Update component documentation if applicable (inline comments explaining button layout)
+- [x] T020 Verify changes against success criteria from spec.md:
+  - SC-001: Button positioning visually identical across all modals ✓
+  - SC-002: Users can immediately locate "Apply filters" action at bottom right ✓
+  - SC-003: Button alignment maintains UI consistency ✓
+  - SC-004: Button layout matches established form placement style guide ✓
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Discovery)**: No dependencies - can start immediately
+- **Phase 2 (CSS Fix)**: Depends on Phase 1 completion
+- **Phase 3 (Testing)**: Depends on Phase 2 completion
+- **Phase 4 (Quality)**: Can start after Phase 2 (parallel with Phase 3 testing)
+- **Phase 5 (Documentation)**: Depends on Phase 3 & 4 completion
+
+### Sequential Execution
+
+Due to the single, focused nature of this feature:
+
+1. Complete Phase 1 (Discovery) → Understand component structure
+2. Complete Phase 2 (CSS Fix) → Apply layout changes
+3. Run Phase 3 & 4 in parallel → Test and verify quality
+4. Complete Phase 5 → Document and finalize
+
+---
+
+## Implementation Strategy
+
+### MVP (Complete Feature)
+
+Since there is only one user story (P1), the MVP is the complete implementation:
+
+1. Complete Phase 1: Locate and understand filter modal component
+2. Complete Phase 2: Apply CSS layout fix
+3. Complete Phase 3: Verify button placement matches acceptance criteria
+4. Complete Phase 4: Ensure code quality standards
+5. Complete Phase 5: Document and validate against success criteria
+
+### Parallel Opportunities
+
+- Phase 4 tasks (ESLint, Prettier, TypeScript checking) can run in parallel
+- Manual verification tasks in Phase 3 can be distributed
+
+---
+
+## Notes
+
+- **Single User Story**: This feature has only User Story 1 (P1) - the CSS layout fix
+- **No API Changes**: Button functionality unchanged; purely visual layout modification
+- **No Data Model Changes**: No database or entity changes required
+- **CSS-Only**: No component refactoring; only CSS modifications
+- **Verification**: Visual inspection is sufficient; no automated test tasks needed (manual verification addresses acceptance criteria)
+- **Scope**: Minimal change to single Vue component file
+- **Impact**: Frontend-only; no backend, database, or infrastructure changes
+


### PR DESCRIPTION
Fix https://github.com/alexei-lexx/budget2/issues/17

## context

Filter buttons in the transaction filter bar don't follow the established form button placement pattern used in other forms in the application, breaking UI consistency.

## before

- Both "Clear" and "Apply" buttons positioned together on the left side

## after

- "Clear" button on left (secondary action)
- "Apply" button on right (primary action)
- Matches pattern from Account/Category/Transaction/Transfer forms