### PR TITLE
update aws-cdk to version 2.1103.0 and disable telemetry

### DIFF
--- a/infra-cdk/cdk.context.json
+++ b/infra-cdk/cdk.context.json
@@ -1,0 +1,6 @@
+{
+  "acknowledged-issue-numbers": [
+    34892
+  ],
+  "cli-telemetry": false
+}

--- a/infra-cdk/package-lock.json
+++ b/infra-cdk/package-lock.json
@@ -2103,9 +2103,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1100.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1100.1.tgz",
-      "integrity": "sha512-q2poFrQh90TK6eqeI0zznA8r1JkDI63WVOSqC7gFGo6qjQjAnvFk/utxHoNRgAC0RL0CLd19uCcHh3jfX9NiSg==",
+      "version": "2.1103.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1103.0.tgz",
+      "integrity": "sha512-bxEcqIeAT983x7525gf4Ya4zgpDt3Ou54El7j1ITCa/KqJ8ZaOP4F0ZHiiGuCbZduMcGJlszIXkaPJuvyNADgg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2113,9 +2113,6 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {


### PR DESCRIPTION
- Upgrade aws-cdk package for improved features and fixes
- Add cdk.context.json to disable CLI telemetry