### PR TITLE
consolidate infra parameter defaults in CDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,14 @@ ENV=staging ./deploy.sh
 
 ### Override Configuration (Optional)
 
-All parameters have sensible defaults. To override any default, create parameters in AWS Systems Manager Parameter Store:
+All parameters have sensible defaults. To override any default, create parameters in AWS Systems Manager Parameter Store.
+
+Parameters fall into two groups:
+
+- **Deployment-time** — read by `deploy.sh` and CDK during stack deployment. Changes take effect on the next `./deploy.sh`.
+- **Runtime** — read by the backend Lambda on cold start. Changes take effect on the next cold start without redeploy.
+
+#### Deployment-time
 
 ```bash
 # Allow/disallow user self-registration
@@ -102,26 +109,6 @@ aws ssm put-parameter --overwrite --type String \
     --name "/manual/budget/production/auth/domain-prefix" \
     --value "production-budget-auth"
 
-# Auth scopes
-aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/auth/scope" \
-    --value "openid profile email"
-
-# AI max response tokens
-aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/bedrock/max-tokens" \
-    --value "2000"
-
-# AI model ID (e.g., openai.gpt-oss-120b-1:0)
-aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/bedrock/model-id" \
-    --value "openai.gpt-oss-120b-1:0"
-
-# AI sampling temperature
-aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/bedrock/temperature" \
-    --value "0.2"
-
 # Custom domain (optional, see Custom Domain Setup)
 aws ssm put-parameter --overwrite --type String \
     --name "/manual/budget/production/frontend/custom-domain" \
@@ -136,6 +123,35 @@ aws ssm put-parameter --overwrite --type String \
 aws ssm put-parameter --overwrite --type String \
     --name "/manual/budget/production/lambda/timeout-seconds" \
     --value "30"
+```
+
+#### Runtime
+
+```bash
+# AI connection timeout (in milliseconds)
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/connection-timeout" \
+    --value "5000"
+
+# AI max response tokens
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/max-tokens" \
+    --value "2000"
+
+# AI model ID (e.g., openai.gpt-oss-120b-1:0)
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/model-id" \
+    --value "openai.gpt-oss-120b-1:0"
+
+# AI request timeout (in milliseconds)
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/request-timeout" \
+    --value "30000"
+
+# AI sampling temperature
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/temperature" \
+    --value "0.2"
 
 # Chat history max messages
 aws ssm put-parameter --overwrite --type String \

--- a/deploy.sh
+++ b/deploy.sh
@@ -117,7 +117,6 @@ ssm_get_or_default() {
 
 DEFAULT_AUTH_CLAIM_NAMESPACE="https://personal-budget-tracker"
 DEFAULT_AUTH_DOMAIN_PREFIX="$ENV-budget-auth"
-DEFAULT_AUTH_SCOPE="openid profile email"
 
 AUTH_ALLOW_USER_REGISTRATION=$(ssm_get_or_default "/manual/budget/$ENV/auth/allow-user-registration" "") || exit $?
 echo "AUTH_ALLOW_USER_REGISTRATION=$AUTH_ALLOW_USER_REGISTRATION"
@@ -127,9 +126,6 @@ echo "AUTH_CLAIM_NAMESPACE=$AUTH_CLAIM_NAMESPACE"
 
 AUTH_DOMAIN_PREFIX=$(ssm_get_or_default "/manual/budget/$ENV/auth/domain-prefix" "$DEFAULT_AUTH_DOMAIN_PREFIX") || exit $?
 echo "AUTH_DOMAIN_PREFIX=$AUTH_DOMAIN_PREFIX"
-
-AUTH_SCOPE=$(ssm_get_or_default "/manual/budget/$ENV/auth/scope" "$DEFAULT_AUTH_SCOPE") || exit $?
-echo "AUTH_SCOPE=$AUTH_SCOPE"
 
 AWS_LAMBDA_MEMORY_SIZE=$(ssm_get_or_default "/manual/budget/$ENV/lambda/memory-size" "") || exit $?
 echo "AWS_LAMBDA_MEMORY_SIZE=$AWS_LAMBDA_MEMORY_SIZE"
@@ -164,6 +160,7 @@ env AUTH_ALLOW_USER_REGISTRATION="$AUTH_ALLOW_USER_REGISTRATION" \
 echo "Extracting auth configuration from CDK outputs..."
 AUTH_ISSUER=$(cat "$CDK_OUTPUT_FILE" | jq -r '."'"$ENV"'-BudgetAuth".AuthIssuer // empty')
 AUTH_CLIENT_ID=$(cat "$CDK_OUTPUT_FILE" | jq -r '."'"$ENV"'-BudgetAuth".UserPoolClientId // empty')
+AUTH_SCOPE=$(cat "$CDK_OUTPUT_FILE" | jq -r '."'"$ENV"'-BudgetAuth".AuthScope // empty')
 AUTH_UI_URL=$(cat "$CDK_OUTPUT_FILE" | jq -r '."'"$ENV"'-BudgetAuth".UserPoolDomainUrl // empty')
 
 if [ -z "$AUTH_ISSUER" ] || [ "$AUTH_ISSUER" = "null" ]; then
@@ -179,6 +176,13 @@ if [ -z "$AUTH_CLIENT_ID" ] || [ "$AUTH_CLIENT_ID" = "null" ]; then
   exit 1
 fi
 echo "AUTH_CLIENT_ID=$AUTH_CLIENT_ID"
+
+if [ -z "$AUTH_SCOPE" ] || [ "$AUTH_SCOPE" = "null" ]; then
+  echo "ERROR: AuthScope not found in CDK outputs from auth stack"
+  echo "Auth stack deployment may have failed or outputs are misconfigured"
+  exit 1
+fi
+echo "AUTH_SCOPE=$AUTH_SCOPE"
 
 if [ -z "$AUTH_UI_URL" ] || [ "$AUTH_UI_URL" = "null" ]; then
   echo "ERROR: UserPoolDomainUrl not found in CDK outputs from auth stack"

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,7 @@ NODE_ENV="$ENV"
 #
 # Behavior:
 #   - Returns the parameter value if it exists and is non-empty
-#   - Returns the provided default if:
+#   - Returns empty string if:
 #       • the parameter does not exist (ParameterNotFound)
 #       • the parameter exists but is empty (or AWS returns "None")
 #   - Fails hard on real AWS problems:
@@ -31,22 +31,17 @@ NODE_ENV="$ENV"
 # Designed for: set -euo pipefail
 #
 # Usage:
-#   VALUE=$(ssm_get_or_default "/path/to/param" "fallback") || exit $?
+#   VALUE=$(ssm_get "/path/to/param") || exit $?
 
-ssm_get_or_default() {
-  # First argument: full SSM parameter name
+ssm_get() {
+  # Full SSM parameter name
   local name="$1"
 
-  # Second argument: default value (optional)
-  local def="${2-}"
-
-  # Will capture either:
-  #   - the parameter value (stdout)
-  #   - or AWS error message (stderr redirected to stdout)
+  # Captures either the parameter value (stdout) or the AWS error message
+  # (stderr redirected to stdout via 2>&1 below)
   local out
 
-  # Will store the exit status of the aws command
-  # (0 = success, non-zero = failure)
+  # Exit status of the aws command (0 = success, non-zero = failure)
   local rc
 
   # Log what we are about to fetch (stderr keeps stdout clean for command substitution)
@@ -62,75 +57,49 @@ ssm_get_or_default() {
           --query 'Parameter.Value' \
           --output text 2>&1)
 
-  # Immediately save the exit code of the aws command.
-  # $? always refers to the most recently executed command.
+  # Save exit code immediately — $? always refers to the most recent command
   rc=$?
 
-  # Show raw AWS result for debugging
   echo "[ssm] aws exit code: $rc" >&2
   echo "[ssm] raw output: $out" >&2
 
-  # ------------------------------------------------------------------
-  # SUCCESS PATH — AWS returned without error
-  # ------------------------------------------------------------------
+  # SUCCESS — AWS returned without error
   if [[ $rc -eq 0 ]]; then
-    # out now contains the parameter value (may be empty)
-
-    # Use the value only if:
-    #   - it is non-empty
-    #   - and not the AWS placeholder string "None"
+    # "None" is AWS placeholder for empty; normalize to empty string
     if [[ -n "$out" && "$out" != "None" ]]; then
-      echo "[ssm] value found → returning value" >&2
+      echo "[ssm] value found" >&2
       printf '%s' "$out"
     else
-      # Parameter exists but is empty → fall back to default
-      echo "[ssm] value empty → using default" >&2
-      printf '%s' "$def"
+      echo "[ssm] value empty" >&2
     fi
     return 0
   fi
 
-  # ------------------------------------------------------------------
-  # MISSING PARAMETER PATH — not a real failure
-  # ------------------------------------------------------------------
-
-  # If AWS explicitly reports ParameterNotFound,
-  # treat this as expected and return the default.
+  # MISSING — ParameterNotFound is expected, not a failure
   if grep -q 'ParameterNotFound' <<<"$out"; then
-    echo "[ssm] parameter not found → using default" >&2
-    printf '%s' "$def"
+    echo "[ssm] parameter not found" >&2
     return 0
   fi
 
-  # ------------------------------------------------------------------
-  # REAL ERROR PATH — must stop the script
-  # ------------------------------------------------------------------
-
-  # Any other error means something is genuinely wrong:
-  # credentials missing, IAM denied, network issues, etc.
+  # REAL ERROR — credentials, IAM, network
   echo "[ssm] fatal AWS error:" >&2
   echo "$out" >&2
-
-  # Propagate the original AWS exit code
   return "$rc"
 }
 
-DEFAULT_AUTH_CLAIM_NAMESPACE="https://personal-budget-tracker"
-DEFAULT_AUTH_DOMAIN_PREFIX="$ENV-budget-auth"
-
-AUTH_ALLOW_USER_REGISTRATION=$(ssm_get_or_default "/manual/budget/$ENV/auth/allow-user-registration" "") || exit $?
+AUTH_ALLOW_USER_REGISTRATION=$(ssm_get "/manual/budget/$ENV/auth/allow-user-registration") || exit $?
 echo "AUTH_ALLOW_USER_REGISTRATION=$AUTH_ALLOW_USER_REGISTRATION"
 
-AUTH_CLAIM_NAMESPACE=$(ssm_get_or_default "/manual/budget/$ENV/auth/claim-namespace" "$DEFAULT_AUTH_CLAIM_NAMESPACE") || exit $?
+AUTH_CLAIM_NAMESPACE=$(ssm_get "/manual/budget/$ENV/auth/claim-namespace") || exit $?
 echo "AUTH_CLAIM_NAMESPACE=$AUTH_CLAIM_NAMESPACE"
 
-AUTH_DOMAIN_PREFIX=$(ssm_get_or_default "/manual/budget/$ENV/auth/domain-prefix" "$DEFAULT_AUTH_DOMAIN_PREFIX") || exit $?
+AUTH_DOMAIN_PREFIX=$(ssm_get "/manual/budget/$ENV/auth/domain-prefix") || exit $?
 echo "AUTH_DOMAIN_PREFIX=$AUTH_DOMAIN_PREFIX"
 
-AWS_LAMBDA_MEMORY_SIZE=$(ssm_get_or_default "/manual/budget/$ENV/lambda/memory-size" "") || exit $?
+AWS_LAMBDA_MEMORY_SIZE=$(ssm_get "/manual/budget/$ENV/lambda/memory-size") || exit $?
 echo "AWS_LAMBDA_MEMORY_SIZE=$AWS_LAMBDA_MEMORY_SIZE"
 
-AWS_LAMBDA_TIMEOUT_SECONDS=$(ssm_get_or_default "/manual/budget/$ENV/lambda/timeout-seconds" "") || exit $?
+AWS_LAMBDA_TIMEOUT_SECONDS=$(ssm_get "/manual/budget/$ENV/lambda/timeout-seconds") || exit $?
 echo "AWS_LAMBDA_TIMEOUT_SECONDS=$AWS_LAMBDA_TIMEOUT_SECONDS"
 
 echo "Switching to backend directory..."

--- a/infra-cdk/bin/app.ts
+++ b/infra-cdk/bin/app.ts
@@ -7,6 +7,7 @@ import { FrontendCdkStack } from "../lib/frontend-cdk-stack";
 import { requireEnv, requireIntEnv } from "../lib/require-env";
 
 const DEFAULT_AUTH_ALLOW_USER_REGISTRATION = "true";
+const DEFAULT_AUTH_CLAIM_NAMESPACE = "https://personal-budget-tracker";
 const DEFAULT_AWS_LAMBDA_MEMORY_SIZE = 512;
 const DEFAULT_AWS_LAMBDA_TIMEOUT_SECONDS = 30;
 
@@ -36,14 +37,20 @@ const lambdaProps = {
   ),
 };
 
-const authClaimNamespace = requireEnv("AUTH_CLAIM_NAMESPACE");
+const authClaimNamespace = requireEnv(
+  "AUTH_CLAIM_NAMESPACE",
+  DEFAULT_AUTH_CLAIM_NAMESPACE,
+);
 
 // Auth stack for Cognito User Pool
 const authStack = new AuthCdkStack(app, "AuthCdkStack", {
   ...lambdaProps,
   authClaimNamespace,
   callbackUrls: (process.env.AUTH_CALLBACK_URLS || undefined)?.split(","),
-  domainPrefix: requireEnv("AUTH_DOMAIN_PREFIX"),
+  domainPrefix: requireEnv(
+    "AUTH_DOMAIN_PREFIX",
+    `${nodeEnv.toLowerCase()}-budget-auth`,
+  ),
   env,
   logoutUrls: (process.env.AUTH_LOGOUT_URLS || undefined)?.split(","),
   retainUserPoolOnDestroy: nodeEnv === "production",

--- a/infra-cdk/lib/auth-cdk-stack.ts
+++ b/infra-cdk/lib/auth-cdk-stack.ts
@@ -19,19 +19,12 @@ import { defaultLambdaOptions } from "./default-lambda-options";
  * - Password: Traditional email + password authentication
  * - Passkey: WebAuthn/FIDO2 passwordless authentication
  *
- * Environment variables:
- * - NODE_ENV: Environment name (default: "test")
- * - AUTH_ALLOW_USER_REGISTRATION: Enable self sign-up ("true") or disable it ("false")
- * - AUTH_CALLBACK_URLS: Comma-separated callback URLs (optional, for local development)
- * - AUTH_CLAIM_NAMESPACE: Namespace for custom claims (required)
- * - AUTH_DOMAIN_PREFIX: Cognito domain prefix
- * - AUTH_LOGOUT_URLS: Comma-separated logout URLs (optional, for local development)
- *
  * Outputs:
  * - UserPoolId: The Cognito User Pool ID
  * - UserPoolClientId: The ID of the User Pool Client
  * - UserPoolDomainUrl: The full Cognito Hosted UI domain URL
  * - AuthIssuer: The OIDC issuer URL for JWT verification
+ * - AuthScope: The space-separated list of OAuth scopes
  *
  * Note on Callback/Logout URLs:
  * - Production: Set by AuthCallbackConfigStack after CloudFront deployment

--- a/infra-cdk/lib/auth-cdk-stack.ts
+++ b/infra-cdk/lib/auth-cdk-stack.ts
@@ -150,6 +150,12 @@ export class AuthCdkStack extends cdk.Stack {
       cognito.LambdaVersion.V2_0,
     );
 
+    const scopes = [
+      cognito.OAuthScope.OPENID, // Required for OIDC compliance and to get ID tokens
+      cognito.OAuthScope.PROFILE, // Grants access to user's name and other profile info
+      cognito.OAuthScope.EMAIL, // Grants access to user's email address
+    ];
+
     this.userPoolClient = new cognito.UserPoolClient(this, "UserPoolClient", {
       userPool: this.userPool,
 
@@ -173,12 +179,8 @@ export class AuthCdkStack extends cdk.Stack {
           implicitCodeGrant: false, // Deprecated, less secure
           clientCredentials: false, // Machine-to-machine only, not for users
         },
-        // OIDC scopes: openid (required), profile (name), email (email address)
-        scopes: [
-          cognito.OAuthScope.OPENID,
-          cognito.OAuthScope.PROFILE,
-          cognito.OAuthScope.EMAIL,
-        ],
+        // OIDC scopes
+        scopes,
         // Callback/logout URLs are optional - supports local development with localhost URLs
         // Production URLs are set by AuthCallbackConfigStack after CloudFront deployment
         // Where Cognito redirects after login
@@ -243,6 +245,11 @@ export class AuthCdkStack extends cdk.Stack {
     new cdk.CfnOutput(this, "AuthIssuer", {
       value: this.userPool.userPoolProviderUrl,
       description: "OIDC Issuer URL for JWT verification",
+    });
+
+    new cdk.CfnOutput(this, "AuthScope", {
+      value: scopes.map((scope) => scope.scopeName).join(" "),
+      description: "Space-separated list of OAuth scopes",
     });
   }
 }

--- a/infra-cdk/package-lock.json
+++ b/infra-cdk/package-lock.json
@@ -21,7 +21,7 @@
         "@types/aws-lambda": "^8.10.160",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.3",
-        "aws-cdk": "^2.1115.1",
+        "aws-cdk": "^2.1118.4",
         "esbuild": "^0.27.3",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
@@ -4201,9 +4201,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1115.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1115.1.tgz",
-      "integrity": "sha512-6vvSuHTq5FKClXIIXXvbmdYkzG+I6Ij80iXyg3Oky3+FZn+lYgYlM3RCS9gLWyJLhgcOhwB8jQpy6593OlbQcw==",
+      "version": "2.1118.4",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.4.tgz",
+      "integrity": "sha512-wJfRQdvb+FJ2cni059mYdmjhfwhMskP+PAB59BL9jhon+jYtjy8X3pbj3uzHgAOJwNhh6jGkP8xq36Cffccbbw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/infra-cdk/package.json
+++ b/infra-cdk/package.json
@@ -26,7 +26,7 @@
     "@types/aws-lambda": "^8.10.160",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.3",
-    "aws-cdk": "^2.1115.1",
+    "aws-cdk": "^2.1118.4",
     "esbuild": "^0.27.3",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
## context

Infrastructure parameter defaults were split between `deploy.sh` (bash variables) and `infra-cdk/bin/app.ts` (TypeScript constants), making it easy for the two sides to drift. OAuth scopes were overridable via SSM yet had to match the typed `scopes` array hardcoded in the auth stack — a second source of drift with no real benefit, since Cognito and the frontend must agree exactly.

## before

- Default values for infra parameters are duplicated between `deploy.sh` and CDK `app.ts`.
- OAuth scopes are read from an SSM parameter but must stay in sync with the typed scopes array in the auth stack.
- README mixes deploy-time and runtime SSM parameters in a single list.

## after

- All infra parameter defaults live in CDK `app.ts` and are applied via `requireEnv` fallback; `ssm_get` returns an empty string on missing params.
- OAuth scopes are defined once in the auth stack and exposed via a new `AuthScope` CfnOutput consumed by the frontend build.
- README groups SSM overrides into separate deploy-time and runtime sections.