### PR TITLE
remove year range validation from repository

### DIFF
--- a/backend/src/repositories/transaction-repository.test.ts
+++ b/backend/src/repositories/transaction-repository.test.ts
@@ -12,7 +12,6 @@ import {
   TransactionType,
   UpdateTransactionInput,
 } from "../models/transaction";
-import { YEAR_RANGE_OFFSET } from "../types/validation";
 import { createDynamoDBDocumentClient } from "../utils/dynamo-client";
 import { TransactionRepository } from "./transaction-repository";
 
@@ -1902,20 +1901,16 @@ describe("TransactionRepository", () => {
     it("should throw error for invalid year", async () => {
       // Act & Assert
       const userId = faker.string.uuid();
-
-      const currentYear = new Date().getFullYear();
-      const minYear = currentYear - YEAR_RANGE_OFFSET;
-      const maxYear = currentYear + YEAR_RANGE_OFFSET;
-      const expectedMessage = `Year must be a valid integer between ${minYear} and ${maxYear}`;
+      const expectedMessage = "Year must be a positive integer";
 
       await expect(
-        repository.findActiveByMonthAndTypes(userId, minYear - 1, 1, [
+        repository.findActiveByMonthAndTypes(userId, -1, 1, [
           TransactionType.EXPENSE,
         ]),
       ).rejects.toThrow(expectedMessage);
 
       await expect(
-        repository.findActiveByMonthAndTypes(userId, maxYear + 1, 1, [
+        repository.findActiveByMonthAndTypes(userId, 0, 1, [
           TransactionType.EXPENSE,
         ]),
       ).rejects.toThrow(expectedMessage);

--- a/backend/src/repositories/transaction-repository.ts
+++ b/backend/src/repositories/transaction-repository.ts
@@ -29,7 +29,6 @@ import {
   PageInfo,
   PaginationInput,
 } from "../types/pagination";
-import { YEAR_RANGE_OFFSET } from "../types/validation";
 import { formatDateAsYYYYMMDD } from "../utils/date";
 import {
   DYNAMODB_TRANSACT_WRITE_MAX_ITEMS,
@@ -688,13 +687,9 @@ export class TransactionRepository implements ITransactionRepository {
       );
     }
 
-    const currentYear = new Date().getFullYear();
-    const minYear = currentYear - YEAR_RANGE_OFFSET;
-    const maxYear = currentYear + YEAR_RANGE_OFFSET;
-
-    if (!Number.isInteger(year) || year < minYear || year > maxYear) {
+    if (!Number.isInteger(year) || year <= 0) {
       throw new TransactionRepositoryError(
-        `Year must be a valid integer between ${minYear} and ${maxYear}`,
+        "Year must be a positive integer",
         "INVALID_PARAMETERS",
       );
     }


### PR DESCRIPTION
Repository layer should not enforce business validation like year range constraints.
This validation currently exists in resolver but will also be moved to appropriate layer later.