### PR TITLE
amend constitution to v0.24.0 (clarify service-heavy input validation)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -413,7 +413,8 @@ graph LR
   - Example: email format validation matters IF email notifications are business-critical
   - Example: date format validation matters IF date queries are business operations
   - Not all format validation is mandatory - only what impacts business operations
-- Throw only business errors, propagate lower-level errors without wrapping
+- Throw business errors for expected domain failures (validation errors, business rule violations)
+- Propagate infrastructure errors without wrapping (database failures, network errors)
 
 **Repository Layer**:
 - Validate only what is necessary to execute database operations correctly


### PR DESCRIPTION
## context

The Input Validation section in the constitution describes a two-layer validation approach (GraphQL for format/structure, Service for business rules) that doesn't accurately reflect the project's actual architecture where services must be self-validating entry points callable from multiple contexts.

## before

- GraphQL layer uses Zod schemas for format/structure validation
- Service layer only validates business rules
- Validation responsibilities are split across layers
- Services assume GraphQL has already validated input format
- Architecture doesn't account for non-GraphQL entry points

## after

- GraphQL layer relies primarily on schema validation with minimal additions
- Service layer is the self-validating entry point that validates all business-important input
- Repository layer only validates operational requirements
- Services can be safely called from any context (GraphQL, REST, CLI, batch jobs)
- Clear guidance that not all format validation is mandatory, only what has business importance

Close #136