### PR TITLE
move transfer business logic into service layer and add tests

### DIFF
--- a/backend/src/resolvers/transfer-resolvers.ts
+++ b/backend/src/resolvers/transfer-resolvers.ts
@@ -1,54 +1,12 @@
-import { GraphQLError } from "graphql";
-import { z } from "zod";
 import {
   MutationCreateTransferArgs,
   MutationDeleteTransferArgs,
   MutationUpdateTransferArgs,
   QueryTransferArgs,
-  TransactionType,
 } from "../__generated__/resolvers-types";
 import { GraphQLContext } from "../server";
-import { BusinessError } from "../services/business-error";
 import { toDateString } from "../types/date";
-import {
-  accountIdSchema,
-  amountSchema,
-  dateSchema,
-  descriptionSchema,
-} from "./schemas";
 import { getAuthenticatedUser, handleResolverError } from "./shared";
-
-/**
- * Reusable schema components for transfers
- */
-const transferIdSchema = z.uuid({
-  message: "Transfer ID must be a valid UUID",
-});
-
-/**
- * Zod schema for transfer input validation
- */
-const createTransferInputSchema = z.object({
-  fromAccountId: accountIdSchema,
-  toAccountId: accountIdSchema,
-  amount: amountSchema,
-  date: dateSchema.transform(toDateString),
-  description: descriptionSchema,
-});
-
-/**
- * Zod schema for update transfer input validation
- */
-const updateTransferInputSchema = z.object({
-  id: transferIdSchema,
-  fromAccountId: accountIdSchema.optional(),
-  toAccountId: accountIdSchema.optional(),
-  amount: amountSchema.optional(),
-  date: dateSchema
-    .optional()
-    .transform((value) => (value ? toDateString(value) : undefined)),
-  description: descriptionSchema,
-});
 
 export const transferResolvers = {
   Query: {
@@ -58,87 +16,22 @@ export const transferResolvers = {
       context: GraphQLContext,
     ) => {
       try {
-        // Validate and normalize input
-        const id = transferIdSchema.parse(args.id);
         const user = await getAuthenticatedUser(context);
-
-        // Get transfer transactions using the existing method
-        const transferTransactions =
-          await context.transactionRepository.findActiveByTransferId(
-            id,
-            user.id,
-          );
-
-        // Check if transfer exists
-        if (transferTransactions.length === 0) {
-          return undefined; // Return undefined if transfer not found (GraphQL convention for Maybe types)
-        }
-
-        // Validate we have exactly 2 transactions
-        if (transferTransactions.length !== 2) {
-          throw new BusinessError(
-            `Invalid transfer state: expected 2 transactions, found ${transferTransactions.length}`,
-            "INVALID_TRANSFER_STATE",
-            {
-              transferId: id,
-              userId: user.id,
-              transactionCount: transferTransactions.length,
-            },
-          );
-        }
-
-        // Identify outbound and inbound transactions
-        const outboundTransaction = transferTransactions.find(
-          (t) => t.type === TransactionType.TRANSFER_OUT,
-        );
-        const inboundTransaction = transferTransactions.find(
-          (t) => t.type === TransactionType.TRANSFER_IN,
+        const transferResult = await context.transferService.getTransfer(
+          args.id,
+          user.id,
         );
 
-        if (!outboundTransaction) {
-          throw new BusinessError(
-            "Invalid transfer state: missing TRANSFER_OUT transaction",
-            "INVALID_TRANSFER_STATE",
-            {
-              transferId: id,
-              userId: user.id,
-              missingTransactionType: TransactionType.TRANSFER_OUT,
-              foundTransactionTypes: transferTransactions.map((t) => t.type),
-            },
-          );
+        if (!transferResult) {
+          return undefined;
         }
 
-        if (!inboundTransaction) {
-          throw new BusinessError(
-            "Invalid transfer state: missing TRANSFER_IN transaction",
-            "INVALID_TRANSFER_STATE",
-            {
-              transferId: id,
-              userId: user.id,
-              missingTransactionType: TransactionType.TRANSFER_IN,
-              foundTransactionTypes: transferTransactions.map((t) => t.type),
-            },
-          );
-        }
-
-        // Return the transfer object that matches the GraphQL Transfer type
         return {
-          id: id,
-          outboundTransaction,
-          inboundTransaction,
+          id: transferResult.transferId,
+          outboundTransaction: transferResult.outboundTransaction,
+          inboundTransaction: transferResult.inboundTransaction,
         };
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const firstError = error.issues[0];
-          throw new GraphQLError(firstError.message, {
-            extensions: { code: "BAD_USER_INPUT" },
-          });
-        }
-        if (error instanceof BusinessError) {
-          throw new GraphQLError(error.message, {
-            extensions: { code: error.code, details: error.details },
-          });
-        }
         handleResolverError(error, "Failed to get transfer");
       }
     },
@@ -150,33 +43,22 @@ export const transferResolvers = {
       context: GraphQLContext,
     ) => {
       try {
-        // Validate and normalize input
-        const validatedInput = createTransferInputSchema.parse(args.input);
         const user = await getAuthenticatedUser(context);
 
         const transferResult = await context.transferService.createTransfer(
-          validatedInput,
+          {
+            ...args.input,
+            date: toDateString(args.input.date),
+          },
           user.id,
         );
 
-        // Return the transfer object that matches the GraphQL Transfer type
         return {
           id: transferResult.transferId,
           outboundTransaction: transferResult.outboundTransaction,
           inboundTransaction: transferResult.inboundTransaction,
         };
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const firstError = error.issues[0];
-          throw new GraphQLError(firstError.message, {
-            extensions: { code: "BAD_USER_INPUT" },
-          });
-        }
-        if (error instanceof BusinessError) {
-          throw new GraphQLError(error.message, {
-            extensions: { code: error.code, details: error.details },
-          });
-        }
         handleResolverError(error, "Failed to create transfer");
       }
     },
@@ -186,35 +68,24 @@ export const transferResolvers = {
       context: GraphQLContext,
     ) => {
       try {
-        // Validate and normalize input
-        const validatedInput = updateTransferInputSchema.parse(args.input);
         const user = await getAuthenticatedUser(context);
-        const { id } = validatedInput;
+        const { id, ...updateData } = args.input;
 
         const transferResult = await context.transferService.updateTransfer(
           id,
           user.id,
-          validatedInput,
+          {
+            ...updateData,
+            date: updateData.date ? toDateString(updateData.date) : undefined,
+          },
         );
 
-        // Return the transfer object that matches the GraphQL Transfer type
         return {
           id: transferResult.transferId,
           outboundTransaction: transferResult.outboundTransaction,
           inboundTransaction: transferResult.inboundTransaction,
         };
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const firstError = error.issues[0];
-          throw new GraphQLError(firstError.message, {
-            extensions: { code: "BAD_USER_INPUT" },
-          });
-        }
-        if (error instanceof BusinessError) {
-          throw new GraphQLError(error.message, {
-            extensions: { code: error.code, details: error.details },
-          });
-        }
         handleResolverError(error, "Failed to update transfer");
       }
     },
@@ -224,25 +95,10 @@ export const transferResolvers = {
       context: GraphQLContext,
     ) => {
       try {
-        // Validate and normalize input
-        const validatedId = transferIdSchema.parse(args.id);
         const user = await getAuthenticatedUser(context);
-
-        await context.transferService.deleteTransfer(validatedId, user.id);
-
+        await context.transferService.deleteTransfer(args.id, user.id);
         return true;
       } catch (error) {
-        if (error instanceof z.ZodError) {
-          const firstError = error.issues[0];
-          throw new GraphQLError(firstError.message, {
-            extensions: { code: "BAD_USER_INPUT" },
-          });
-        }
-        if (error instanceof BusinessError) {
-          throw new GraphQLError(error.message, {
-            extensions: { code: error.code, details: error.details },
-          });
-        }
         handleResolverError(error, "Failed to delete transfer");
       }
     },

--- a/backend/src/services/transfer-service.test.ts
+++ b/backend/src/services/transfer-service.test.ts
@@ -1,0 +1,263 @@
+import { faker } from "@faker-js/faker";
+import { IAccountRepository } from "../models/account";
+import { ITransactionRepository, TransactionType } from "../models/transaction";
+import { toDateString } from "../types/date";
+import { DESCRIPTION_MAX_LENGTH } from "../types/validation";
+import { fakeAccount, fakeTransaction } from "../utils/test-utils/factories";
+import {
+  createMockAccountRepository,
+  createMockTransactionRepository,
+} from "../utils/test-utils/mock-repositories";
+import { BusinessError, BusinessErrorCodes } from "./business-error";
+import { TransferService } from "./transfer-service";
+
+describe("TransferService", () => {
+  let service: TransferService;
+  let userId: string;
+  let mockTransactionRepository: jest.Mocked<ITransactionRepository>;
+  let mockAccountRepository: jest.Mocked<IAccountRepository>;
+
+  beforeEach(() => {
+    mockTransactionRepository = createMockTransactionRepository();
+    mockAccountRepository = createMockAccountRepository();
+
+    service = new TransferService(
+      mockTransactionRepository,
+      mockAccountRepository,
+    );
+
+    userId = faker.string.uuid();
+
+    jest.clearAllMocks();
+  });
+
+  describe("getTransfer", () => {
+    it("should return undefined when transfer not found", async () => {
+      const transferId = faker.string.uuid();
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([]);
+
+      const result = await service.getTransfer(transferId, userId);
+
+      expect(result).toBeUndefined();
+      expect(
+        mockTransactionRepository.findActiveByTransferId,
+      ).toHaveBeenCalledWith(transferId, userId);
+    });
+
+    it("should throw INVALID_TRANSFER_STATE when only one transaction found", async () => {
+      const transferId = faker.string.uuid();
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        fakeTransaction({ type: TransactionType.TRANSFER_OUT, transferId }),
+      ]);
+
+      const promise = service.getTransfer(transferId, userId);
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Invalid transfer state: expected 2 transactions, found 1",
+        code: BusinessErrorCodes.INVALID_TRANSFER_STATE,
+      });
+    });
+
+    it("should throw INVALID_TRANSFER_STATE when more than two transactions found", async () => {
+      const transferId = faker.string.uuid();
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        fakeTransaction({ type: TransactionType.TRANSFER_OUT, transferId }),
+        fakeTransaction({ type: TransactionType.TRANSFER_IN, transferId }),
+        fakeTransaction({ type: TransactionType.TRANSFER_OUT, transferId }),
+      ]);
+
+      const promise = service.getTransfer(transferId, userId);
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Invalid transfer state: expected 2 transactions, found 3",
+        code: BusinessErrorCodes.INVALID_TRANSFER_STATE,
+      });
+    });
+
+    it("should throw INVALID_TRANSFER_STATE when TRANSFER_OUT transaction is missing", async () => {
+      const transferId = faker.string.uuid();
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        fakeTransaction({ type: TransactionType.TRANSFER_IN, transferId }),
+        fakeTransaction({ type: TransactionType.TRANSFER_IN, transferId }),
+      ]);
+
+      const promise = service.getTransfer(transferId, userId);
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Invalid transfer state: missing TRANSFER_OUT transaction",
+        code: BusinessErrorCodes.INVALID_TRANSFER_STATE,
+      });
+    });
+
+    it("should throw INVALID_TRANSFER_STATE when TRANSFER_IN transaction is missing", async () => {
+      const transferId = faker.string.uuid();
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        fakeTransaction({ type: TransactionType.TRANSFER_OUT, transferId }),
+        fakeTransaction({ type: TransactionType.TRANSFER_OUT, transferId }),
+      ]);
+
+      const promise = service.getTransfer(transferId, userId);
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Invalid transfer state: missing TRANSFER_IN transaction",
+        code: BusinessErrorCodes.INVALID_TRANSFER_STATE,
+      });
+    });
+
+    it("should return transfer result with correctly identified outbound and inbound transactions", async () => {
+      const transferId = faker.string.uuid();
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        transferId,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        transferId,
+      });
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        outboundTransaction,
+        inboundTransaction,
+      ]);
+
+      const result = await service.getTransfer(transferId, userId);
+
+      expect(result).toEqual({
+        transferId,
+        outboundTransaction,
+        inboundTransaction,
+      });
+    });
+
+    it("should identify outbound and inbound correctly regardless of array order", async () => {
+      const transferId = faker.string.uuid();
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        transferId,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        transferId,
+      });
+      // Inbound arrives first in the array
+      mockTransactionRepository.findActiveByTransferId.mockResolvedValue([
+        inboundTransaction,
+        outboundTransaction,
+      ]);
+
+      const result = await service.getTransfer(transferId, userId);
+
+      expect(result).toEqual({
+        transferId,
+        outboundTransaction,
+        inboundTransaction,
+      });
+    });
+  });
+
+  describe("createTransfer", () => {
+    it("should create transfer and return result with outbound and inbound transactions", async () => {
+      const fromAccount = fakeAccount({ userId });
+      const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+      });
+
+      mockAccountRepository.findActiveById
+        .mockResolvedValueOnce(fromAccount)
+        .mockResolvedValueOnce(toAccount);
+      mockTransactionRepository.createMany.mockResolvedValue([
+        outboundTransaction,
+        inboundTransaction,
+      ]);
+
+      const result = await service.createTransfer(
+        {
+          fromAccountId: fromAccount.id,
+          toAccountId: toAccount.id,
+          amount: 100,
+          date: toDateString("2024-01-01"),
+        },
+        userId,
+      );
+
+      expect(result).toEqual({
+        transferId: expect.any(String),
+        outboundTransaction,
+        inboundTransaction,
+      });
+    });
+
+    it("should reject description exceeding maximum length", async () => {
+      const promise = service.createTransfer(
+        {
+          fromAccountId: faker.string.uuid(),
+          toAccountId: faker.string.uuid(),
+          amount: 100,
+          date: toDateString("2024-01-01"),
+          description: "a".repeat(DESCRIPTION_MAX_LENGTH + 1),
+        },
+        userId,
+      );
+
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+        code: BusinessErrorCodes.INVALID_PARAMETERS,
+      });
+
+      expect(mockTransactionRepository.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateTransfer", () => {
+    it("should update transfer and return result with updated transactions", async () => {
+      const transferId = faker.string.uuid();
+      const fromAccount = fakeAccount({ userId });
+      const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        transferId,
+        accountId: fromAccount.id,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        transferId,
+        accountId: toAccount.id,
+      });
+
+      mockTransactionRepository.findActiveByTransferId
+        .mockResolvedValueOnce([outboundTransaction, inboundTransaction])
+        .mockResolvedValueOnce([outboundTransaction, inboundTransaction]);
+      mockAccountRepository.findActiveById
+        .mockResolvedValueOnce(fromAccount)
+        .mockResolvedValueOnce(toAccount);
+
+      const result = await service.updateTransfer(transferId, userId, {
+        amount: 200,
+      });
+
+      expect(result).toEqual({
+        transferId,
+        outboundTransaction,
+        inboundTransaction,
+      });
+    });
+
+    it("should reject description exceeding maximum length", async () => {
+      const promise = service.updateTransfer(faker.string.uuid(), userId, {
+        description: "a".repeat(DESCRIPTION_MAX_LENGTH + 1),
+      });
+
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+        code: BusinessErrorCodes.INVALID_PARAMETERS,
+      });
+
+      expect(mockTransactionRepository.updateMany).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/services/transfer-service.ts
+++ b/backend/src/services/transfer-service.ts
@@ -7,12 +7,13 @@ import {
   TransactionType,
 } from "../models/transaction";
 import { DateString } from "../types/date";
+import { DESCRIPTION_MAX_LENGTH } from "../types/validation";
 import { BusinessError, BusinessErrorCodes } from "./business-error";
 
 /**
  * Input type for creating transfers between accounts
  */
-export interface CreateTransferInput {
+export interface CreateTransferServiceInput {
   fromAccountId: string;
   toAccountId: string;
   amount: number;
@@ -23,7 +24,7 @@ export interface CreateTransferInput {
 /**
  * Input type for updating transfers between accounts
  */
-export interface UpdateTransferInput {
+export interface UpdateTransferServiceInput {
   fromAccountId?: string;
   toAccountId?: string;
   amount?: number;
@@ -51,6 +52,75 @@ export class TransferService {
   ) {}
 
   /**
+   * Get a transfer by ID with its paired transactions
+   * @param transferId - The transfer ID to retrieve
+   * @param userId - The user ID owning the transfer
+   * @returns Promise<TransferResult | undefined> - The transfer result or undefined if not found
+   * @throws BusinessError if the transfer is in an invalid state
+   */
+  async getTransfer(
+    transferId: string,
+    userId: string,
+  ): Promise<TransferResult | undefined> {
+    const transferTransactions =
+      await this.transactionRepository.findActiveByTransferId(
+        transferId,
+        userId,
+      );
+
+    if (transferTransactions.length === 0) {
+      return undefined;
+    }
+
+    if (transferTransactions.length !== 2) {
+      throw new BusinessError(
+        `Invalid transfer state: expected 2 transactions, found ${transferTransactions.length}`,
+        BusinessErrorCodes.INVALID_TRANSFER_STATE,
+        {
+          transferId,
+          userId,
+          transactionCount: transferTransactions.length,
+        },
+      );
+    }
+
+    const outboundTransaction = transferTransactions.find(
+      (t) => t.type === TransactionType.TRANSFER_OUT,
+    );
+    const inboundTransaction = transferTransactions.find(
+      (t) => t.type === TransactionType.TRANSFER_IN,
+    );
+
+    if (!outboundTransaction) {
+      throw new BusinessError(
+        "Invalid transfer state: missing TRANSFER_OUT transaction",
+        BusinessErrorCodes.INVALID_TRANSFER_STATE,
+        {
+          transferId,
+          userId,
+          missingTransactionType: TransactionType.TRANSFER_OUT,
+          foundTransactionTypes: transferTransactions.map((t) => t.type),
+        },
+      );
+    }
+
+    if (!inboundTransaction) {
+      throw new BusinessError(
+        "Invalid transfer state: missing TRANSFER_IN transaction",
+        BusinessErrorCodes.INVALID_TRANSFER_STATE,
+        {
+          transferId,
+          userId,
+          missingTransactionType: TransactionType.TRANSFER_IN,
+          foundTransactionTypes: transferTransactions.map((t) => t.type),
+        },
+      );
+    }
+
+    return { transferId, outboundTransaction, inboundTransaction };
+  }
+
+  /**
    * Create a transfer between two accounts
    * Creates two linked transactions: TRANSFER_OUT from source, TRANSFER_IN to destination
    * @param input - Transfer creation input
@@ -59,11 +129,12 @@ export class TransferService {
    * @throws BusinessError for any business rule violations
    */
   async createTransfer(
-    input: CreateTransferInput,
+    input: CreateTransferServiceInput,
     userId: string,
   ): Promise<TransferResult> {
     // Validate input parameters
     this.validateAmount(input.amount);
+    this.validateDescription(input.description);
 
     // Validate not transferring to the same account (fail fast before DB calls)
     this.validateNotSelfTransfer(
@@ -222,8 +293,14 @@ export class TransferService {
   async updateTransfer(
     transferId: string,
     userId: string,
-    input: UpdateTransferInput,
+    input: UpdateTransferServiceInput,
   ): Promise<TransferResult> {
+    // Validate input parameters before any DB calls
+    if (input.amount !== undefined) {
+      this.validateAmount(input.amount);
+    }
+    this.validateDescription(input.description);
+
     // Find the existing transfer transactions first
     const existingTransactions =
       await this.transactionRepository.findActiveByTransferId(
@@ -302,9 +379,6 @@ export class TransferService {
       input.description !== undefined
         ? input.description
         : outboundTransaction.description;
-
-    // Validate the effective values
-    this.validateAmount(amount);
 
     // Validate not transferring to the same account (fail fast before DB calls)
     this.validateNotSelfTransfer(fromAccountId, toAccountId, userId);
@@ -402,6 +476,24 @@ export class TransferService {
           toAccountId: toAccountId,
           amount: amount,
           originalError: error,
+        },
+      );
+    }
+  }
+
+  /**
+   * Validate that the description does not exceed the maximum allowed length
+   * @param description - The description to validate (null/undefined are allowed)
+   * @throws BusinessError if description exceeds maximum length
+   */
+  private validateDescription(description?: string | null): void {
+    if (description && description.length > DESCRIPTION_MAX_LENGTH) {
+      throw new BusinessError(
+        `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+        BusinessErrorCodes.INVALID_PARAMETERS,
+        {
+          descriptionLength: description.length,
+          maxLength: DESCRIPTION_MAX_LENGTH,
         },
       );
     }


### PR DESCRIPTION
## context

Transfer resolvers contained business logic (transfer state validation, input
normalization) that belongs in the service layer.
The service also lacked a dedicated `getTransfer` method and had no unit tests.

## before

- Transfer resolvers validate transfer state and identify outbound/inbound transactions directly
- No `getTransfer` method on `TransferService` — query resolver reimplements retrieval logic inline
- `validateDescription` is absent from `TransferService`, unlike `TransactionService`
- `TransferService` has no unit tests

## after

- Transfer resolvers delegate all business logic to `TransferService`
- `TransferService.getTransfer` encapsulates transfer retrieval and state validation
- `validateDescription` is added to `TransferService`, consistent with `TransactionService`
- `transfer-service.test.ts` covers `getTransfer`, `createTransfer`, and `updateTransfer`