### PR TITLE
fix validateDateRange variable naming and endDate test coverage

### DIFF
--- a/backend/src/services/insight-service.test.ts
+++ b/backend/src/services/insight-service.test.ts
@@ -134,7 +134,7 @@ describe("InsightService", () => {
       });
     });
 
-    it("should throw error when date year is out of range", async () => {
+    it("should throw error when startDate year is out of range", async () => {
       // Arrange
       const currentYear = new Date().getFullYear();
       const minYear = currentYear - YEAR_RANGE_OFFSET;
@@ -143,7 +143,6 @@ describe("InsightService", () => {
       const input: InsightInput = {
         ...validInput,
         startDate: toDateString(`${outOfRangeYear}-01-01`),
-        endDate: toDateString(`${outOfRangeYear}-01-31`),
       };
 
       // Act & Assert
@@ -152,6 +151,27 @@ describe("InsightService", () => {
       await expect(promise).rejects.toThrow(BusinessError);
       await expect(promise).rejects.toMatchObject({
         message: `Start date must be between ${minYear} and ${maxYear}`,
+        code: BusinessErrorCodes.INVALID_DATE,
+      });
+    });
+
+    it("should throw error when endDate year is out of range", async () => {
+      // Arrange
+      const currentYear = new Date().getFullYear();
+      const minYear = currentYear - YEAR_RANGE_OFFSET;
+      const maxYear = currentYear + YEAR_RANGE_OFFSET;
+      const outOfRangeYear = maxYear + 1;
+      const input: InsightInput = {
+        ...validInput,
+        endDate: toDateString(`${outOfRangeYear}-01-31`),
+      };
+
+      // Act & Assert
+      const promise = service.call(userId, input);
+
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `End date must be between ${minYear} and ${maxYear}`,
         code: BusinessErrorCodes.INVALID_DATE,
       });
     });

--- a/backend/src/services/insight-service.ts
+++ b/backend/src/services/insight-service.ts
@@ -146,16 +146,16 @@ export class InsightService {
       );
     }
 
-    const startDateDate = new Date(startDate);
-    const endDateDate = new Date(endDate);
+    const startDateObj = new Date(startDate);
+    const endDateObj = new Date(endDate);
 
     const currentYear = new Date().getFullYear();
     const minimumYear = currentYear - YEAR_RANGE_OFFSET;
     const maximumYear = currentYear + YEAR_RANGE_OFFSET;
 
     if (
-      startDateDate.getFullYear() < minimumYear ||
-      startDateDate.getFullYear() > maximumYear
+      startDateObj.getFullYear() < minimumYear ||
+      startDateObj.getFullYear() > maximumYear
     ) {
       throw new BusinessError(
         `Start date must be between ${minimumYear} and ${maximumYear}`,
@@ -164,8 +164,8 @@ export class InsightService {
     }
 
     if (
-      endDateDate.getFullYear() < minimumYear ||
-      endDateDate.getFullYear() > maximumYear
+      endDateObj.getFullYear() < minimumYear ||
+      endDateObj.getFullYear() > maximumYear
     ) {
       throw new BusinessError(
         `End date must be between ${minimumYear} and ${maximumYear}`,
@@ -174,7 +174,7 @@ export class InsightService {
     }
 
     const differenceInDays =
-      (endDateDate.getTime() - startDateDate.getTime()) / (1000 * 60 * 60 * 24);
+      (endDateObj.getTime() - startDateObj.getTime()) / (1000 * 60 * 60 * 24);
 
     if (differenceInDays > MAX_PERIOD_DAYS) {
       throw new BusinessError(


### PR DESCRIPTION
## context

PR #170 (remove DateRange) introduced `validateDateRange(startDate, endDate)` but left two small issues: awkward local variable names from converting a `Date` object, and a test gap where `endDate` year-range validation had no dedicated test case.

## before

- Local variables in `validateDateRange` are named `startDateDate` and `endDateDate`
- The existing year-range test was named "date year is out of range" with both dates set out of range, so it only exercised the `startDate` branch
- `endDate` year-range validation has no test

## after

- Variables renamed to `startDateObj` and `endDateObj`
- Existing test renamed and scoped to `startDate` only
- New test covers `endDate` year out of range independently