### PR TITLE
enforce non-transfer constraint on transaction service input at type level

### DIFF
--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -9,6 +9,11 @@ export enum TransactionType {
   REFUND = "REFUND",
 }
 
+export type NonTransferTransactionType = Exclude<
+  TransactionType,
+  TransactionType.TRANSFER_IN | TransactionType.TRANSFER_OUT
+>;
+
 export interface TransactionFilterInput {
   accountIds?: string[];
   categoryIds?: string[];

--- a/backend/src/services/transaction-service.test.ts
+++ b/backend/src/services/transaction-service.test.ts
@@ -6,7 +6,6 @@ import { MIN_SEARCH_TEXT_LENGTH } from "../types/validation";
 import {
   fakeAccount,
   fakeCategory,
-  fakeCreateTransactionInput,
   fakeTransaction,
   fakeTransactionPattern,
 } from "../utils/test-utils/factories";
@@ -15,6 +14,7 @@ import {
   createMockCategoryRepository,
   createMockTransactionRepository,
 } from "../utils/test-utils/mock-repositories";
+import { fakeCreateTransactionServiceInput } from "../utils/test-utils/service-factories";
 import { BusinessError, BusinessErrorCodes } from "./business-error";
 import {
   DEFAULT_TRANSACTION_PATTERNS_LIMIT,
@@ -748,12 +748,13 @@ describe("TransactionService", () => {
   });
 
   describe("createTransaction with REFUND type", () => {
+    const currency = "EUR";
     let accountId: string;
     let expenseCategory: Category;
     let incomeCategory: Category;
 
     beforeEach(() => {
-      const account = fakeAccount({ userId });
+      const account = fakeAccount({ currency, userId });
       accountId = account.id;
       expenseCategory = fakeCategory({
         userId,
@@ -772,8 +773,7 @@ describe("TransactionService", () => {
 
     it("should allow REFUND transaction with EXPENSE category", async () => {
       // Arrange
-      const input = fakeCreateTransactionInput({
-        userId,
+      const input = fakeCreateTransactionServiceInput({
         accountId,
         categoryId: expenseCategory.id,
         type: TransactionType.REFUND,
@@ -794,13 +794,16 @@ describe("TransactionService", () => {
         expenseCategory.id,
         userId,
       );
-      expect(mockTransactionRepository.create).toHaveBeenCalledWith(input);
+      expect(mockTransactionRepository.create).toHaveBeenCalledWith({
+        ...input,
+        currency,
+        userId,
+      });
     });
 
     it("should reject REFUND transaction with INCOME category", async () => {
       // Arrange
-      const input = fakeCreateTransactionInput({
-        userId,
+      const input = fakeCreateTransactionServiceInput({
         accountId,
         categoryId: incomeCategory.id,
         type: TransactionType.REFUND,
@@ -822,8 +825,7 @@ describe("TransactionService", () => {
 
     it("should allow REFUND transaction without category (uncategorized)", async () => {
       // Arrange
-      const input = fakeCreateTransactionInput({
-        userId,
+      const input = fakeCreateTransactionServiceInput({
         accountId,
         categoryId: undefined,
         type: TransactionType.REFUND,

--- a/backend/src/services/transaction-service.ts
+++ b/backend/src/services/transaction-service.ts
@@ -8,6 +8,7 @@ import {
   CreateTransactionInput,
   EnrichedTransactionPattern,
   ITransactionRepository,
+  NonTransferTransactionType,
   Transaction,
   TransactionConnection,
   TransactionFilterInput,
@@ -15,6 +16,7 @@ import {
   TransactionType,
   UpdateTransactionInput,
 } from "../models/transaction";
+import { DateString } from "../types/date";
 import { PaginationInput } from "../types/pagination";
 import { MIN_SEARCH_TEXT_LENGTH } from "../types/validation";
 import { BusinessError, BusinessErrorCodes } from "./business-error";
@@ -29,17 +31,22 @@ export const MAX_DESCRIPTION_SUGGESTIONS_LIMIT = 10;
 export const DESCRIPTION_SUGGESTIONS_SAMPLE_SIZE = 100;
 
 /**
- * Service layer input for creating transactions (currency automatically derived from account)
+ * Service layer input for creating transactions
  */
-type CreateTransactionServiceInput = Omit<
-  CreateTransactionInput,
-  "userId" | "currency"
->;
+export interface CreateTransactionServiceInput {
+  accountId: string;
+  amount: number;
+  categoryId?: string | null;
+  date: DateString;
+  description?: string | null;
+  type: NonTransferTransactionType; // INCOME, EXPENSE, or REFUND
+}
 
 /**
- * Service layer input for updating transactions (currency automatically updated when account changes)
+ * Service layer input for updating transactions
  */
-type UpdateTransactionServiceInput = Omit<UpdateTransactionInput, "currency">;
+export type UpdateTransactionServiceInput =
+  Partial<CreateTransactionServiceInput>;
 
 /**
  * Transaction service class for handling business logic and validation

--- a/backend/src/utils/test-utils/service-factories.ts
+++ b/backend/src/utils/test-utils/service-factories.ts
@@ -1,0 +1,18 @@
+import { faker } from "@faker-js/faker";
+import { TransactionType } from "../../models/transaction";
+import { CreateTransactionServiceInput } from "../../services/transaction-service";
+import { toDateString } from "../../types/date";
+
+export const fakeCreateTransactionServiceInput = (
+  overrides: Partial<CreateTransactionServiceInput> = {},
+): CreateTransactionServiceInput => {
+  return {
+    accountId: faker.string.uuid(),
+    categoryId: faker.string.uuid(),
+    type: TransactionType.EXPENSE,
+    amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
+    date: toDateString(faker.date.recent().toISOString().split("T")[0]),
+    description: faker.finance.transactionDescription(),
+    ...overrides,
+  };
+};


### PR DESCRIPTION
## context

`CreateTransactionServiceInput` accepted the full `TransactionType` enum,
meaning the compiler allowed passing `TRANSFER_IN` or `TRANSFER_OUT` to `createTransaction`.
The constraint was only enforced at runtime via business validation.

## before

- `CreateTransactionServiceInput` uses `Omit<CreateTransactionInput, "userId" | "currency">`, leaving `type: TransactionType` broad
- Passing a transfer type to `createTransaction` is a runtime error, not a compile-time error
- No dedicated service-layer test factory exists; tests reuse the model-layer `fakeCreateTransactionInput`

## after

- `NonTransferTransactionType` (excludes `TRANSFER_IN`/`TRANSFER_OUT`) is defined in the transaction model
- `CreateTransactionServiceInput` uses `type: NonTransferTransactionType`, making invalid inputs a compile-time error
- `UpdateTransactionServiceInput` follows as `Partial<CreateTransactionServiceInput>`
- `fakeCreateTransactionServiceInput` factory added for service-layer tests