### PR TITLE
surface passkey session error on redirect

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -133,6 +133,7 @@ const handlePasskeyRegistration = () => {
   if (mobile.value) {
     drawer.value = false;
   }
+
   sessionStorage.setItem(PASSKEY_PENDING_KEY, "true");
   window.location.href = passkeyRegistrationUrl.value!;
 };


### PR DESCRIPTION
## context

When a user clicks "Register Passkey" after a long idle period, Cognito redirects back with `result=invalid_session`. The app currently ignores this signal, so the user sees nothing — no error, no guidance on what to do next. This is Phase 1: detect the error and show an actionable message. The root cause (the session expiry itself) is addressed in a separate phase.

Follow-up on #145. Partially addresses #151 (Phase 1 only).

## before

- Clicking "Register Passkey" after ~24h idle silently redirects back to the app
- No error message is shown to the user
- User has no indication that a fresh sign-in is needed

## after

- If the redirect originated from "Register Passkey", a passkey-specific error snackbar is shown
- If the redirect came from another source, a generic "fresh sign-in required" snackbar is shown
