### PR TITLE
rename agent types to reflect pattern and role

### DIFF
--- a/backend/src/ai/react-agent.test.ts
+++ b/backend/src/ai/react-agent.test.ts
@@ -7,8 +7,8 @@ import {
   tool,
 } from "langchain";
 import { z } from "zod";
-import { AnyToolSignature } from "../models/ai-agent";
-import { LangchainAgent } from "./langchain-agent";
+import { ToolSignature } from "../models/agent";
+import { ReActAgent } from "./react-agent";
 
 // Mock LangChain's createAgent and tool
 jest.mock("langchain", () => ({
@@ -17,8 +17,8 @@ jest.mock("langchain", () => ({
   tool: jest.fn(),
 }));
 
-describe("LangchainAgent", () => {
-  let agent: LangchainAgent;
+describe("ReActAgent", () => {
+  let agent: ReActAgent;
   let mockModel: BaseChatModel;
   let mockReactAgent: { invoke: jest.Mock };
 
@@ -33,7 +33,7 @@ describe("LangchainAgent", () => {
 
     (createAgent as jest.Mock).mockReturnValue(mockReactAgent);
 
-    agent = new LangchainAgent(mockModel);
+    agent = new ReActAgent(mockModel);
 
     jest.clearAllMocks();
   });
@@ -43,7 +43,7 @@ describe("LangchainAgent", () => {
       // Arrange
       const messages = [{ role: "user" as const, content: "Test question" }];
       const systemPrompt = "You are a test assistant";
-      const testTool: AnyToolSignature = {
+      const testTool: ToolSignature<{ text: string }> = {
         name: "test_tool",
         description: "A test tool",
         func: async (input: { text: string }) => `Echo: ${input.text}`,

--- a/backend/src/ai/react-agent.ts
+++ b/backend/src/ai/react-agent.ts
@@ -2,19 +2,19 @@ import { randomUUID } from "crypto";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { AIMessage, ToolMessage, createAgent, tool } from "langchain";
 import {
-  AIAgent,
-  AiMessage,
-  AnyToolSignature,
+  Agent,
+  AgentMessage,
   ToolExecution,
-} from "../models/ai-agent";
+  ToolSignature,
+} from "../models/agent";
 
-export class LangchainAgent implements AIAgent {
+export class ReActAgent implements Agent {
   constructor(private model: BaseChatModel) {}
 
   async call(input: {
-    messages: readonly AiMessage[];
+    messages: readonly AgentMessage[];
     systemPrompt?: string;
-    tools?: readonly AnyToolSignature[];
+    tools?: readonly ToolSignature<any>[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   }) {
     const langchainTools = input.tools?.map((toolSignature) => {
       return tool(toolSignature.func, {

--- a/backend/src/models/agent.ts
+++ b/backend/src/models/agent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export interface AiMessage {
+export interface AgentMessage {
   role: "system" | "user" | "assistant";
   content: string;
 }
@@ -12,21 +12,16 @@ export interface ToolSignature<TInput> {
   inputSchema: z.ZodType<TInput>;
 }
 
-// Type alias for arrays of heterogeneous tools
-// Using `any` here is safe because runtime validation is done via Zod schemas
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyToolSignature = ToolSignature<any>;
-
 export interface ToolExecution {
   tool: string;
   input: string;
   output: string;
 }
 
-export interface AIAgent {
+export interface Agent {
   call(input: {
-    messages: readonly AiMessage[];
+    messages: readonly AgentMessage[];
     systemPrompt?: string;
-    tools?: readonly AnyToolSignature[];
+    tools?: readonly ToolSignature<any>[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   }): Promise<{ answer: string; toolExecutions?: ToolExecution[] }>;
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { ApolloServer } from "@apollo/server";
 import DataLoader from "dataloader";
-import { LangchainAgent } from "./ai/langchain-agent";
+import { ReActAgent } from "./ai/react-agent";
 import { AuthContext, JwtAuthService } from "./auth/jwt-auth";
 import { createAccountLoader } from "./dataloaders/account-loader";
 import { createCategoryLoader } from "./dataloaders/category-loader";
@@ -117,7 +117,7 @@ export async function createContext(req: {
   }
 
   if (!insightService) {
-    const aiAgent = new LangchainAgent(createBedrockChatModel());
+    const aiAgent = new ReActAgent(createBedrockChatModel());
     const aiDataService = new AiDataService(
       accountRepository,
       categoryRepository,

--- a/backend/src/services/insight-data-tools.ts
+++ b/backend/src/services/insight-data-tools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { ToolSignature } from "../models/ai-agent";
+import { ToolSignature } from "../models/agent";
 import { DateRange } from "../types/date-range";
 import { AiDataService } from "./ai-data-service";
 

--- a/backend/src/services/insight-math-tools.ts
+++ b/backend/src/services/insight-math-tools.ts
@@ -1,6 +1,6 @@
 import { evaluate, mean, sum } from "mathjs";
 import { z } from "zod";
-import { ToolSignature } from "../models/ai-agent";
+import { ToolSignature } from "../models/agent";
 
 const sumInputSchema = z.object({
   numbers: z.array(z.number()),

--- a/backend/src/services/insight-service.test.ts
+++ b/backend/src/services/insight-service.test.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { IAccountRepository } from "../models/account";
-import { type AIAgent } from "../models/ai-agent";
+import { type Agent } from "../models/agent";
 import { ICategoryRepository } from "../models/category";
 import { ITransactionRepository } from "../models/transaction";
 import { YEAR_RANGE_OFFSET } from "../types/validation";
@@ -13,7 +13,7 @@ import { AiDataService } from "./ai-data-service";
 import { BusinessError, BusinessErrorCodes } from "./business-error";
 import { type InsightInput, InsightService } from "./insight-service";
 
-const createMockAiAgent = (): jest.Mocked<AIAgent> => ({
+const createMockAiAgent = (): jest.Mocked<Agent> => ({
   call: jest.fn(),
 });
 
@@ -23,7 +23,7 @@ describe("InsightService", () => {
   let mockTransactionRepository: jest.Mocked<ITransactionRepository>;
   let mockAccountRepository: jest.Mocked<IAccountRepository>;
   let mockCategoryRepository: jest.Mocked<ICategoryRepository>;
-  let mockAiAgent: jest.Mocked<AIAgent>;
+  let mockAiAgent: jest.Mocked<Agent>;
   let aiDataService: AiDataService;
 
   beforeEach(() => {

--- a/backend/src/services/insight-service.ts
+++ b/backend/src/services/insight-service.ts
@@ -1,4 +1,4 @@
-import { AIAgent } from "../models/ai-agent";
+import { Agent } from "../models/agent";
 import { DateRange } from "../types/date-range";
 import { YEAR_RANGE_OFFSET } from "../types/validation";
 import { formatDateAsYYYYMMDD } from "../utils/date";
@@ -61,7 +61,7 @@ export interface InsightInput {
 export class InsightService {
   constructor(
     private aiDataService: AiDataService,
-    private aiAgent: AIAgent,
+    private aiAgent: Agent,
   ) {}
 
   async call(userId: string, input: InsightInput): Promise<string> {


### PR DESCRIPTION
## context

The agent abstraction used generic names (`LangchainAgent`, `AIAgent`, `AiMessage`) that obscured the meaningful distinctions between agent patterns (ReAct, Reflection) and the library used to implement them.
The class name `LangchainAgent` implied provider coupling, while the actual provider is injected via `BaseChatModel`.

## before

- `LangchainAgent` conflates library name with agent pattern, making future pattern variants (e.g. reflection) harder to distinguish
- `AIAgent` and `AiMessage` use inconsistent casing and redundant prefixes
- `AnyToolSignature` hides `any` behind a type alias

## after

- `ReActAgent` names the concrete class after the pattern it implements (ReAct loop via LangChain)
- `Agent` and `AgentMessage` are clean, idiomatic interface names
- `AnyToolSignature` removed; `ToolSignature<any>` used inline with an explicit eslint-disable comment