### PR TITLE
add signed amount helper for transactions

### DIFF
--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -1,0 +1,55 @@
+import { fakeTransaction } from "../__tests__/utils/factories";
+import { TransactionType, getSignedAmount } from "./transaction";
+
+describe("transaction model", () => {
+  describe("getSignedAmount", () => {
+    it("should return positive amount for INCOME transactions", () => {
+      const transaction = fakeTransaction({
+        type: TransactionType.INCOME,
+        amount: 100,
+      });
+      expect(getSignedAmount(transaction)).toBe(100);
+    });
+
+    it("should return positive amount for REFUND transactions", () => {
+      const transaction = fakeTransaction({
+        type: TransactionType.REFUND,
+        amount: 100,
+      });
+      expect(getSignedAmount(transaction)).toBe(100);
+    });
+
+    it("should return positive amount for TRANSFER_IN transactions", () => {
+      const transaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        amount: 100,
+      });
+      expect(getSignedAmount(transaction)).toBe(100);
+    });
+
+    it("should return negative amount for EXPENSE transactions", () => {
+      const transaction = fakeTransaction({
+        type: TransactionType.EXPENSE,
+        amount: 100,
+      });
+      expect(getSignedAmount(transaction)).toBe(-100);
+    });
+
+    it("should return negative amount for TRANSFER_OUT transactions", () => {
+      const transaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        amount: 100,
+      });
+      expect(getSignedAmount(transaction)).toBe(-100);
+    });
+
+    it("should throw error for unknown transaction type", () => {
+      const transaction = fakeTransaction({
+        type: "UNKNOWN" as TransactionType,
+      });
+      expect(() => getSignedAmount(transaction)).toThrow(
+        "Unknown transaction type: UNKNOWN",
+      );
+    });
+  });
+});

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -127,3 +127,20 @@ export interface ITransactionRepository {
     sampleSize: number,
   ): Promise<TransactionPattern[]>;
 }
+
+// Get signed amount based on transaction type
+// Positive for INCOME, REFUND, TRANSFER_IN
+// Negative for EXPENSE, TRANSFER_OUT
+export function getSignedAmount(transaction: Transaction): number {
+  switch (transaction.type) {
+    case TransactionType.INCOME:
+    case TransactionType.REFUND:
+    case TransactionType.TRANSFER_IN:
+      return transaction.amount;
+    case TransactionType.EXPENSE:
+    case TransactionType.TRANSFER_OUT:
+      return -transaction.amount;
+    default:
+      throw new Error(`Unknown transaction type: ${transaction.type}`);
+  }
+}

--- a/backend/src/services/account-service.ts
+++ b/backend/src/services/account-service.ts
@@ -1,5 +1,5 @@
 import { IAccountRepository } from "../models/account";
-import { ITransactionRepository, TransactionType } from "../models/transaction";
+import { ITransactionRepository, getSignedAmount } from "../models/transaction";
 import { BusinessError, BusinessErrorCodes } from "./business-error";
 
 /**
@@ -44,19 +44,10 @@ export class AccountService {
         );
 
       // Calculate balance: initialBalance + INCOME + REFUND + TRANSFER_IN - EXPENSE - TRANSFER_OUT
-      const balance = transactions.reduce((sum, transaction) => {
-        switch (transaction.type) {
-          case TransactionType.INCOME:
-          case TransactionType.REFUND:
-          case TransactionType.TRANSFER_IN:
-            return sum + transaction.amount;
-          case TransactionType.EXPENSE:
-          case TransactionType.TRANSFER_OUT:
-            return sum - transaction.amount;
-          default:
-            return sum;
-        }
-      }, account.initialBalance);
+      const balance = transactions.reduce(
+        (sum, transaction) => sum + getSignedAmount(transaction),
+        account.initialBalance,
+      );
 
       return balance;
     } catch (error) {

--- a/backend/src/services/monthly-by-category-report-service.ts
+++ b/backend/src/services/monthly-by-category-report-service.ts
@@ -4,6 +4,7 @@ import {
   ITransactionRepository,
   Transaction,
   TransactionType,
+  getSignedAmount,
 } from "../models/transaction";
 
 const UNCATEGORIZED_LABEL = "Uncategorized";
@@ -67,13 +68,25 @@ export class MonthlyByCategoryReportService {
     // For INCOME reports, fetch only INCOME transactions
     let transactionTypesToFetch: TransactionType[];
 
+    // Function to get signed amount based on report type
+    // For EXPENSE: expenses are positive, refunds are negative
+    // For INCOME: amounts are as-is
+    let amountGetter: typeof getSignedAmount;
+
+    // Negate to get expenses as positive, refunds as negative
+    const negatedSignedAmount = (transaction: Transaction) =>
+      -getSignedAmount(transaction);
+
     if (type === ReportType.EXPENSE) {
       transactionTypesToFetch = [
         TransactionType.EXPENSE,
         TransactionType.REFUND,
       ];
+
+      amountGetter = negatedSignedAmount;
     } else if (type === ReportType.INCOME) {
       transactionTypesToFetch = [TransactionType.INCOME];
+      amountGetter = getSignedAmount;
     } else {
       throw new Error("Invalid report type");
     }
@@ -95,16 +108,6 @@ export class MonthlyByCategoryReportService {
         currencyTotals: [],
       };
     }
-
-    // For EXPENSE reports: calculate net (expenses - refunds)
-    // For INCOME reports: sum amounts as-is
-    const amountGetter =
-      type === ReportType.EXPENSE
-        ? (transaction: Transaction) =>
-            transaction.type === TransactionType.EXPENSE
-              ? transaction.amount
-              : -transaction.amount // REFUND amounts are subtracted
-        : (transaction: Transaction) => transaction.amount;
 
     const currencyTotals = this.calculateCurrencyTotals(
       transactions,


### PR DESCRIPTION
Introduce `getSignedAmount()` utility function that returns transaction amounts with appropriate signs based on type:
- positive for INCOME, REFUND, TRANSFER_IN
- negative for EXPENSE, TRANSFER_OUT

This simplifies balance calculations across the codebase by providing a consistent way to treat transaction amounts according to their effect on account balances.