### PR TITLE
create pass-credentials skill

### DIFF
--- a/.claude/skills/pass-credentials/pass-credentials/SKILL.md
+++ b/.claude/skills/pass-credentials/pass-credentials/SKILL.md
@@ -27,10 +27,5 @@ playwright-cli fill <password-field-ref> "$PASSWORD"
 
 ## Troubleshooting
 
-If `pass show` hangs or asks for a GPG passphrase interactively, the
-gpg-agent may have timed out. Run this to restart it and retry:
-
-```bash
-gpg-agent --daemon
-pass show budget/dev/user/email
-```
+If `pass show` fails with `Screen or window too small`, enlarge the terminal
+window and retry.


### PR DESCRIPTION
## context

Playwright tasks that log in to the budget app need credentials.
Without a dedicated skill, each task has to manually retrieve them from `pass`.

## before

- No reusable skill exists for retrieving budget app credentials
- Each task must handle credential retrieval on its own

## after

- A `pass-credentials` skill retrieves email and password from the local `pass` store
- The skill can be invoked automatically when login credentials are needed