### PR TITLE
add LangSmith tracing for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ aws ssm put-parameter --overwrite --type String \
 aws ssm put-parameter --overwrite --type String \
     --name "/manual/budget/production/app/chat-message-ttl-seconds" \
     --value "86400"
+
+# LangSmith tracing enabled
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/langsmith/tracing" \
+    --value "true"
+
+# LangSmith API key
+aws ssm put-parameter --overwrite --type SecureString \
+    --name "/manual/budget/production/langsmith/api-key" \
+    --value "<your-langsmith-api-key>"
+
+# LangSmith project name
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/langsmith/project" \
+    --value "<your-langsmith-project>"
 ```
 
 To override configuration for a specific environment, replace `production` in the parameter names with your target environment (e.g., `/manual/budget/staging/auth/domain-prefix`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,3 +39,8 @@ AWS_BEARER_TOKEN_BEDROCK=<your_bedrock_api_key> # Long-term API key
 # CHAT_HISTORY_MAX_MESSAGES=20
 # CHAT_MESSAGE_TTL_SECONDS=86400 # 24 hours in seconds
 WEBHOOK_BASE_URL="http://localhost:4000"
+
+# LangSmith Tracing
+# LANGSMITH_TRACING=false
+# LANGSMITH_API_KEY=<your-langsmith-api-key>
+# LANGSMITH_PROJECT=<your-langsmith-project>

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -42,3 +42,8 @@ AWS_BEARER_TOKEN_BEDROCK=bedrock-1234567890 # Long-term API key
 # CHAT_HISTORY_MAX_MESSAGES=20
 # CHAT_MESSAGE_TTL_SECONDS=86400 # 24 hours in seconds
 WEBHOOK_BASE_URL="http://localhost:4000"
+
+# LangSmith Tracing
+# LANGSMITH_TRACING=false
+# LANGSMITH_API_KEY=<your-langsmith-api-key>
+# LANGSMITH_PROJECT=<your-langsmith-project>

--- a/backend/src/dependencies.ts
+++ b/backend/src/dependencies.ts
@@ -134,6 +134,7 @@ export const resolveAssistantAgent = createSingleton(
         transactionRepository: resolveTransactionRepository(),
         transactionService: resolveTransactionService(),
       }),
+      "assistant-agent",
     ),
 );
 export const resolveCreateTransactionAgent = createSingleton(
@@ -146,6 +147,7 @@ export const resolveCreateTransactionAgent = createSingleton(
         transactionRepository: resolveTransactionRepository(),
         transactionService: resolveTransactionService(),
       }),
+      "create-transaction-agent",
     ),
 );
 

--- a/backend/src/lambdas/bootstrap.test.ts
+++ b/backend/src/lambdas/bootstrap.test.ts
@@ -138,6 +138,27 @@ describe("injectRuntimeEnv", () => {
     expect(processEnv.FEATURE_Z).toBe("value-z");
   });
 
+  it("should request SSM parameters with decryption enabled", async () => {
+    // Arrange
+    const processEnv: NodeJS.ProcessEnv = {
+      AWS_LAMBDA_FUNCTION_NAME: "web-lambda",
+      NODE_ENV: "test",
+    };
+    const bindings = [
+      { ssmPath: "/budget/test/feature-x", envVar: "FEATURE_X" },
+    ];
+
+    // SSM returns nothing; test only inspects outgoing command
+    sendMock.mockResolvedValue({ $metadata: {}, Parameters: [] });
+
+    // Act
+    await injectRuntimeEnv(processEnv, () => bindings);
+
+    // Assert
+    const command = sendMock.mock.calls[0][0] as GetParametersCommand;
+    expect(command.input.WithDecryption).toBe(true);
+  });
+
   // Validation failures
 
   it("should skip SSM fetch when not running on Lambda", async () => {

--- a/backend/src/lambdas/bootstrap.ts
+++ b/backend/src/lambdas/bootstrap.ts
@@ -114,7 +114,7 @@ export async function injectRuntimeEnv(
     }
 
     for (const parameter of response.InvalidParameters ?? []) {
-      console.log(`Skipped SSM parameter ${parameter}: likely not existent`);
+      console.log(`Skipped SSM parameter ${parameter}: likely nonexistent`);
     }
   }
 }

--- a/backend/src/lambdas/bootstrap.ts
+++ b/backend/src/lambdas/bootstrap.ts
@@ -39,6 +39,18 @@ const defaultSsmEnvBindings: SsmEnvBindingsFactory = (nodeEnv) => [
     ssmPath: `/manual/budget/${nodeEnv}/app/chat-message-ttl-seconds`,
     envVar: "CHAT_MESSAGE_TTL_SECONDS",
   },
+  {
+    ssmPath: `/manual/budget/${nodeEnv}/langsmith/tracing`,
+    envVar: "LANGSMITH_TRACING",
+  },
+  {
+    ssmPath: `/manual/budget/${nodeEnv}/langsmith/api-key`,
+    envVar: "LANGSMITH_API_KEY",
+  },
+  {
+    ssmPath: `/manual/budget/${nodeEnv}/langsmith/project`,
+    envVar: "LANGSMITH_PROJECT",
+  },
 ];
 
 export async function injectRuntimeEnv(
@@ -48,16 +60,23 @@ export async function injectRuntimeEnv(
   // AWS_LAMBDA_FUNCTION_NAME is set by the Lambda runtime, never in local dev.
   // Local dev loads its config from .env via dotenvx and must not hit SSM.
   if (!processEnv.AWS_LAMBDA_FUNCTION_NAME) {
+    console.warn(
+      "Skipping SSM parameter injection: AWS_LAMBDA_FUNCTION_NAME is not set",
+    );
     return;
   }
 
   const nodeEnv = processEnv.NODE_ENV;
   if (!nodeEnv) {
+    console.warn("Skipping SSM parameter injection: NODE_ENV is not set");
     return;
   }
 
   const bindings = getBindings(nodeEnv);
   if (bindings.length === 0) {
+    console.warn(
+      "Skipping SSM parameter injection: no parameter bindings configured",
+    );
     return;
   }
 
@@ -69,7 +88,7 @@ export async function injectRuntimeEnv(
 
     const ssmPaths = chunk.map((binding) => binding.ssmPath);
     const response = await ssmClient.send(
-      new GetParametersCommand({ Names: ssmPaths }),
+      new GetParametersCommand({ Names: ssmPaths, WithDecryption: true }),
     );
 
     for (const parameter of response.Parameters ?? []) {
@@ -92,6 +111,10 @@ export async function injectRuntimeEnv(
           `Skipped ${binding.envVar}: already set (SSM parameter ${parameter.Name} ignored)`,
         );
       }
+    }
+
+    for (const parameter of response.InvalidParameters ?? []) {
+      console.log(`Skipped SSM parameter ${parameter}: likely not existent`);
     }
   }
 }

--- a/backend/src/langchain/langchain-agent.test.ts
+++ b/backend/src/langchain/langchain-agent.test.ts
@@ -87,6 +87,44 @@ describe("LangChainAgent", () => {
       expect(passedConfig.context.userId).toBe("user-123");
     });
 
+    it("should forward runName to underlying agent when provided", async () => {
+      // Arrange
+      const namedAgent = new LangChainAgent(
+        mockAgent as unknown as ReactAgent,
+        "my-agent",
+      );
+      mockAgent.invoke.mockResolvedValue({
+        messages: [new AIMessage({ content: "Answer" })],
+      });
+
+      // Act
+      await namedAgent.invoke(state, config);
+
+      // Assert
+      const [, passedConfig] = mockAgent.invoke.mock.calls[0] as [
+        unknown,
+        { runName?: string },
+      ];
+      expect(passedConfig.runName).toBe("my-agent");
+    });
+
+    it("should not include runName in forwarded config when not provided", async () => {
+      // Arrange
+      mockAgent.invoke.mockResolvedValue({
+        messages: [new AIMessage({ content: "Answer" })],
+      });
+
+      // Act
+      await agent.invoke(state, config);
+
+      // Assert
+      const [, passedConfig] = mockAgent.invoke.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      expect(passedConfig).not.toHaveProperty("runName");
+    });
+
     it("should build agentTrace TEXT entry from LLM callback", async () => {
       // Arrange
       mockAgent.invoke.mockImplementation(async (_state, options) => {

--- a/backend/src/langchain/langchain-agent.ts
+++ b/backend/src/langchain/langchain-agent.ts
@@ -18,8 +18,11 @@ export class LangChainAgent<TContext extends Record<string, unknown>>
 {
   // ReactAgent is generic over its internal state shape, which is irrelevant
   // at this abstraction level — we only call invoke() and read response.messages.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor(private agent: ReactAgent<any>) {}
+  constructor(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private agent: ReactAgent<any>,
+    private runName?: string,
+  ) {}
 
   async invoke(
     state: { messages: readonly AgentMessage[] },
@@ -76,7 +79,11 @@ export class LangChainAgent<TContext extends Record<string, unknown>>
 
     const response = await this.agent.invoke(
       { ...state, messages },
-      { ...config, callbacks: callbackManager },
+      {
+        ...config,
+        callbacks: callbackManager,
+        ...(this.runName === undefined ? {} : { runName: this.runName }),
+      },
     );
 
     const answer = extractLastMessageText(response.messages)?.trim();

--- a/backend/src/langchain/tools/create-transaction-subagent.ts
+++ b/backend/src/langchain/tools/create-transaction-subagent.ts
@@ -39,11 +39,6 @@ export const createCreateTransactionSubagentTool = ({
     transactionService,
   });
 
-  // The agent's invoke accepts a narrower config type than LangChain's generic
-  // ToolRunnableConfig. The cast is safe: LangChain always propagates the full
-  // runnable config (including context) from the outer agent to tool functions.
-  type AgentInvokeConfig = Parameters<typeof agent.invoke>[1];
-
   return tool(
     async ({ text }, config) => {
       const response = await agent.invoke(
@@ -55,7 +50,16 @@ export const createCreateTransactionSubagentTool = ({
             },
           ],
         },
-        config as AgentInvokeConfig,
+        {
+          ...config,
+          // Explicit re-assignment: the inner agent requires a non-optional `context`,
+          // but ToolRunnableConfig types it as optional.
+          // Spread alone loses the required-ness.
+          // This line carries the loosely-typed context through
+          // so TS accepts the stricter target.
+          context: config.context,
+          runName: "create-transaction-subagent",
+        },
       );
 
       const answer = extractLastMessageText(response.messages)?.trim();

--- a/infra-cdk/lib/backend-cdk-stack.ts
+++ b/infra-cdk/lib/backend-cdk-stack.ts
@@ -287,9 +287,33 @@ export class BackendCdkStack extends cdk.Stack {
       resources: [appConfigParameterArn],
     });
 
+    // Decrypt SecureString SSM parameters using the AWS-managed `aws/ssm` key.
+    // Scoped via kms:ViaService so the grant is only usable through the SSM service.
+    const decryptSsmSecureStringPolicy = new iam.PolicyStatement({
+      actions: ["kms:Decrypt"],
+      resources: [
+        cdk.Arn.format(
+          {
+            service: "kms",
+            resource: "alias",
+            resourceName: "aws/ssm",
+          },
+          this,
+        ),
+      ],
+      conditions: {
+        StringEquals: {
+          "kms:ViaService": `ssm.${this.region}.amazonaws.com`,
+        },
+      },
+    });
+
     webFunction.addToRolePolicy(readAppConfigPolicy);
+    webFunction.addToRolePolicy(decryptSsmSecureStringPolicy);
     backgroundJobFunction.addToRolePolicy(readAppConfigPolicy);
+    backgroundJobFunction.addToRolePolicy(decryptSsmSecureStringPolicy);
     migrationFunction.addToRolePolicy(readAppConfigPolicy);
+    migrationFunction.addToRolePolicy(decryptSsmSecureStringPolicy);
 
     // Used by deploy.sh to invoke the migration Lambda after deploy.
     new cdk.CfnOutput(this, "MigrationFunctionName", {

--- a/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/design.md
+++ b/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/design.md
@@ -1,0 +1,142 @@
+# Design: Enable LangSmith Tracing
+
+## Context
+
+The backend runs two LangChain agents (`assistant-agent`, `create-transaction-agent`) plus a subagent tool (`create_transaction_subagent`) that reinvokes the create-transaction agent internally. All agent runs flow through a thin wrapper at [backend/src/langchain/langchain-agent.ts](backend/src/langchain/langchain-agent.ts) that calls `agent.invoke(state, config)` and collects results via LangChain callback manager.
+
+Runtime configuration is already split across two mechanisms:
+
+1. **Lambda environment variables** set at deploy time via CDK (in [infra-cdk/lib/backend-cdk-stack.ts](infra-cdk/lib/backend-cdk-stack.ts)) — used for values that are stable per deploy (table names, Cognito IDs, `NODE_ENV`).
+2. **SSM Parameter Store** read at Lambda cold start by [backend/src/lambdas/bootstrap.ts](backend/src/lambdas/bootstrap.ts) — used for tunables that should be changeable without a redeploy (Bedrock model ID, timeouts, chat history limits). Each Lambda entry point calls `injectRuntimeEnv(process.env)` before any handler logic; results are cached via `createSingleton` so warm starts skip SSM.
+
+The existing `bootstrap.ts` uses SSM `String` parameters only. LangSmith requires an API key — secret — so the pattern must be extended to support `SecureString` parameters.
+
+LangSmith auto-instruments LangChain runs via environment variables that its SDK reads on first use. Setting `LANGSMITH_TRACING=true` + `LANGSMITH_API_KEY=<key>` + `LANGSMITH_PROJECT=<name>` is sufficient to stream traces to the LangSmith backend. No code change in the agent layer is strictly required for basic tracing — only for run naming, which improves trace readability but is not a prerequisite.
+
+The `langsmith@0.5.20` package is already installed as a transitive dependency of `langchain`; no new direct dependencies are added.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship LangSmith tracing as an **opt-in** feature: fully off by default, on only when `LANGSMITH_TRACING=true` is set.
+- Configure independently per environment (dev, staging, prod) with no redeploy needed for secret or project changes.
+- Store the API key securely, reusing the existing SSM-driven bootstrap pattern.
+- Make agent and subagent runs visually distinguishable in the LangSmith UI.
+- Keep the implementation minimal — no metadata enrichment, no sampling, no CloudWatch alarms on volume.
+- Preserve current behavior exactly when tracing is disabled (zero SSM/IAM impact when params are absent).
+
+**Non-Goals:**
+
+- User-facing trace UI — that remains the responsibility of `ai-agent-trace`.
+- Automated tracing of tests. `.env.test` leaves the tracing env vars unset.
+- Budget/usage alerts for LangSmith free-tier overage. Monitor via LangSmith dashboard.
+- Sampling, tags, custom metadata (userId, sessionId). Defer until a concrete need emerges.
+- Generic observability framework that could support other trace backends (Langfuse, OpenTelemetry). Out of scope for this change.
+
+## Decisions
+
+### Decision 1: Env-var-driven tracing (no code-level SDK integration)
+
+**Choice**: Rely on LangSmith's env-var auto-wiring. Do not construct or pass tracer/callback objects from application code.
+
+**Rationale**: LangSmith's SDK reads `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT` on first LangChain run and installs its own callback handlers automatically. Application code stays clean, and "off" is truly off (no imports, no initialization, no runtime cost when disabled).
+
+**Alternatives considered**:
+
+- Pass a `Client` or tracer explicitly into `createAgent` config → more explicit but requires new imports even when disabled and complicates the wrapper. Rejected.
+- Conditionally install a callback handler via `BaseCallbackHandler` → same downsides, plus duplicates what the SDK does automatically.
+
+### Decision 2: Config stored in SSM, under `/manual/budget/${nodeEnv}/langsmith/*`
+
+**Choice**: All three LangSmith env vars come from SSM via the existing bootstrap:
+
+| Param path                                    | Type           | Populates           |
+| --------------------------------------------- | -------------- | ------------------- |
+| `/manual/budget/${nodeEnv}/langsmith/tracing` | `String`       | `LANGSMITH_TRACING` |
+| `/manual/budget/${nodeEnv}/langsmith/api-key` | `SecureString` | `LANGSMITH_API_KEY` |
+| `/manual/budget/${nodeEnv}/langsmith/project` | `String`       | `LANGSMITH_PROJECT` |
+
+**Rationale**: Matches the existing pattern. Consistent storage — all three values live in one prefix. Runtime-tunable — rotating the key or renaming the project does not require a redeploy. Missing params are silently skipped by `injectRuntimeEnv`, which implements the "optional" contract for free.
+
+**Alternatives considered**:
+
+- **Project name as CDK Lambda env (`LANGSMITH_PROJECT=budget-${nodeEnv}`)** — saves one SSM lookup but fragments config across two mechanisms and requires a redeploy to change. Rejected.
+- **AWS Secrets Manager for the API key** — purpose-built, supports rotation, but introduces a new read path and ~$0.40/mo/secret cost. Not justified for a single-key, manually-rotated use case at this project's scale. Rejected.
+- **Lambda env from CDK for the API key (plaintext)** — simplest, but the value appears in CloudFormation templates, Lambda env listings, and CloudTrail events. Weak security posture for a credential. Rejected.
+
+### Decision 3: Bootstrap extended to support SecureString decryption
+
+**Choice**: The single `GetParametersCommand` call in `bootstrap.ts` gains `WithDecryption: true`. The parameter list is a mix of `String` and `SecureString` paths; SSM returns decrypted values for `SecureString` items automatically when decryption is requested.
+
+**Rationale**: One code path, one SDK call, one IAM grant — simplest and already chunked to respect the 10-name-per-call SSM limit. No need to separate bindings by type.
+
+**Alternatives considered**:
+
+- Two separate fetches (strings vs secrets) → doubles cold-start SSM calls for no benefit.
+
+### Decision 4: IAM — `kms:Decrypt` on the AWS-managed `aws/ssm` key
+
+**Choice**: Grant each Lambda role `ssm:GetParameters` on `arn:aws:ssm:*:*:parameter/manual/budget/${nodeEnv}/*` (already granted today) **plus** `kms:Decrypt` on the default `alias/aws/ssm` KMS key.
+
+**Rationale**: SSM `SecureString` with the default AWS-managed key requires the caller to have `kms:Decrypt` permission on that key. Using the AWS-managed key avoids the need to provision and manage a customer-managed key. Scoped to the ssm alias to minimize blast radius.
+
+**Alternatives considered**:
+
+- Customer-managed KMS key (CMK) → more auditability but adds a resource and a rotation responsibility. Not warranted at this scale.
+
+### Decision 5: Run names via the `LangChainAgent` wrapper + inner subagent invoke
+
+**Choice**:
+
+- `LangChainAgent` constructor accepts optional `runName`; passed into `agent.invoke(state, { ...config, runName })`.
+- `dependencies.ts` sets `runName: "assistant-agent"` and `"create-transaction-agent"` at wrapper construction.
+- `create-transaction-subagent.ts` sets `runName: "create-transaction-agent"` on the inner `agent.invoke(..., config)`.
+
+**Rationale**: Two clear entry points. The LangSmith UI labels each root trace by the agent's logical name. The nested subagent run is also labeled, so a single trace tree reads as `assistant-agent → [tool: create_transaction_subagent] → create-transaction-agent → [tool: create_transaction]` instead of `LangGraph → [tool] → LangGraph`.
+
+**Alternatives considered**:
+
+- Pass `runName` per invocation from the caller → leaks infra concern into service code. Rejected.
+- Skip run names entirely → traces still work but are harder to filter/scan in the UI. Declined; run-name plumbing is trivial.
+
+### Decision 6: No sampling, no metadata, no alarms
+
+**Choice**: Trace 100% of runs. No custom tags, metadata, or per-run attributes beyond the default LangChain capture. No CloudWatch alarm on trace volume.
+
+**Rationale**: YAGNI. Current expected traffic is well under the LangSmith free tier (5k traces/mo). Adding sampling or metadata now creates surface area that is not required. If usage grows past the cap or debugging needs emerge, these are single-line additions later — in the SDK config (sampling rate env var) or in the wrapper (`config.metadata`/`config.tags`).
+
+## Risks / Trade-offs
+
+- **Vendor egress / data sensitivity** → Trace payloads include prompts and tool arguments, which may carry user financial details. Mitigation: feature is opt-in per environment; prod can remain off until the data-handling risk is reviewed. Constitution's "Vendor Independence" principle is preserved — tracing is env-gated and app code has zero vendor-specific imports in the hot path.
+- **LangSmith outage or SDK bug blocks requests** → LangSmith calls are designed to be fire-and-forget by the SDK, but a misbehaving SDK version could introduce latency. Mitigation: keep tracing off in prod initially; observe dev/staging first. Disabling is instant (unset `LANGSMITH_TRACING` in SSM).
+- **API key leak** → SecureString + `kms:Decrypt` grant limits exposure. Key never appears in CloudFormation or Lambda env inspection via console. Mitigation: rotate by updating the SSM parameter; next Lambda cold start picks up the new value.
+- **Cold-start overhead** → One extra SSM `GetParameters` call already exists; adding three more param paths does not add a round trip (still one call, chunked at 10). Decryption adds single-digit ms. Acceptable.
+- **Test pollution** → If a developer accidentally sets `LANGSMITH_TRACING=true` in their shell while running tests, integration tests would send traces to whichever project is configured. Mitigation: document in `.env.test.example` that tracing env vars must remain unset; CI does not set them.
+- **Free-tier overage surprise** → 5k traces/mo can be exceeded by heavy bot usage. Mitigation out of scope (Q5 decision). If it becomes an issue, enable `LANGSMITH_TRACING_SAMPLING_RATE` via SSM or toggle off.
+
+## Migration Plan
+
+1. Land code + infra changes with SSM params absent in all environments → tracing stays off; zero behavior change.
+2. In **dev** (developer's local `.env`): add all three env vars manually. Validate traces appear in LangSmith under `budget-dev`. Exercise assistant + create-transaction flows.
+3. Provision SSM params in **staging**:
+   - `/manual/budget/staging/langsmith/tracing` = `true`
+   - `/manual/budget/staging/langsmith/project` = `budget-staging`
+   - `/manual/budget/staging/langsmith/api-key` (SecureString) = `<key>`
+4. Redeploy staging → cold start picks up params. Validate traces.
+5. Decide whether to enable in **prod**. Same SSM provisioning pattern.
+6. **Rollback**: delete (or set `LANGSMITH_TRACING` to `false`) on the SSM parameter; next cold start disables tracing. No redeploy required.
+
+## Open Questions
+
+None. Remaining open items (sampling, metadata, alarms) are explicitly deferred by Decision 6.
+
+## Constitution Compliance
+
+- **Vendor Independence** — Feature is optional and env-gated. Backend code has no hard dependency on LangSmith-specific APIs; the SDK wires itself via env vars. Backend remains deployable to any Node.js runtime; disabling the feature requires only unsetting env vars.
+- **Backend Layer Structure** — Changes are confined to the infrastructure wrapper layer (`LangChainAgent`) and bootstrap. No impact on services, repositories, or GraphQL resolvers.
+- **Result Pattern** — Trace delivery is internal to the LangSmith SDK (fire-and-forget). No new service or external-integration return surface introduced that would require the Result pattern.
+- **Input Validation** — No new user inputs. New env vars are operational configuration, consistent with existing `requireEnv`/bootstrap conventions; absence is tolerated (tracing off).
+- **TypeScript Code Generation** — New wrapper parameter is a named optional field; no `any` casts, no non-null assertions. Enum-free.
+- **Code Quality Validation** — Bootstrap changes are covered by the existing `bootstrap.test.ts` suite (extended with cases for the new bindings). `LangChainAgent` `runName` plumbing is covered by existing agent tests.
+- **Test Strategy** — No new test directories; any new tests co-located next to source. Tracing itself is not tested end-to-end (external SaaS side effects out of scope for the test suite).

--- a/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/proposal.md
+++ b/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/proposal.md
@@ -1,0 +1,54 @@
+# Enable LangSmith Tracing
+
+## Why
+
+The existing `ai-agent-trace` capability surfaces per-request traces in-app (TEXT, TOOL_CALL, TOOL_RESULT messages for the current response). This is useful for inspecting a single interaction but is ephemeral, per-user, and lacks developer-focused context: latency breakdowns, token and cost accounting, cross-request search, historical retention, prompt/tool-argument diffs across runs, and side-by-side comparison.
+
+LangSmith complements the existing trace UI by adding persistent, developer-side observability across all runs. It captures the same logical information plus model metadata, tracks performance over time, and enables regression analysis when prompts, models, or agent graphs change. The `langsmith` package is already a transitive dependency of the installed `langchain` — enabling it is primarily a matter of configuration (`docs.langchain.com/oss/javascript/langchain/observability`).
+
+The feature must be **optional** (safe to ship with tracing off, and safe to run in environments that do not want vendor data egress) and **configurable per environment** (dev/staging/prod tuned independently, without a redeploy for secret or project-name changes).
+
+## What Changes
+
+- Introduce env-var-driven LangSmith tracing: `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`. Tracing is off unless `LANGSMITH_TRACING=true` is set.
+- Extend the existing SSM runtime-config bootstrap (`backend/src/lambdas/bootstrap.ts`) with LangSmith bindings under `/manual/budget/${nodeEnv}/langsmith/*`. API key stored as SSM `SecureString`; other values as plaintext `String`.
+- Grant the three Lambda roles (web, background-job, migration) permissions to read the new SSM params with decryption (`kms:Decrypt` on the default `aws/ssm` key, `ssm:GetParameters` with `WithDecryption`).
+- Attach LangChain run names to the two agents: `assistant-agent` and `create-transaction-agent`. The `LangChainAgent` wrapper accepts an optional `runName` passed into `agent.invoke` config; the subagent tool sets `runName` on the inner `agent.invoke` so the nested create-transaction run is distinguishable in traces.
+- Document the new env vars in `backend/.env.example`; leave them empty in `backend/.env.test.example` so tests remain untraced by default.
+- No sampling, no CloudWatch alarm, no per-run metadata enrichment (YAGNI — add later if volume or debugging needs justify it).
+
+## Capabilities
+
+### New Capabilities
+
+- `ai-agent-observability`: Backend observability for AI agent executions (analogous to logs and metrics, but in the traces pillar). Covers env-var-driven LangSmith tracing, per-environment configuration, and run-name conventions that distinguish agents and subagents. Distinct from `ai-agent-trace`, which is a user-facing UI for inspecting the current response.
+
+### Modified Capabilities
+
+None. `ai-agent-trace` covers the user-facing in-app trace panel and is unrelated to developer-side observability.
+
+## Impact
+
+- **Code**:
+  - `backend/src/lambdas/bootstrap.ts` — extend SSM bindings; add decryption support for SecureString params.
+  - `backend/src/langchain/langchain-agent.ts` — accept optional `runName` at construction; pass into `agent.invoke` config.
+  - `backend/src/dependencies.ts` — name the two wrapped agents at construction.
+  - `backend/src/langchain/tools/create-transaction-subagent.ts` — set `runName` on inner `agent.invoke`.
+- **Infra**:
+  - `infra-cdk/lib/backend-cdk-stack.ts` — IAM policy expansion for SSM decryption on the LangSmith parameter path; no new stacks, no new resources beyond IAM statements.
+- **Config**:
+  - `backend/.env.example`, `backend/.env.test.example` — document new vars (unset by default).
+- **Operational**:
+  - One extra (optional) `GetParameters` call on Lambda cold start; cached for the duration of the container. Negligible latency impact; zero impact when all params are absent.
+- **Runtime behavior**:
+  - With `LANGSMITH_TRACING` unset → identical behavior to today.
+  - With `LANGSMITH_TRACING=true` + valid `LANGSMITH_API_KEY` → agent runs stream to LangSmith asynchronously; responses are not gated on trace delivery (fire-and-forget).
+- **Security**: API key never logged; stored encrypted in SSM; decrypted only inside Lambda at cold start.
+
+## Constitution Compliance
+
+- **Vendor Independence**: LangSmith is a third-party SaaS. Compliance preserved because the feature is optional, env-gated, and introduces zero code coupling beyond env vars that LangSmith's SDK reads directly. Disabling it requires no code change. Backend deployability to any Node.js runtime is unaffected.
+- **Backend Layer Structure**: Tracing hooks into the langchain infrastructure layer (the agent wrapper). Service and repository layers are untouched.
+- **Result Pattern**: Trace delivery is fire-and-forget inside the LangChain/LangSmith SDK; no new service/external-integration return paths are introduced that would require the Result pattern.
+- **Input Validation**: No new user inputs. Env vars are treated as operational configuration, consistent with existing `requireEnv` patterns.
+- **Test Strategy**: Bootstrap changes are unit-tested alongside existing `bootstrap.test.ts` coverage. The `LangChainAgent` `runName` plumbing is covered by existing agent tests (no new test file needed). No integration-level tracing tests — tracing is off in `.env.test`.

--- a/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/specs/ai-agent-observability/spec.md
+++ b/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/specs/ai-agent-observability/spec.md
@@ -1,0 +1,87 @@
+# AI Agent Observability Specification
+
+## ADDED Requirements
+
+### Requirement: Optional Tracing
+
+The system SHALL support streaming AI agent execution traces to an external observability platform (LangSmith). Tracing SHALL be disabled by default. Trace data SHALL leave the system only when tracing is explicitly enabled for the running environment.
+
+#### Scenario: Tracing disabled by default
+
+- **WHEN** an environment is deployed without any observability configuration
+- **THEN** no trace data is sent to the external platform and agent behavior is unchanged
+
+#### Scenario: Tracing enabled for an environment
+
+- **WHEN** observability is explicitly enabled for the environment and valid credentials are provided
+- **THEN** each agent invocation streams its run (prompts, tool calls, tool results, model outputs) to the external platform asynchronously, without delaying the response to the caller
+
+### Requirement: Per-Environment Configuration
+
+The system SHALL allow each environment (development, staging, production) to enable, disable, and configure observability independently of the others. The observability project name SHALL be set per environment so traces from different environments are not mixed.
+
+#### Scenario: Observability enabled in one environment but not another
+
+- **WHEN** observability is enabled in staging and disabled in production
+- **THEN** staging runs stream to the observability platform and production runs do not
+
+#### Scenario: Traces are grouped by environment
+
+- **WHEN** observability is enabled in two environments with different project names
+- **THEN** traces from each environment appear under their own project in the observability platform
+
+### Requirement: Configuration Changes Without Redeploy
+
+The system SHALL allow operators to toggle observability on or off, rotate credentials, and change the project name for a given environment without rebuilding or redeploying the application.
+
+#### Scenario: Toggling observability off
+
+- **WHEN** an operator disables observability for an environment
+- **THEN** subsequent agent runs in that environment stop sending traces without requiring a redeploy
+
+#### Scenario: Rotating the API credential
+
+- **WHEN** an operator replaces the observability API credential
+- **THEN** subsequent agent runs use the new credential without requiring a redeploy
+
+### Requirement: Secure Credential Storage
+
+The system SHALL store the observability API credential such that it never appears in plaintext in deployment artifacts, version control, or runtime environment listings, and SHALL be accessible only to authorized components of the running application.
+
+#### Scenario: Credential not visible in deployment artifacts
+
+- **WHEN** deployment artifacts (infrastructure templates, release bundles) are inspected
+- **THEN** the API credential value is not present in plaintext
+
+#### Scenario: Credential not exposed via runtime inspection
+
+- **WHEN** someone with read access to deployment metadata inspects the environment configuration
+- **THEN** the API credential value is not visible in plaintext
+
+### Requirement: Agent and Subagent Distinguishability
+
+The system SHALL label each agent run in the observability platform with a stable, human-readable name identifying which agent produced the run. Runs produced by a subagent invoked as a tool from another agent SHALL be labeled with the subagent's own identity, not a generic or inherited label.
+
+#### Scenario: Distinguishing the assistant agent from the create-transaction agent
+
+- **WHEN** both agents produce runs within the same time window
+- **THEN** each run is labeled with the agent's name and is filterable by name in the observability platform
+
+#### Scenario: Subagent run is separately identified
+
+- **WHEN** the assistant agent invokes the create-transaction subagent as a tool
+- **THEN** the resulting trace shows a nested run labeled with the create-transaction agent's name, distinct from the parent assistant run
+
+### Requirement: Graceful Absence of Configuration
+
+The system SHALL operate normally when observability configuration is partially or entirely absent. Missing or invalid configuration SHALL NOT cause agent invocations to fail.
+
+#### Scenario: Observability config entirely absent
+
+- **WHEN** no observability configuration is provided for an environment
+- **THEN** agents run normally and no errors are raised related to observability
+
+#### Scenario: Observability config partially present
+
+- **WHEN** some but not all observability configuration values are provided (e.g., project name without credential)
+- **THEN** tracing stays off and agents run normally without surfacing configuration errors to end users

--- a/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/tasks.md
+++ b/openspec/changes/archive/2026-04-21-enable-langsmith-tracing/tasks.md
@@ -1,0 +1,55 @@
+# Tasks: Enable LangSmith Tracing
+
+## 1. Bootstrap — SecureString support and LangSmith bindings
+
+- [x] 1.1 In [backend/src/lambdas/bootstrap.test.ts](backend/src/lambdas/bootstrap.test.ts), add failing tests covering: (a) `GetParametersCommand` is invoked with `WithDecryption: true`, (b) the new LangSmith bindings (`tracing`, `api-key`, `project`) populate the corresponding env vars, (c) absent/partial LangSmith params leave env vars unset and do not throw
+- [x] 1.2 Extend [backend/src/lambdas/bootstrap.ts](backend/src/lambdas/bootstrap.ts) `defaultSsmEnvBindings` with the three LangSmith entries under `/manual/budget/${nodeEnv}/langsmith/*`
+- [x] 1.3 Pass `WithDecryption: true` in the `GetParametersCommand` call so `SecureString` params are returned decrypted
+- [x] 1.4 Verify test `1.1` now passes and existing bootstrap tests still pass
+
+## 2. LangChainAgent — runName plumbing
+
+- [x] 2.1 In [backend/src/langchain/langchain-agent.test.ts](backend/src/langchain/langchain-agent.test.ts), add a failing test asserting that when a `runName` is supplied to the wrapper, the value is forwarded in the `config` argument to `agent.invoke`
+- [x] 2.2 Add a failing test asserting that when no `runName` is supplied, the `config` forwarded to `agent.invoke` does not contain a `runName` field
+- [x] 2.3 Extend [backend/src/langchain/langchain-agent.ts](backend/src/langchain/langchain-agent.ts) `LangChainAgent` constructor to accept an optional `runName: string` and forward it in `agent.invoke(state, { ...config, runName })`
+- [x] 2.4 Verify tests `2.1` and `2.2` pass
+
+## 3. Dependencies wiring — agent names
+
+- [x] 3.1 In [backend/src/dependencies.ts](backend/src/dependencies.ts), set `runName: "assistant-agent"` when constructing the wrapped assistant agent
+- [x] 3.2 In the same file, set `runName: "create-transaction-agent"` when constructing the wrapped create-transaction agent
+
+## 4. Subagent tool — inner run name
+
+- [x] 4.1 In [backend/src/langchain/tools/create-transaction-subagent.test.ts](backend/src/langchain/tools/create-transaction-subagent.test.ts), add a failing test asserting the inner `agent.invoke` receives `runName: "create-transaction-agent"` in its config
+- [x] 4.2 Update [backend/src/langchain/tools/create-transaction-subagent.ts](backend/src/langchain/tools/create-transaction-subagent.ts) to pass `runName: "create-transaction-agent"` into the inner `agent.invoke(..., config)`
+- [x] 4.3 Verify test `4.1` passes
+
+## 5. Infrastructure — IAM for SecureString decryption
+
+- [x] 5.1 In [infra-cdk/lib/backend-cdk-stack.ts](infra-cdk/lib/backend-cdk-stack.ts), grant each of the three Lambda roles (web, background-job, migration) `kms:Decrypt` on the AWS-managed `alias/aws/ssm` key
+- [x] 5.2 Confirm the existing `ssm:GetParameters` grant covers the `/manual/budget/${nodeEnv}/langsmith/*` path (wildcard path already in place); expand if necessary
+- [x] 5.3 Run `npm run test` from `infra-cdk/` to validate CDK snapshot tests still pass (update snapshots if IAM changes are the only diff)
+
+## 6. Documentation — env examples
+
+- [x] 6.1 In [backend/.env.example](backend/.env.example), document the three LangSmith env vars as commented-out placeholders with a short inline note that tracing is opt-in
+- [x] 6.2 In [backend/.env.test.example](backend/.env.test.example), include the same commented-out placeholders and note that tests MUST NOT enable tracing
+
+## 7. Validation
+
+- [x] 7.1 From `backend/`: run `npm test` (unit) and confirm green
+- [x] 7.2 From `backend/`: run `npm run typecheck` and `npm run format`, fix any issues
+- [x] 7.3 From `infra-cdk/`: run `npm run typecheck` and `npm test`
+- [x] 7.4 Manual smoke test (dev): set the three env vars locally with a real LangSmith dev key, trigger an assistant chat and a create-transaction flow, confirm traces appear in LangSmith under `budget-dev` with run names `assistant-agent` and `create-transaction-agent` (including nested subagent)
+- [x] 7.5 Manual smoke test (tracing off): unset all three env vars, repeat the flows, confirm no trace data is sent and no errors are raised
+
+## Constitution Compliance
+
+- **Vendor Independence** — Tests in `1.1`, `2.1`, `4.1` validate that behavior is indistinguishable (aside from the forwarded `runName`/env-var side effect) when tracing is disabled. Smoke test `7.5` confirms absence of tracing is a first-class state.
+- **Backend Layer Structure** — All code changes live in the infrastructure wrapper (`LangChainAgent`), bootstrap, dependency wiring, and the subagent tool. No service or repository changes.
+- **Result Pattern** — Not applicable; no new public service or external-integration methods introduced.
+- **Input Validation** — Not applicable; only operational configuration, consistent with existing `requireEnv`/bootstrap patterns (missing config is tolerated).
+- **Test Strategy** — TDD applied: each code-changing task group starts with failing tests before the implementation step. Tests co-located with source per constitution rule. No new test directories.
+- **TypeScript Code Generation** — New `runName` parameter is a named optional field. No `any` casts, no non-null assertions introduced by these tasks.
+- **Code Quality Validation** — Task group `7` runs the full validation pipeline (test, typecheck, lint) from each affected package root.

--- a/openspec/specs/ai-agent-observability/spec.md
+++ b/openspec/specs/ai-agent-observability/spec.md
@@ -1,0 +1,91 @@
+# AI Agent Observability Specification
+
+## Purpose
+
+Provides external observability for AI agent execution by streaming agent runs (prompts, tool calls, tool results, model outputs) to an observability platform (LangSmith), enabling operators and developers to inspect, debug, and monitor agent behavior across environments without affecting end-user latency or requiring redeploys to change configuration.
+
+## Requirements
+
+### Requirement: Optional Tracing
+
+The system SHALL support streaming AI agent execution traces to an external observability platform (LangSmith). Tracing SHALL be disabled by default. Trace data SHALL leave the system only when tracing is explicitly enabled for the running environment.
+
+#### Scenario: Tracing disabled by default
+
+- **WHEN** an environment is deployed without any observability configuration
+- **THEN** no trace data is sent to the external platform and agent behavior is unchanged
+
+#### Scenario: Tracing enabled for an environment
+
+- **WHEN** observability is explicitly enabled for the environment and valid credentials are provided
+- **THEN** each agent invocation streams its run (prompts, tool calls, tool results, model outputs) to the external platform asynchronously, without delaying the response to the caller
+
+### Requirement: Per-Environment Configuration
+
+The system SHALL allow each environment (development, staging, production) to enable, disable, and configure observability independently of the others. The observability project name SHALL be set per environment so traces from different environments are not mixed.
+
+#### Scenario: Observability enabled in one environment but not another
+
+- **WHEN** observability is enabled in staging and disabled in production
+- **THEN** staging runs stream to the observability platform and production runs do not
+
+#### Scenario: Traces are grouped by environment
+
+- **WHEN** observability is enabled in two environments with different project names
+- **THEN** traces from each environment appear under their own project in the observability platform
+
+### Requirement: Configuration Changes Without Redeploy
+
+The system SHALL allow operators to toggle observability on or off, rotate credentials, and change the project name for a given environment without rebuilding or redeploying the application.
+
+#### Scenario: Toggling observability off
+
+- **WHEN** an operator disables observability for an environment
+- **THEN** subsequent agent runs in that environment stop sending traces without requiring a redeploy
+
+#### Scenario: Rotating the API credential
+
+- **WHEN** an operator replaces the observability API credential
+- **THEN** subsequent agent runs use the new credential without requiring a redeploy
+
+### Requirement: Secure Credential Storage
+
+The system SHALL store the observability API credential such that it never appears in plaintext in deployment artifacts, version control, or runtime environment listings, and SHALL be accessible only to authorized components of the running application.
+
+#### Scenario: Credential not visible in deployment artifacts
+
+- **WHEN** deployment artifacts (infrastructure templates, release bundles) are inspected
+- **THEN** the API credential value is not present in plaintext
+
+#### Scenario: Credential not exposed via runtime inspection
+
+- **WHEN** someone with read access to deployment metadata inspects the environment configuration
+- **THEN** the API credential value is not visible in plaintext
+
+### Requirement: Agent and Subagent Distinguishability
+
+The system SHALL label each agent run in the observability platform with a stable, human-readable name identifying which agent produced the run. Runs produced by a subagent invoked as a tool from another agent SHALL be labeled with the subagent's own identity, not a generic or inherited label.
+
+#### Scenario: Distinguishing the assistant agent from the create-transaction agent
+
+- **WHEN** both agents produce runs within the same time window
+- **THEN** each run is labeled with the agent's name and is filterable by name in the observability platform
+
+#### Scenario: Subagent run is separately identified
+
+- **WHEN** the assistant agent invokes the create-transaction subagent as a tool
+- **THEN** the resulting trace shows a nested run labeled with the create-transaction agent's name, distinct from the parent assistant run
+
+### Requirement: Graceful Absence of Configuration
+
+The system SHALL operate normally when observability configuration is partially or entirely absent. Missing or invalid configuration SHALL NOT cause agent invocations to fail.
+
+#### Scenario: Observability config entirely absent
+
+- **WHEN** no observability configuration is provided for an environment
+- **THEN** agents run normally and no errors are raised related to observability
+
+#### Scenario: Observability config partially present
+
+- **WHEN** some but not all observability configuration values are provided (e.g., project name without credential)
+- **THEN** tracing stays off and agents run normally without surfacing configuration errors to end users


### PR DESCRIPTION
## context

Developers have no way to inspect past AI agent runs — the in-app trace shows only the last one.

## before

- Only the last agent run is visible

## after

- Every agent run is available in LangSmith
- Tracing can be turned on or off per environment