### PR TITLE
refactor monthly report to use dedicated report type enum

### DIFF
--- a/backend/codegen.ts
+++ b/backend/codegen.ts
@@ -16,6 +16,7 @@ const config: CodegenConfig = {
         // Map GraphQL enums to model enums to avoid type mismatches
         enumValues: {
           CategoryType: "../models/Category#CategoryType",
+          ReportType: "../models/Report#ReportType",
           TransactionType: "../models/Transaction#TransactionType",
         },
         // Map GraphQL types to model types for field resolvers and computed fields

--- a/backend/src/__generated__/resolvers-types.ts
+++ b/backend/src/__generated__/resolvers-types.ts
@@ -1,4 +1,5 @@
 import { CategoryType } from '../models/Category';
+import { ReportType } from '../models/Report';
 import { TransactionType } from '../models/Transaction';
 import { GraphQLResolveInfo } from 'graphql';
 import { GraphQLContext } from '../server';
@@ -72,7 +73,7 @@ export type MonthlyReport = {
   categories: Array<MonthlyReportCategory>;
   currencyTotals: Array<MonthlyReportCurrencyTotal>;
   month: Scalars['Int']['output'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['output'];
 };
 
@@ -206,7 +207,7 @@ export type QueryCategoriesArgs = {
 
 export type QueryMonthlyReportArgs = {
   month: Scalars['Int']['input'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['input'];
 };
 
@@ -230,6 +231,8 @@ export type QueryTransactionsArgs = {
 export type QueryTransferArgs = {
   id: Scalars['ID']['input'];
 };
+
+export { ReportType };
 
 /**
  * Transaction with embedded account and category data.
@@ -450,6 +453,7 @@ export type ResolversTypes = {
   PageInfo: ResolverTypeWrapper<PageInfo>;
   PaginationInput: PaginationInput;
   Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
+  ReportType: ReportType;
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   Transaction: ResolverTypeWrapper<Omit<Transaction, 'account' | 'category'>>;
   TransactionConnection: ResolverTypeWrapper<Omit<TransactionConnection, 'edges'> & { edges: Array<ResolversTypes['TransactionEdge']> }>;
@@ -524,7 +528,7 @@ export type MonthlyReportResolvers<ContextType = GraphQLContext, ParentType exte
   categories?: Resolver<Array<ResolversTypes['MonthlyReportCategory']>, ParentType, ContextType>;
   currencyTotals?: Resolver<Array<ResolversTypes['MonthlyReportCurrencyTotal']>, ParentType, ContextType>;
   month?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
-  type?: Resolver<ResolversTypes['TransactionType'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['ReportType'], ParentType, ContextType>;
   year?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
 };
 
@@ -578,6 +582,8 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   transactions?: Resolver<ResolversTypes['TransactionConnection'], ParentType, ContextType, Partial<QueryTransactionsArgs>>;
   transfer?: Resolver<Maybe<ResolversTypes['Transfer']>, ParentType, ContextType, RequireFields<QueryTransferArgs, 'id'>>;
 };
+
+export type ReportTypeResolvers = EnumResolverSignature<{ EXPENSE?: any, INCOME?: any }, ResolversTypes['ReportType']>;
 
 export type TransactionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Transaction'] = ResolversParentTypes['Transaction']> = {
   account?: Resolver<ResolversTypes['TransactionEmbeddedAccount'], ParentType, ContextType>;
@@ -644,6 +650,7 @@ export type Resolvers<ContextType = GraphQLContext> = {
   Mutation?: MutationResolvers<ContextType>;
   PageInfo?: PageInfoResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  ReportType?: ReportTypeResolvers;
   Transaction?: TransactionResolvers<ContextType>;
   TransactionConnection?: TransactionConnectionResolvers<ContextType>;
   TransactionEdge?: TransactionEdgeResolvers<ContextType>;

--- a/backend/src/models/Report.ts
+++ b/backend/src/models/Report.ts
@@ -1,0 +1,4 @@
+export enum ReportType {
+  INCOME = "INCOME",
+  EXPENSE = "EXPENSE",
+}

--- a/backend/src/resolvers/reportResolvers.ts
+++ b/backend/src/resolvers/reportResolvers.ts
@@ -1,6 +1,6 @@
 import { GraphQLError } from "graphql";
 import { z } from "zod";
-import { TransactionType } from "../models/Transaction";
+import { ReportType } from "../models/Report";
 import { GraphQLContext } from "../server";
 import { YEAR_RANGE_OFFSET } from "../types/validation";
 import { getAuthenticatedUser, handleResolverError } from "./shared";
@@ -15,15 +15,12 @@ const yearSchema = z
   .min(currentYear - YEAR_RANGE_OFFSET)
   .max(currentYear + YEAR_RANGE_OFFSET);
 const monthSchema = z.number().int().min(1).max(12);
-const transactionTypeSchema = z.enum([
-  TransactionType.INCOME,
-  TransactionType.EXPENSE,
-]);
+const reportTypeSchema = z.enum(ReportType);
 
 const monthlyReportInputSchema = z.object({
   year: yearSchema,
   month: monthSchema,
-  type: transactionTypeSchema,
+  type: reportTypeSchema,
 });
 
 export const reportResolvers = {

--- a/backend/src/schema.graphql
+++ b/backend/src/schema.graphql
@@ -8,7 +8,7 @@ type Query {
   ): TransactionConnection!
   transfer(id: ID!): Transfer
   transactionPatterns(type: TransactionPatternType!): [TransactionPattern!]!
-  monthlyReport(year: Int!, month: Int!, type: TransactionType!): MonthlyReport!
+  monthlyReport(year: Int!, month: Int!, type: ReportType!): MonthlyReport!
   transactionDescriptionSuggestions(searchText: String!): [String!]!
 }
 
@@ -41,6 +41,11 @@ enum TransactionPatternType {
   INCOME
   EXPENSE
   REFUND
+}
+
+enum ReportType {
+  INCOME
+  EXPENSE
 }
 
 type Category {
@@ -216,7 +221,7 @@ type MonthlyReportCurrencyTotal {
 type MonthlyReport {
   year: Int!
   month: Int!
-  type: TransactionType! # TODO: remove if not needed
+  type: ReportType! # TODO: remove if not needed
   categories: [MonthlyReportCategory!]!
   currencyTotals: [MonthlyReportCurrencyTotal!]!
 }

--- a/backend/src/services/MonthlyByCategoryReportService.test.ts
+++ b/backend/src/services/MonthlyByCategoryReportService.test.ts
@@ -7,7 +7,10 @@ import {
 } from "../__tests__/utils/mockRepositories";
 import { ICategoryRepository } from "../models/Category";
 import { ITransactionRepository, TransactionType } from "../models/Transaction";
-import { MonthlyByCategoryReportService } from "./MonthlyByCategoryReportService";
+import {
+  MonthlyByCategoryReportService,
+  ReportType,
+} from "./MonthlyByCategoryReportService";
 
 describe("MonthlyByCategoryReportService", () => {
   let monthlyByCategoryReportService: MonthlyByCategoryReportService;
@@ -34,7 +37,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result).toEqual({
@@ -82,7 +85,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(3);
@@ -108,7 +111,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.currencyTotals).toEqual([
@@ -139,7 +142,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       const foodCategory = result.categories.find(
@@ -171,7 +174,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);
@@ -199,7 +202,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);
@@ -237,7 +240,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories.map((c) => c.categoryName)).toEqual([
@@ -266,7 +269,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.currencyTotals.map((ct) => ct.currency)).toEqual([
@@ -301,7 +304,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2000,
         1,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       const percentages = result.categories[0].currencyBreakdowns[0].percentage;
@@ -338,7 +341,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2025,
         11,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);
@@ -367,7 +370,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2025,
         11,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);
@@ -396,7 +399,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2025,
         11,
-        TransactionType.INCOME,
+        ReportType.INCOME,
       );
 
       expect(
@@ -451,7 +454,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2025,
         11,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);
@@ -490,7 +493,7 @@ describe("MonthlyByCategoryReportService", () => {
         userId,
         2025,
         11,
-        TransactionType.EXPENSE,
+        ReportType.EXPENSE,
       );
 
       expect(result.categories).toHaveLength(1);

--- a/backend/src/services/MonthlyByCategoryReportService.ts
+++ b/backend/src/services/MonthlyByCategoryReportService.ts
@@ -1,4 +1,5 @@
 import { ICategoryRepository } from "../models/Category";
+import { ReportType } from "../models/Report";
 import {
   ITransactionRepository,
   Transaction,
@@ -27,7 +28,7 @@ export interface MonthlyReportCurrencyTotal {
 export interface MonthlyReport {
   year: number;
   month: number;
-  type: TransactionType;
+  type: ReportType;
   categories: MonthlyReportCategory[];
   currencyTotals: MonthlyReportCurrencyTotal[];
 }
@@ -53,29 +54,36 @@ export class MonthlyByCategoryReportService {
    * @param userId - The user ID to generate the report for
    * @param year - The year (e.g., 2025)
    * @param month - The month (1-12)
-   * @param type - The transaction type (EXPENSE or INCOME)
+   * @param type - The report type (EXPENSE or INCOME)
    * @returns Monthly report with categories and currency totals
    */
   async call(
     userId: string,
     year: number,
     month: number,
-    type: TransactionType,
+    type: ReportType,
   ): Promise<MonthlyReport> {
-    const isExpenseReport = type === TransactionType.EXPENSE;
-
     // For EXPENSE reports, fetch both EXPENSE and REFUND transactions
     // For INCOME reports, fetch only INCOME transactions
-    const typesToFetch = isExpenseReport
-      ? [TransactionType.EXPENSE, TransactionType.REFUND]
-      : [type];
+    let transactionTypesToFetch: TransactionType[];
+
+    if (type === ReportType.EXPENSE) {
+      transactionTypesToFetch = [
+        TransactionType.EXPENSE,
+        TransactionType.REFUND,
+      ];
+    } else if (type === ReportType.INCOME) {
+      transactionTypesToFetch = [TransactionType.INCOME];
+    } else {
+      throw new Error("Invalid report type");
+    }
 
     const transactions =
       await this.transactionRepository.findActiveByMonthAndTypes(
         userId,
         year,
         month,
-        typesToFetch,
+        transactionTypesToFetch,
       );
 
     if (transactions.length === 0) {
@@ -90,12 +98,13 @@ export class MonthlyByCategoryReportService {
 
     // For EXPENSE reports: calculate net (expenses - refunds)
     // For INCOME reports: sum amounts as-is
-    const amountGetter = isExpenseReport
-      ? (transaction: Transaction) =>
-          transaction.type === TransactionType.EXPENSE
-            ? transaction.amount
-            : -transaction.amount // REFUND amounts are subtracted
-      : (transaction: Transaction) => transaction.amount;
+    const amountGetter =
+      type === ReportType.EXPENSE
+        ? (transaction: Transaction) =>
+            transaction.type === TransactionType.EXPENSE
+              ? transaction.amount
+              : -transaction.amount // REFUND amounts are subtracted
+        : (transaction: Transaction) => transaction.amount;
 
     const currencyTotals = this.calculateCurrencyTotals(
       transactions,

--- a/frontend/src/__generated__/graphql-types.ts
+++ b/frontend/src/__generated__/graphql-types.ts
@@ -67,7 +67,7 @@ export type MonthlyReport = {
   categories: Array<MonthlyReportCategory>;
   currencyTotals: Array<MonthlyReportCurrencyTotal>;
   month: Scalars['Int']['output'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['output'];
 };
 
@@ -201,7 +201,7 @@ export type QueryCategoriesArgs = {
 
 export type QueryMonthlyReportArgs = {
   month: Scalars['Int']['input'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['input'];
 };
 
@@ -225,6 +225,10 @@ export type QueryTransactionsArgs = {
 export type QueryTransferArgs = {
   id: Scalars['ID']['input'];
 };
+
+export type ReportType =
+  | 'EXPENSE'
+  | 'INCOME';
 
 /**
  * Transaction with embedded account and category data.
@@ -371,7 +375,7 @@ export type MonthlyReportCategoryFieldsFragment = { __typename?: 'MonthlyReportC
 
 export type MonthlyReportCurrencyTotalFieldsFragment = { __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number };
 
-export type MonthlyReportFieldsFragment = { __typename?: 'MonthlyReport', year: number, month: number, type: TransactionType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> };
+export type MonthlyReportFieldsFragment = { __typename?: 'MonthlyReport', year: number, month: number, type: ReportType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> };
 
 export type EnsureUserMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -504,11 +508,11 @@ export type GetTransactionPatternsQuery = { __typename?: 'Query', transactionPat
 export type GetMonthlyReportQueryVariables = Exact<{
   year: Scalars['Int']['input'];
   month: Scalars['Int']['input'];
-  type: TransactionType;
+  type: ReportType;
 }>;
 
 
-export type GetMonthlyReportQuery = { __typename?: 'Query', monthlyReport: { __typename?: 'MonthlyReport', year: number, month: number, type: TransactionType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> } };
+export type GetMonthlyReportQuery = { __typename?: 'Query', monthlyReport: { __typename?: 'MonthlyReport', year: number, month: number, type: ReportType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> } };
 
 export type GetTransactionDescriptionSuggestionsQueryVariables = Exact<{
   searchText: Scalars['String']['input'];

--- a/frontend/src/__generated__/vue-apollo.ts
+++ b/frontend/src/__generated__/vue-apollo.ts
@@ -71,7 +71,7 @@ export type MonthlyReport = {
   categories: Array<MonthlyReportCategory>;
   currencyTotals: Array<MonthlyReportCurrencyTotal>;
   month: Scalars['Int']['output'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['output'];
 };
 
@@ -205,7 +205,7 @@ export type QueryCategoriesArgs = {
 
 export type QueryMonthlyReportArgs = {
   month: Scalars['Int']['input'];
-  type: TransactionType;
+  type: ReportType;
   year: Scalars['Int']['input'];
 };
 
@@ -229,6 +229,10 @@ export type QueryTransactionsArgs = {
 export type QueryTransferArgs = {
   id: Scalars['ID']['input'];
 };
+
+export type ReportType =
+  | 'EXPENSE'
+  | 'INCOME';
 
 /**
  * Transaction with embedded account and category data.
@@ -375,7 +379,7 @@ export type MonthlyReportCategoryFieldsFragment = { __typename?: 'MonthlyReportC
 
 export type MonthlyReportCurrencyTotalFieldsFragment = { __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number };
 
-export type MonthlyReportFieldsFragment = { __typename?: 'MonthlyReport', year: number, month: number, type: TransactionType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> };
+export type MonthlyReportFieldsFragment = { __typename?: 'MonthlyReport', year: number, month: number, type: ReportType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> };
 
 export type EnsureUserMutationVariables = Exact<{ [key: string]: never; }>;
 
@@ -508,11 +512,11 @@ export type GetTransactionPatternsQuery = { __typename?: 'Query', transactionPat
 export type GetMonthlyReportQueryVariables = Exact<{
   year: Scalars['Int']['input'];
   month: Scalars['Int']['input'];
-  type: TransactionType;
+  type: ReportType;
 }>;
 
 
-export type GetMonthlyReportQuery = { __typename?: 'Query', monthlyReport: { __typename?: 'MonthlyReport', year: number, month: number, type: TransactionType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> } };
+export type GetMonthlyReportQuery = { __typename?: 'Query', monthlyReport: { __typename?: 'MonthlyReport', year: number, month: number, type: ReportType, categories: Array<{ __typename?: 'MonthlyReportCategory', categoryId?: string | null | undefined, categoryName: string, currencyBreakdowns: Array<{ __typename?: 'MonthlyReportCurrencyBreakdown', currency: string, totalAmount: number, percentage: number }> }>, currencyTotals: Array<{ __typename?: 'MonthlyReportCurrencyTotal', currency: string, totalAmount: number }> } };
 
 export type GetTransactionDescriptionSuggestionsQueryVariables = Exact<{
   searchText: Scalars['String']['input'];
@@ -1163,7 +1167,7 @@ export function useGetTransactionPatternsLazyQuery(variables?: GetTransactionPat
 }
 export type GetTransactionPatternsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<GetTransactionPatternsQuery, GetTransactionPatternsQueryVariables>;
 export const GetMonthlyReportDocument = gql`
-    query GetMonthlyReport($year: Int!, $month: Int!, $type: TransactionType!) {
+    query GetMonthlyReport($year: Int!, $month: Int!, $type: ReportType!) {
   monthlyReport(year: $year, month: $month, type: $type) {
     ...MonthlyReportFields
   }

--- a/frontend/src/composables/useMonthlyReports.ts
+++ b/frontend/src/composables/useMonthlyReports.ts
@@ -1,16 +1,15 @@
 import { ref, computed, unref, type Ref } from "vue";
 import {
   useGetMonthlyReportQuery,
-  type TransactionType,
   type MonthlyReport,
   type MonthlyReportCategory,
   type MonthlyReportCurrencyBreakdown,
   type MonthlyReportCurrencyTotal,
+  type ReportType,
 } from "@/__generated__/vue-apollo";
 
 // Re-export types for backward compatibility
 export type {
-  TransactionType,
   MonthlyReport,
   MonthlyReportCategory,
   MonthlyReportCurrencyBreakdown,
@@ -24,7 +23,7 @@ export function useMonthlyReports() {
   const getMonthlyReport = (
     year: Ref<number> | number,
     month: Ref<number> | number,
-    type: TransactionType,
+    type: ReportType,
   ) => {
     const {
       result: monthlyReportResult,

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -73,7 +73,7 @@ export const GET_TRANSACTION_PATTERNS = gql`
 `;
 
 export const GET_MONTHLY_REPORT = gql`
-  query GetMonthlyReport($year: Int!, $month: Int!, $type: TransactionType!) {
+  query GetMonthlyReport($year: Int!, $month: Int!, $type: ReportType!) {
     monthlyReport(year: $year, month: $month, type: $type) {
       ...MonthlyReportFields
     }

--- a/frontend/src/schema.graphql
+++ b/frontend/src/schema.graphql
@@ -8,7 +8,7 @@ type Query {
   ): TransactionConnection!
   transfer(id: ID!): Transfer
   transactionPatterns(type: TransactionPatternType!): [TransactionPattern!]!
-  monthlyReport(year: Int!, month: Int!, type: TransactionType!): MonthlyReport!
+  monthlyReport(year: Int!, month: Int!, type: ReportType!): MonthlyReport!
   transactionDescriptionSuggestions(searchText: String!): [String!]!
 }
 
@@ -41,6 +41,11 @@ enum TransactionPatternType {
   INCOME
   EXPENSE
   REFUND
+}
+
+enum ReportType {
+  INCOME
+  EXPENSE
 }
 
 type Category {
@@ -216,7 +221,7 @@ type MonthlyReportCurrencyTotal {
 type MonthlyReport {
   year: Int!
   month: Int!
-  type: TransactionType! # TODO: remove if not needed
+  type: ReportType! # TODO: remove if not needed
   categories: [MonthlyReportCategory!]!
   currencyTotals: [MonthlyReportCurrencyTotal!]!
 }


### PR DESCRIPTION
## context

The monthly report query was using `TransactionType` to specify whether to show income or expense data, but `TransactionType` includes values like TRANSFER_IN, TRANSFER_OUT, and REFUND that don't make sense in a reporting context.

## before

- Monthly report query uses `TransactionType` which contains transaction-specific values
- Report functionality is coupled to transaction type semantics
- The domain model conflates transaction types with report categories

## after

- Monthly report query uses `ReportType` with only INCOME and EXPENSE values
- Report functionality is decoupled from transaction-specific concepts
- The domain model clearly separates report types from transaction types