### PR TITLE
prioritize standard email claim over namespaced claim

### DIFF
--- a/backend/src/auth/jwt-auth.ts
+++ b/backend/src/auth/jwt-auth.ts
@@ -7,7 +7,7 @@ import { normalizeAndValidateEmail } from "../utils/email";
  */
 export interface JwtPayload {
   sub: string; // User ID
-  email: string; // User email
+  email?: string; // User email
   iss: string; // Issuer
   aud: string | string[]; // Audience
   exp: number; // Expiration


### PR DESCRIPTION
## context

Follow up on #55, which migrated authentication to email-based lookups. The JWT email extraction logic was checking namespaced claims first and always requiring `AUTH_CLAIM_NAMESPACE` to be configured. This creates unnecessary coupling when the JWT provider uses standard `email` claims.

## before

- Always checks custom namespaced claim (`AUTH_CLAIM_NAMESPACE` required)
- Falls back to standard `email` claim if namespaced claim not found
- Configuration required even when using standard JWT claims

## after

- Prioritizes standard `email` claim over namespaced claim
- Only checks `AUTH_CLAIM_NAMESPACE` if standard claim is missing
- Reduces configuration requirements for standard JWT providers