### PR TITLE
rename skills to format-* convention and enable execution after formatting

### DIFF
--- a/.claude/skills/format-git-commit/SKILL.md
+++ b/.claude/skills/format-git-commit/SKILL.md
@@ -71,4 +71,4 @@ fix account balance calculation
 
 ### Step 5: Present the result
 
-Output the formatted commit message in a code block. Do not commit — only return the formatted message.
+Output the formatted commit message in a code block, then proceed to commit using available tools.

--- a/.claude/skills/format-github-issue/SKILL.md
+++ b/.claude/skills/format-github-issue/SKILL.md
@@ -192,4 +192,4 @@ For bug issues, also include:
 **Label:** bug
 ```
 
-Do not create or update the issue — only return the formatted content.
+Return the formatted content, then proceed to create or update the issue using available tools.

--- a/.claude/skills/format-github-pr/SKILL.md
+++ b/.claude/skills/format-github-pr/SKILL.md
@@ -112,4 +112,4 @@ Return formatted title and body separately and clearly labeled:
 <formatted body>
 ```
 
-Do not create or update the PR — only return the formatted content.
+Return the formatted content, then proceed to create or update the PR using available tools.


### PR DESCRIPTION
## context

Skills had inconsistent naming and stopped after presenting formatted output instead of proceeding to execute the underlying action.

## before

- `draft-git-commit` and `github-pr` don't follow the `format-*` naming pattern
- Skills output formatted content and explicitly stop — they don't commit or update the PR
- `format-github-issue` also stops after output without taking action

## after

- `draft-git-commit` renamed to `format-git-commit`; `github-pr` renamed to `format-github-pr`
- All format-* skills present formatted content first, then proceed to execute using available tools
- Naming is consistent across all format-related skills