### PR TITLE
fix button overflow on tablet viewports

### DIFF
--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -7,7 +7,7 @@
     >
       <h1 class="text-h5 text-sm-h4">Transactions</h1>
       <div class="d-flex">
-        <!-- d-none d-md-flex: hidden by default, shown at 960px+ -->
+        <!-- Desktop buttons: d-none d-md-flex - hidden by default, shown at 960px+ -->
         <v-btn
           class="d-none d-md-flex"
           color="primary"
@@ -16,7 +16,7 @@
         >
           Add Transaction
         </v-btn>
-        <!-- d-flex d-md-none: shown by default, hidden at 960px+ -->
+        <!-- Tablet/Mobile buttons: d-flex d-md-none - shown by default, hidden at 960px+ -->
         <v-btn
           class="d-flex d-md-none"
           color="primary"


### PR DESCRIPTION
## context

The "Add Transaction" and "Add Transfer" buttons overflow on tablet viewports (600-960px) because they display full text labels, leaving no room for both buttons on a single row.

## before

- Buttons switch to full-text labels at 600px breakpoint (sm)
- Tablet viewports don't have enough space for both text buttons
- Buttons overflow or become partially hidden on some tablet sizes

## after

- Buttons remain icon-only until 960px breakpoint (md)
- Full-text labels only display on desktop viewports (960px+)
- Buttons are fully visible and accessible on all tablet sizes

Close #188