### PR TITLE
decouple LangchainAgent from Bedrock model

### DIFF
--- a/backend/src/ai/langchain-agent.test.ts
+++ b/backend/src/ai/langchain-agent.test.ts
@@ -1,4 +1,4 @@
-import { ChatBedrockConverse } from "@langchain/aws";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import {
   AIMessage,
   StructuredTool,
@@ -8,7 +8,7 @@ import {
 } from "langchain";
 import { z } from "zod";
 import { AnyToolSignature } from "../models/ai-agent";
-import { LangchainBedrockAgent } from "./langchain-bedrock-agent";
+import { LangchainAgent } from "./langchain-agent";
 
 // Mock LangChain's createAgent and tool
 jest.mock("langchain", () => ({
@@ -17,14 +17,14 @@ jest.mock("langchain", () => ({
   tool: jest.fn(),
 }));
 
-describe("LangchainBedrockAgent", () => {
-  let agent: LangchainBedrockAgent;
-  let mockModel: jest.Mocked<ChatBedrockConverse>;
+describe("LangchainAgent", () => {
+  let agent: LangchainAgent;
+  let mockModel: BaseChatModel;
   let mockReactAgent: { invoke: jest.Mock };
 
   beforeEach(() => {
     // Create mock model
-    mockModel = {} as jest.Mocked<ChatBedrockConverse>;
+    mockModel = {} as BaseChatModel;
 
     // Create mock ReAct agent
     mockReactAgent = {
@@ -33,7 +33,7 @@ describe("LangchainBedrockAgent", () => {
 
     (createAgent as jest.Mock).mockReturnValue(mockReactAgent);
 
-    agent = new LangchainBedrockAgent(mockModel);
+    agent = new LangchainAgent(mockModel);
 
     jest.clearAllMocks();
   });

--- a/backend/src/ai/langchain-agent.ts
+++ b/backend/src/ai/langchain-agent.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { ChatBedrockConverse } from "@langchain/aws";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { AIMessage, ToolMessage, createAgent, tool } from "langchain";
 import {
   AIAgent,
@@ -7,29 +7,9 @@ import {
   AnyToolSignature,
   ToolExecution,
 } from "../models/ai-agent";
-import {
-  createBedrockRuntimeClient,
-  loadBedrockMaxTokens,
-  loadBedrockModelId,
-  loadBedrockRegion,
-  loadBedrockTemperature,
-} from "../utils/bedrock-runtime-client";
 
-export class LangchainBedrockAgent implements AIAgent {
-  private model: ChatBedrockConverse;
-
-  constructor(model?: ChatBedrockConverse) {
-    // Create Bedrock model via LangChain
-    this.model =
-      model ??
-      new ChatBedrockConverse({
-        model: loadBedrockModelId(),
-        region: loadBedrockRegion(),
-        maxTokens: loadBedrockMaxTokens(),
-        temperature: loadBedrockTemperature(),
-        client: createBedrockRuntimeClient(),
-      });
-  }
+export class LangchainAgent implements AIAgent {
+  constructor(private model: BaseChatModel) {}
 
   async call(input: {
     messages: readonly AiMessage[];

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { ApolloServer } from "@apollo/server";
 import DataLoader from "dataloader";
-import { LangchainBedrockAgent } from "./ai/langchain-bedrock-agent";
+import { LangchainAgent } from "./ai/langchain-agent";
 import { AuthContext, JwtAuthService } from "./auth/jwt-auth";
 import { createAccountLoader } from "./dataloaders/account-loader";
 import { createCategoryLoader } from "./dataloaders/category-loader";
@@ -27,6 +27,7 @@ import type {
   TransactionEmbeddedAccount,
   TransactionEmbeddedCategory,
 } from "./types/graphql";
+import { createBedrockChatModel } from "./utils/bedrock";
 
 export interface GraphQLContext {
   auth: AuthContext;
@@ -116,7 +117,7 @@ export async function createContext(req: {
   }
 
   if (!insightService) {
-    const aiAgent = new LangchainBedrockAgent();
+    const aiAgent = new LangchainAgent(createBedrockChatModel());
     const aiDataService = new AiDataService(
       accountRepository,
       categoryRepository,

--- a/backend/src/utils/bedrock.ts
+++ b/backend/src/utils/bedrock.ts
@@ -1,28 +1,9 @@
 import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
+import { ChatBedrockConverse } from "@langchain/aws";
 import { requireEnv, requireFloatEnv, requireIntEnv } from "./require-env";
 
 const isLocalEnvironment =
   process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
-
-/** Reads the Bedrock model identifier from AWS_BEDROCK_MODEL_ID. */
-export function loadBedrockModelId(): string {
-  return requireEnv("AWS_BEDROCK_MODEL_ID");
-}
-
-/** Reads the max response tokens from AWS_BEDROCK_MAX_TOKENS. */
-export function loadBedrockMaxTokens(): number {
-  return requireIntEnv("AWS_BEDROCK_MAX_TOKENS");
-}
-
-/** Reads the sampling temperature from AWS_BEDROCK_TEMPERATURE. */
-export function loadBedrockTemperature(): number {
-  return requireFloatEnv("AWS_BEDROCK_TEMPERATURE");
-}
-
-/** Reads the AWS region from AWS_REGION. */
-export function loadBedrockRegion(): string {
-  return requireEnv("AWS_REGION");
-}
 
 /**
  * Creates a Bedrock runtime client.
@@ -35,4 +16,15 @@ export function createBedrockRuntimeClient(): BedrockRuntimeClient {
     : {};
 
   return new BedrockRuntimeClient(config);
+}
+
+/** Creates a LangChain Bedrock chat model configured from environment variables. */
+export function createBedrockChatModel(): ChatBedrockConverse {
+  return new ChatBedrockConverse({
+    model: requireEnv("AWS_BEDROCK_MODEL_ID"),
+    region: requireEnv("AWS_REGION"),
+    maxTokens: requireIntEnv("AWS_BEDROCK_MAX_TOKENS"),
+    temperature: requireFloatEnv("AWS_BEDROCK_TEMPERATURE"),
+    client: createBedrockRuntimeClient(),
+  });
 }


### PR DESCRIPTION
## context

The LangChain agent was hard-coded to AWS Bedrock, making the underlying LLM
impossible to swap without modifying production code.

## before

- `LangchainBedrockAgent` owns its own model construction internally
- Swapping the LLM requires changing the agent class

## after

- `LangchainAgent` accepts any LangChain-compatible `BaseChatModel`
- Callers choose and inject the model (Bedrock, Ollama, etc.)