### PR TITLE
move year/month validation to service layer

### DIFF
--- a/backend/src/resolvers/report-resolvers.ts
+++ b/backend/src/resolvers/report-resolvers.ts
@@ -1,55 +1,26 @@
-import { GraphQLError } from "graphql";
-import { z } from "zod";
 import { ReportType } from "../models/report";
 import { GraphQLContext } from "../server";
-import { YEAR_RANGE_OFFSET } from "../types/validation";
 import { getAuthenticatedUser, handleResolverError } from "./shared";
-
-/**
- * Zod schemas for input validation
- */
-const currentYear = new Date().getFullYear();
-const yearSchema = z
-  .number()
-  .int()
-  .min(currentYear - YEAR_RANGE_OFFSET)
-  .max(currentYear + YEAR_RANGE_OFFSET);
-const monthSchema = z.number().int().min(1).max(12);
-const reportTypeSchema = z.enum(ReportType);
-
-const monthlyReportInputSchema = z.object({
-  year: yearSchema,
-  month: monthSchema,
-  type: reportTypeSchema,
-});
 
 export const reportResolvers = {
   Query: {
     monthlyReport: async (
       _parent: unknown,
-      args: { year: unknown; month: unknown; type: unknown },
+      args: { year: number; month: number; type: ReportType },
       context: GraphQLContext,
     ) => {
       try {
-        // Validate input parameters
-        const validatedInput = monthlyReportInputSchema.parse(args);
         const user = await getAuthenticatedUser(context);
 
         const monthlyReport = await context.monthlyByCategoryReportService.call(
           user.id,
-          validatedInput.year,
-          validatedInput.month,
-          validatedInput.type,
+          args.year,
+          args.month,
+          args.type,
         );
 
         return monthlyReport;
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const firstError = error.issues[0];
-          throw new GraphQLError(firstError.message, {
-            extensions: { code: "BAD_USER_INPUT" },
-          });
-        }
         handleResolverError(error, "Failed to fetch monthly report");
       }
     },

--- a/backend/src/services/monthly-by-category-report-service.test.ts
+++ b/backend/src/services/monthly-by-category-report-service.test.ts
@@ -8,6 +8,8 @@ import {
 import { ICategoryRepository } from "../models/category";
 import { ReportType } from "../models/report";
 import { ITransactionRepository, TransactionType } from "../models/transaction";
+import { YEAR_RANGE_OFFSET } from "../types/validation";
+import { BusinessErrorCodes } from "./business-error";
 import { MonthlyByCategoryReportService } from "./monthly-by-category-report-service";
 
 describe("MonthlyByCategoryReportService", () => {
@@ -497,6 +499,90 @@ describe("MonthlyByCategoryReportService", () => {
       expect(result.categories).toHaveLength(1);
       expect(result.categories[0].categoryName).toBe("Uncategorized");
       expect(result.categories[0].currencyBreakdowns[0].totalAmount).toBe(500); // 600 - 100
+    });
+  });
+
+  describe("validation", () => {
+    describe("year validation", () => {
+      it("should throw error for invalid year", async () => {
+        const currentYear = new Date().getFullYear();
+        const minYear = currentYear - YEAR_RANGE_OFFSET;
+        const maxYear = currentYear + YEAR_RANGE_OFFSET;
+
+        const invalidYears = [minYear - 1, maxYear + 1, 2000.5];
+
+        for (const invalidYear of invalidYears) {
+          await expect(
+            monthlyByCategoryReportService.call(
+              userId,
+              invalidYear,
+              1,
+              ReportType.EXPENSE,
+            ),
+          ).rejects.toMatchObject({
+            message: `Year must be a valid integer between ${minYear} and ${maxYear}`,
+            code: BusinessErrorCodes.INVALID_PARAMETERS,
+          });
+        }
+      });
+
+      it("should accept valid year within range", async () => {
+        const currentYear = new Date().getFullYear();
+        const validYear = currentYear - 50;
+
+        mockTransactionRepository.findActiveByMonthAndTypes.mockResolvedValue(
+          [],
+        );
+
+        await expect(
+          monthlyByCategoryReportService.call(
+            userId,
+            validYear,
+            1,
+            ReportType.EXPENSE,
+          ),
+        ).resolves.toBeDefined();
+      });
+    });
+
+    describe("month validation", () => {
+      it("should throw error for invalid month", async () => {
+        const currentYear = new Date().getFullYear();
+        const invalidMonths = [0, 13, 5.5];
+
+        for (const invalidMonth of invalidMonths) {
+          await expect(
+            monthlyByCategoryReportService.call(
+              userId,
+              currentYear,
+              invalidMonth,
+              ReportType.EXPENSE,
+            ),
+          ).rejects.toMatchObject({
+            message: "Month must be a valid integer between 1 and 12",
+            code: BusinessErrorCodes.INVALID_PARAMETERS,
+          });
+        }
+      });
+
+      it("should accept valid months (1-12)", async () => {
+        const currentYear = new Date().getFullYear();
+
+        mockTransactionRepository.findActiveByMonthAndTypes.mockResolvedValue(
+          [],
+        );
+
+        for (let month = 1; month <= 12; month++) {
+          await expect(
+            monthlyByCategoryReportService.call(
+              userId,
+              currentYear,
+              month,
+              ReportType.EXPENSE,
+            ),
+          ).resolves.toBeDefined();
+        }
+      });
     });
   });
 });

--- a/backend/src/services/monthly-by-category-report-service.ts
+++ b/backend/src/services/monthly-by-category-report-service.ts
@@ -6,6 +6,8 @@ import {
   TransactionType,
   getSignedAmount,
 } from "../models/transaction";
+import { YEAR_RANGE_OFFSET } from "../types/validation";
+import { BusinessError, BusinessErrorCodes } from "./business-error";
 
 const UNCATEGORIZED_LABEL = "Uncategorized";
 
@@ -64,6 +66,9 @@ export class MonthlyByCategoryReportService {
     month: number,
     type: ReportType,
   ): Promise<MonthlyReport> {
+    this.validateYear(year);
+    this.validateMonth(month);
+
     // For EXPENSE reports, fetch both EXPENSE and REFUND transactions
     // For INCOME reports, fetch only INCOME transactions
     let transactionTypesToFetch: TransactionType[];
@@ -226,5 +231,27 @@ export class MonthlyByCategoryReportService {
     }
 
     return breakdowns.sort((a, b) => a.currency.localeCompare(b.currency));
+  }
+
+  private validateYear(year: number): void {
+    const currentYear = new Date().getFullYear();
+    const minYear = currentYear - YEAR_RANGE_OFFSET;
+    const maxYear = currentYear + YEAR_RANGE_OFFSET;
+
+    if (!Number.isInteger(year) || year < minYear || year > maxYear) {
+      throw new BusinessError(
+        `Year must be a valid integer between ${minYear} and ${maxYear}`,
+        BusinessErrorCodes.INVALID_PARAMETERS,
+      );
+    }
+  }
+
+  private validateMonth(month: number): void {
+    if (!Number.isInteger(month) || month < 1 || month > 12) {
+      throw new BusinessError(
+        "Month must be a valid integer between 1 and 12",
+        BusinessErrorCodes.INVALID_PARAMETERS,
+      );
+    }
   }
 }


### PR DESCRIPTION
- remove zod validation from resolver (graphql handles types)
- add year and month validation to service
- follow layered architecture: graphql validates types, service validates business rules, repository validates data integrity