### PR TITLE
refactor transaction update

### DIFF
--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -420,7 +420,7 @@ describe("transaction model", () => {
 
     // Happy path
 
-    it("should set amount and preserve the rest", () => {
+    it("should set amount", () => {
       // Arrange
       const existing = fakeTransaction({ amount: 10 });
 
@@ -573,11 +573,7 @@ describe("transaction model", () => {
       });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { amount: 1 },
-        fixedDeps,
-      );
+      const result = updateTransactionModel(existing, { amount: 1 }, fixedDeps);
 
       // Assert
       expect(result.id).toBe("id-1");

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -243,9 +243,7 @@ describe("transaction model", () => {
           fakeCreateTransactionInput({ userId, account }),
           fixedDeps,
         ),
-      ).toThrow(
-        new ModelError("Cannot create transaction for archived account"),
-      );
+      ).toThrow(new ModelError("Account must not be archived"));
     });
 
     it("should reject zero amount", () => {
@@ -255,7 +253,7 @@ describe("transaction model", () => {
           fakeCreateTransactionInput({ amount: 0 }),
           fixedDeps,
         ),
-      ).toThrow(new ModelError("Transaction amount must be positive"));
+      ).toThrow(new ModelError("Amount must be positive"));
     });
 
     it("should reject negative amount", () => {
@@ -265,7 +263,7 @@ describe("transaction model", () => {
           fakeCreateTransactionInput({ amount: -5 }),
           fixedDeps,
         ),
-      ).toThrow(new ModelError("Transaction amount must be positive"));
+      ).toThrow(new ModelError("Amount must be positive"));
     });
 
     it("should reject when category belongs to different user", () => {
@@ -300,9 +298,7 @@ describe("transaction model", () => {
           fakeCreateTransactionInput({ userId, category }),
           fixedDeps,
         ),
-      ).toThrow(
-        new ModelError("Cannot create transaction for archived category"),
-      );
+      ).toThrow(new ModelError("Category must not be archived"));
     });
 
     it("should reject INCOME category on EXPENSE transaction", () => {
@@ -624,7 +620,7 @@ describe("transaction model", () => {
       // Act & Assert
       expect(() =>
         updateTransactionModel(existing, { amount: 0 }, fixedDeps),
-      ).toThrow(new ModelError("Transaction amount must be positive"));
+      ).toThrow(new ModelError("Amount must be positive"));
     });
 
     it("should reject negative amount", () => {
@@ -634,7 +630,7 @@ describe("transaction model", () => {
       // Act & Assert
       expect(() =>
         updateTransactionModel(existing, { amount: -1 }, fixedDeps),
-      ).toThrow(new ModelError("Transaction amount must be positive"));
+      ).toThrow(new ModelError("Amount must be positive"));
     });
 
     it("should reject account belonging to different user", () => {
@@ -657,9 +653,7 @@ describe("transaction model", () => {
       // Act & Assert
       expect(() =>
         updateTransactionModel(existing, { account }, fixedDeps),
-      ).toThrow(
-        new ModelError("Cannot create transaction for archived account"),
-      );
+      ).toThrow(new ModelError("Account must not be archived"));
     });
 
     it("should reject category belonging to different user", () => {
@@ -689,9 +683,7 @@ describe("transaction model", () => {
       // Act & Assert
       expect(() =>
         updateTransactionModel(existing, { category }, fixedDeps),
-      ).toThrow(
-        new ModelError("Cannot create transaction for archived category"),
-      );
+      ).toThrow(new ModelError("Category must not be archived"));
     });
 
     it("should reject INCOME category on EXPENSE transaction", () => {

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -14,6 +14,7 @@ import {
   TransactionType,
   createTransactionModel,
   getSignedAmount,
+  updateTransactionModel,
 } from "./transaction";
 
 describe("transaction model", () => {
@@ -405,6 +406,379 @@ describe("transaction model", () => {
             type: TransactionType.EXPENSE,
             transferId: faker.string.uuid(),
           }),
+          fixedDeps,
+        ),
+      ).toThrow(
+        new ModelError("Only transfer transactions can include transferId"),
+      );
+    });
+  });
+
+  describe("updateTransactionModel", () => {
+    const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
+    const fixedDeps = { clock: fixedClock };
+
+    // Happy path
+
+    it("should set amount and preserve the rest", () => {
+      // Arrange
+      const existing = fakeTransaction({ amount: 10 });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { amount: 20 },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.amount).toEqual(20);
+    });
+
+    it("should set account and derive currency from new account", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({ userId, currency: "USD" });
+      const newAccount = fakeAccount({ userId, currency: "EUR" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { account: newAccount },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.accountId).toBe(newAccount.id);
+      expect(result.currency).toBe("EUR");
+    });
+
+    it("should keep account and currency when input is undefined", () => {
+      // Arrange
+      const existing = fakeTransaction({ currency: "GBP" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { account: undefined, amount: 1 },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.accountId).toBe(existing.accountId);
+      expect(result.currency).toBe("GBP");
+    });
+
+    it("should set category", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({ userId, categoryId: undefined });
+      const newCategory = fakeCategory({ userId, type: CategoryType.EXPENSE });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { category: newCategory },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.categoryId).toBe(newCategory.id);
+    });
+
+    it("should clear category when input is null", () => {
+      // Arrange
+      const existing = fakeTransaction({ categoryId: faker.string.uuid() });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { category: null },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.categoryId).toBeUndefined();
+    });
+
+    it("should keep category when input is undefined", () => {
+      // Arrange
+      const existing = fakeTransaction({ categoryId: "existing-category" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { category: undefined, amount: 1 },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.categoryId).toBe("existing-category");
+    });
+
+    it("should trim description", () => {
+      // Arrange
+      const existing = fakeTransaction({ description: "old" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { description: "  new  " },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.description).toBe("new");
+    });
+
+    it("should clear description when input is null", () => {
+      // Arrange
+      const existing = fakeTransaction({ description: "old" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { description: null },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.description).toBeUndefined();
+    });
+
+    it("should keep description when input is undefined", () => {
+      // Arrange
+      const existing = fakeTransaction({ description: "keep me" });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { description: undefined, amount: 1 },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.description).toBe("keep me");
+    });
+
+    it("should preserve id, userId, transferId, isArchived, createdAt", () => {
+      // Arrange
+      const existing = fakeTransaction({
+        id: "id-1",
+        userId: "user-1",
+        type: TransactionType.TRANSFER_OUT,
+        categoryId: undefined,
+        transferId: "transfer-1",
+        createdAt: "1999-01-01T00:00:00.000Z",
+      });
+
+      // Act
+      const result = updateTransactionModel(
+        existing,
+        { amount: 1 },
+        fixedDeps,
+      );
+
+      // Assert
+      expect(result.id).toBe("id-1");
+      expect(result.userId).toBe("user-1");
+      expect(result.transferId).toBe("transfer-1");
+      expect(result.isArchived).toBe(false);
+      expect(result.createdAt).toBe("1999-01-01T00:00:00.000Z");
+    });
+
+    it("should set updatedAt", () => {
+      // Arrange
+      const existing = fakeTransaction();
+
+      // Act
+      const result = updateTransactionModel(existing, { amount: 1 }, fixedDeps);
+
+      // Assert
+      expect(result.updatedAt).toBe("2000-01-02T10:11:12.000Z");
+    });
+
+    it("should use default clock when options omitted", () => {
+      // Arrange
+      const existing = fakeTransaction();
+
+      // Act
+      const result = updateTransactionModel(existing, { amount: 1 });
+
+      // Assert
+      expect(result.updatedAt).toBeDefined();
+    });
+
+    // Validation failures
+
+    it("should reject updating archived transaction", () => {
+      // Arrange
+      const existing = fakeTransaction({ isArchived: true });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { amount: 5 }, fixedDeps),
+      ).toThrow(new ModelError("Cannot update archived transaction"));
+    });
+
+    it("should reject zero amount", () => {
+      // Arrange
+      const existing = fakeTransaction();
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { amount: 0 }, fixedDeps),
+      ).toThrow(new ModelError("Transaction amount must be positive"));
+    });
+
+    it("should reject negative amount", () => {
+      // Arrange
+      const existing = fakeTransaction();
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { amount: -1 }, fixedDeps),
+      ).toThrow(new ModelError("Transaction amount must be positive"));
+    });
+
+    it("should reject account belonging to different user", () => {
+      // Arrange
+      const existing = fakeTransaction({ userId: "user-a" });
+      const account = fakeAccount({ userId: "user-b" });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { account }, fixedDeps),
+      ).toThrow(new ModelError("Account does not belong to user"));
+    });
+
+    it("should reject archived account", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({ userId });
+      const account = fakeAccount({ userId, isArchived: true });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { account }, fixedDeps),
+      ).toThrow(
+        new ModelError("Cannot create transaction for archived account"),
+      );
+    });
+
+    it("should reject category belonging to different user", () => {
+      // Arrange
+      const existing = fakeTransaction({ userId: "user-a" });
+      const category = fakeCategory({
+        userId: "user-b",
+        type: CategoryType.EXPENSE,
+      });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { category }, fixedDeps),
+      ).toThrow(new ModelError("Category does not belong to user"));
+    });
+
+    it("should reject archived category", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({ userId });
+      const category = fakeCategory({
+        userId,
+        type: CategoryType.EXPENSE,
+        isArchived: true,
+      });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { category }, fixedDeps),
+      ).toThrow(
+        new ModelError("Cannot create transaction for archived category"),
+      );
+    });
+
+    it("should reject INCOME category on EXPENSE transaction", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.EXPENSE,
+      });
+      const category = fakeCategory({ userId, type: CategoryType.INCOME });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { category }, fixedDeps),
+      ).toThrow(
+        new ModelError("Category type does not match transaction type"),
+      );
+    });
+
+    it("should reject setting category on transfer transaction", () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.TRANSFER_OUT,
+        categoryId: undefined,
+        transferId: faker.string.uuid(),
+      });
+      const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { category }, fixedDeps),
+      ).toThrow(new ModelError("Transfer transactions cannot have a category"));
+    });
+
+    it("should reject description exceeding max length", () => {
+      // Arrange
+      const existing = fakeTransaction();
+      const tooLong = "x".repeat(DESCRIPTION_MAX_LENGTH + 1);
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(existing, { description: tooLong }, fixedDeps),
+      ).toThrow(
+        new ModelError(
+          `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+        ),
+      );
+    });
+
+    it("should reject switching non-transfer to transfer type", () => {
+      // Arrange
+      const existing = fakeTransaction({
+        type: TransactionType.EXPENSE,
+        transferId: undefined,
+      });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(
+          existing,
+          { type: TransactionType.TRANSFER_OUT },
+          fixedDeps,
+        ),
+      ).toThrow(
+        new ModelError("Transfer transactions must include transferId"),
+      );
+    });
+
+    it("should reject switching transfer to non-transfer type", () => {
+      // Arrange
+      const existing = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        categoryId: undefined,
+        transferId: faker.string.uuid(),
+      });
+
+      // Act & Assert
+      expect(() =>
+        updateTransactionModel(
+          existing,
+          { type: TransactionType.EXPENSE },
           fixedDeps,
         ),
       ).toThrow(

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -182,12 +182,12 @@ function assertTransactionInvariants({
     }
 
     if (newAccount.isArchived) {
-      throw new ModelError("Cannot create transaction for archived account");
+      throw new ModelError("Account must not be archived");
     }
   }
 
   if (transaction.amount <= 0) {
-    throw new ModelError("Transaction amount must be positive");
+    throw new ModelError("Amount must be positive");
   }
 
   const isTransfer =
@@ -214,7 +214,7 @@ function assertTransactionInvariants({
     }
 
     if (newCategory.isArchived) {
-      throw new ModelError("Cannot create transaction for archived category");
+      throw new ModelError("Category must not be archived");
     }
 
     const typeMismatch =

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -66,100 +66,88 @@ export function createTransactionModel(
     idGenerator = randomUUID,
   }: { clock?: () => Date; idGenerator?: () => string } = {},
 ): Transaction {
-  const {
-    account,
-    amount,
-    category,
-    date,
-    description,
-    transferId,
-    type,
-    userId,
-  } = input;
-
-  if (account.userId !== userId) {
-    throw new ModelError("Account does not belong to user");
-  }
-
-  if (account.isArchived) {
-    throw new ModelError("Cannot create transaction for archived account");
-  }
-
-  if (amount <= 0) {
-    throw new ModelError("Transaction amount must be positive");
-  }
-
-  const isTransfer =
-    type === TransactionType.TRANSFER_IN ||
-    type === TransactionType.TRANSFER_OUT;
-
-  if (isTransfer && category) {
-    throw new ModelError("Transfer transactions cannot have a category");
-  }
-
-  if (category) {
-    if (category.userId !== userId) {
-      throw new ModelError("Category does not belong to user");
-    }
-
-    if (category.isArchived) {
-      throw new ModelError("Cannot create transaction for archived category");
-    }
-
-    const typeMismatch =
-      (category.type === CategoryType.INCOME &&
-        type !== TransactionType.INCOME) ||
-      (category.type === CategoryType.EXPENSE &&
-        type !== TransactionType.EXPENSE &&
-        type !== TransactionType.REFUND);
-
-    if (typeMismatch) {
-      throw new ModelError("Category type does not match transaction type");
-    }
-  }
-
-  const normalizedDescription = description?.trim() || undefined;
-
-  if (
-    normalizedDescription &&
-    normalizedDescription.length > DESCRIPTION_MAX_LENGTH
-  ) {
-    throw new ModelError(
-      `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-    );
-  }
-
-  if (isTransfer) {
-    if (!transferId) {
-      throw new ModelError("Transfer transactions must include transferId");
-    }
-  } else {
-    if (transferId) {
-      throw new ModelError("Only transfer transactions can include transferId");
-    }
-  }
-
-  const id = idGenerator();
-  const currency = account.currency;
+  const { account, category } = input;
   const now = clock().toISOString();
 
   const transaction: Transaction = {
-    id,
-    userId,
+    id: idGenerator(),
+    userId: input.userId,
     accountId: account.id,
     categoryId: category?.id,
-    type,
-    amount,
-    currency,
-    date,
-    description: normalizedDescription,
-    transferId,
+    type: input.type,
+    amount: input.amount,
+    currency: account.currency,
+    date: input.date,
+    description: normalizeDescription(input.description),
+    transferId: input.transferId,
     isArchived: false,
     createdAt: now,
     updatedAt: now,
   };
 
+  assertTransactionInvariants({
+    transaction,
+    newAccount: account,
+    newCategory: category,
+  });
+
   return transaction;
+}
+
+export interface UpdateTransactionInput {
+  account?: Account;
+  category?: Category | null;
+  type?: TransactionType;
+  amount?: number;
+  date?: DateString;
+  description?: string | null;
+}
+
+export function updateTransactionModel(
+  transaction: Transaction,
+  input: UpdateTransactionInput,
+  { clock = () => new Date() }: { clock?: () => Date } = {},
+): Transaction {
+  if (transaction.isArchived) {
+    throw new ModelError("Cannot update archived transaction");
+  }
+
+  const { account, category } = input;
+  const now = clock().toISOString();
+
+  const newCategoryId =
+    category === undefined // Not overriding category
+      ? transaction.categoryId
+      : category === null // Explicitly removing category
+        ? undefined
+        : category.id;
+
+  const newDescription =
+    input.description === undefined // Not overriding description
+      ? transaction.description
+      : input.description === null // Explicitly removing description
+        ? undefined
+        : normalizeDescription(input.description);
+
+  const updatedTransaction: Transaction = {
+    ...transaction,
+    accountId: account ? account.id : transaction.accountId,
+    categoryId: newCategoryId,
+    type: input.type ?? transaction.type,
+    amount: input.amount ?? transaction.amount,
+    currency: account ? account.currency : transaction.currency,
+    date: input.date ?? transaction.date,
+    description: newDescription,
+    updatedAt: now,
+  };
+
+  assertTransactionInvariants({
+    transaction: updatedTransaction,
+    newAccount: account,
+    newCategory: category ?? undefined,
+  });
+
+  return updatedTransaction;
 }
 
 // Get signed amount based on transaction type
@@ -177,4 +165,80 @@ export function getSignedAmount(transaction: Transaction): number {
     default:
       throw new Error(`Unknown transaction type: ${transaction.type}`);
   }
+}
+
+function assertTransactionInvariants({
+  transaction,
+  newAccount,
+  newCategory,
+}: {
+  transaction: Transaction;
+  newAccount?: Account;
+  newCategory?: Category;
+}): void {
+  if (newAccount) {
+    if (newAccount.userId !== transaction.userId) {
+      throw new ModelError("Account does not belong to user");
+    }
+
+    if (newAccount.isArchived) {
+      throw new ModelError("Cannot create transaction for archived account");
+    }
+  }
+
+  if (transaction.amount <= 0) {
+    throw new ModelError("Transaction amount must be positive");
+  }
+
+  const isTransfer =
+    transaction.type === TransactionType.TRANSFER_IN ||
+    transaction.type === TransactionType.TRANSFER_OUT;
+
+  if (isTransfer && newCategory) {
+    throw new ModelError("Transfer transactions cannot have a category");
+  }
+
+  if (isTransfer) {
+    if (!transaction.transferId) {
+      throw new ModelError("Transfer transactions must include transferId");
+    }
+  } else {
+    if (transaction.transferId) {
+      throw new ModelError("Only transfer transactions can include transferId");
+    }
+  }
+
+  if (newCategory) {
+    if (newCategory.userId !== transaction.userId) {
+      throw new ModelError("Category does not belong to user");
+    }
+
+    if (newCategory.isArchived) {
+      throw new ModelError("Cannot create transaction for archived category");
+    }
+
+    const typeMismatch =
+      (newCategory.type === CategoryType.INCOME &&
+        transaction.type !== TransactionType.INCOME) ||
+      (newCategory.type === CategoryType.EXPENSE &&
+        transaction.type !== TransactionType.EXPENSE &&
+        transaction.type !== TransactionType.REFUND);
+
+    if (typeMismatch) {
+      throw new ModelError("Category type does not match transaction type");
+    }
+  }
+
+  if (
+    transaction.description &&
+    transaction.description.length > DESCRIPTION_MAX_LENGTH
+  ) {
+    throw new ModelError(
+      `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+    );
+  }
+}
+
+function normalizeDescription(description?: string | null): string | undefined {
+  return description?.trim() || undefined;
 }

--- a/backend/src/ports/transaction-repository.ts
+++ b/backend/src/ports/transaction-repository.ts
@@ -20,16 +20,6 @@ export interface TransactionFilterInput {
 export type TransactionEdge = Edge<Transaction>;
 export type TransactionConnection = Connection<Transaction>;
 
-export interface UpdateTransactionInput {
-  accountId?: string;
-  categoryId?: string | null; // Allow null to remove category association
-  type?: TransactionType;
-  amount?: number;
-  currency?: string;
-  date?: DateString;
-  description?: string | null; // Allow null to clear description
-}
-
 export interface TransactionRepository {
   findOneById(selector: {
     id: string;
@@ -59,14 +49,8 @@ export interface TransactionRepository {
   }): Promise<Transaction[]>;
   create(transaction: Transaction): Promise<void>;
   createMany(transactions: Transaction[]): Promise<void>;
-  update(
-    selector: { id: string; userId: string },
-    input: UpdateTransactionInput,
-  ): Promise<Transaction>;
-  updateMany(
-    updates: { id: string; input: UpdateTransactionInput }[],
-    userId: string,
-  ): Promise<void>;
+  update(transaction: Transaction): Promise<void>;
+  updateMany(transactions: Transaction[]): Promise<void>;
   archive(selector: { id: string; userId: string }): Promise<Transaction>;
   archiveMany(selector: { ids: string[]; userId: string }): Promise<void>;
   hasTransactionsForAccount(selector: {

--- a/backend/src/repositories/dyn-transaction-repository.test.ts
+++ b/backend/src/repositories/dyn-transaction-repository.test.ts
@@ -10,7 +10,6 @@ import {
   TransactionPatternType,
   TransactionType,
 } from "../models/transaction";
-import { UpdateTransactionInput } from "../ports/transaction-repository";
 import { toDateString } from "../types/date";
 import { createDynamoDBDocumentClient } from "../utils/dynamo-client";
 import { requireEnv } from "../utils/require-env";
@@ -1758,15 +1757,13 @@ describe("DynTransactionRepository", () => {
   });
 
   describe("update", () => {
-    it("should update all attributes successfully", async () => {
+    // Happy path
+
+    it("should persist every field on the passed Transaction", async () => {
       // Arrange
       const userId = faker.string.uuid();
-      const accountId = faker.string.uuid();
-
-      // Create transaction first
       const created = fakeTransaction({
         userId,
-        accountId,
         type: TransactionType.EXPENSE,
         amount: 75.0,
         currency: "USD",
@@ -1776,94 +1773,32 @@ describe("DynTransactionRepository", () => {
       });
       await repository.create(created);
 
-      // Act - Update ALL possible attributes
-      const newAccountId = faker.string.uuid();
-      const newCategoryId = faker.string.uuid();
-      const updateInput = {
-        accountId: newAccountId,
+      // Act
+      const updated: Transaction = {
+        ...created,
+        accountId: faker.string.uuid(),
+        categoryId: faker.string.uuid(),
         type: TransactionType.INCOME,
         amount: 100.0,
         currency: "EUR",
         date: toDateString("2024-02-01"),
         description: "Updated description",
-        categoryId: newCategoryId,
+        updatedAt: new Date().toISOString(),
       };
-      const result = await repository.update(
-        { id: created.id, userId },
-        updateInput,
-      );
 
-      // Assert - All attributes updated
-      expect(result).toBeDefined();
-      expect(result.id).toBe(created.id);
-      expect(result.userId).toBe(userId);
-      expect(result.accountId).toBe(newAccountId);
-      expect(result.type).toBe(TransactionType.INCOME);
-      expect(result.amount).toBe(100.0);
-      expect(result.currency).toBe("EUR");
-      expect(result.date).toBe("2024-02-01");
-      expect(result.description).toBe("Updated description");
-      expect(result.categoryId).toBe(newCategoryId);
-      expect(result.isArchived).toBe(false);
-      expect(result.createdAt).toBe(created.createdAt);
-      expect(result.updatedAt).not.toBe(created.updatedAt);
+      await repository.update(updated);
 
-      // Refetch from database to verify stored data matches result
-      const stored = await repository.findOneById({ id: result.id, userId });
-      expect(stored).toEqual(result);
-    });
-
-    it("should update no attributes (only updatedAt changes)", async () => {
-      // Arrange
-      const userId = faker.string.uuid();
-      const accountId = faker.string.uuid();
-      const categoryId = faker.string.uuid();
-
-      // Create transaction first
-      const created = fakeTransaction({
+      // Assert
+      const stored = await repository.findOneById({
+        id: created.id,
         userId,
-        accountId,
-        type: TransactionType.EXPENSE,
-        amount: 50.0,
-        currency: "USD",
-        date: toDateString("2024-01-25"),
-        description: "No change description",
-        categoryId,
       });
-      await repository.create(created);
-
-      // Act - Update with empty input (only updatedAt should change)
-      const updateInput = {};
-      const result = await repository.update(
-        { id: created.id, userId },
-        updateInput,
-      );
-
-      // Assert - All original values preserved except updatedAt
-      expect(result).toBeDefined();
-      expect(result.id).toBe(created.id);
-      expect(result.userId).toBe(userId);
-      expect(result.accountId).toBe(accountId);
-      expect(result.type).toBe(TransactionType.EXPENSE);
-      expect(result.amount).toBe(50.0);
-      expect(result.currency).toBe("USD");
-      expect(result.date).toBe("2024-01-25");
-      expect(result.description).toBe("No change description");
-      expect(result.categoryId).toBe(categoryId);
-      expect(result.isArchived).toBe(false);
-      expect(result.createdAt).toBe(created.createdAt);
-      expect(result.updatedAt).not.toBe(created.updatedAt);
-
-      // Refetch from database to verify stored data matches result
-      const stored = await repository.findOneById({ id: result.id, userId });
-      expect(stored).toEqual(result);
+      expect(stored).toEqual(updated);
     });
 
-    it("should overwrite with null values", async () => {
+    it("should REMOVE optional fields when undefined on the Transaction", async () => {
       // Arrange
       const userId = faker.string.uuid();
-
-      // Create transaction first
       const created = fakeTransaction({
         userId,
         description: "Test description",
@@ -1871,240 +1806,153 @@ describe("DynTransactionRepository", () => {
       });
       await repository.create(created);
 
-      // Act - Update with null values
-      const updateInput = {
-        description: null,
-        categoryId: null,
+      // Act
+      const updated: Transaction = {
+        ...created,
+        description: undefined,
+        categoryId: undefined,
+        updatedAt: new Date().toISOString(),
       };
-      const result = await repository.update(
-        { id: created.id, userId },
-        updateInput,
-      );
+      await repository.update(updated);
 
       // Assert
-      expect(result).toBeDefined();
-      expect(result.description).toBeUndefined();
-      expect(result.categoryId).toBeUndefined();
-
-      // Refetch from database to verify stored data matches result
-      const stored = await repository.findOneById({ id: result.id, userId });
-      expect(stored).toEqual(result);
-    });
-
-    it("should update single field (partial update)", async () => {
-      // Arrange
-      const userId = faker.string.uuid();
-      const accountId = faker.string.uuid();
-      const originalCategoryId = faker.string.uuid();
-
-      // Create transaction first
-      const created = fakeTransaction({
+      const stored = await repository.findOneById({
+        id: created.id,
         userId,
-        accountId,
-        type: TransactionType.EXPENSE,
-        amount: 150.0,
-        currency: "GBP",
-        date: toDateString("2024-01-22"),
-        description: "Original description",
-        categoryId: originalCategoryId,
       });
-      await repository.create(created);
-
-      // Act - Update single field
-      const updateInput = { amount: 175.0 };
-      const result = await repository.update(
-        { id: created.id, userId },
-        updateInput,
-      );
-
-      // Assert - Only amount changed, others preserved
-      expect(result).toBeDefined();
-      expect(result.amount).toBe(175.0);
-      expect(result.description).toBe("Original description");
-      expect(result.categoryId).toBe(originalCategoryId);
-      expect(result.type).toBe(TransactionType.EXPENSE);
-      expect(result.currency).toBe("GBP");
-      expect(result.date).toBe("2024-01-22");
-
-      // Refetch from database to verify stored data matches result
-      const stored = await repository.findOneById({ id: result.id, userId });
-      expect(stored).toEqual(result);
+      expect(stored?.description).toBeUndefined();
+      expect(stored?.categoryId).toBeUndefined();
     });
 
-    it("should throw error for non-existent transaction", async () => {
+    // Validation failures
+
+    it("should throw NOT_FOUND when transaction does not exist", async () => {
       // Arrange
-      const userId = faker.string.uuid();
-      const nonExistentId = "non-existent-transaction-id";
-      const updateInput = { amount: 50.0 };
+      const transaction = fakeTransaction();
 
       // Act & Assert
-      await expect(
-        repository.update({ id: nonExistentId, userId }, updateInput),
-      ).rejects.toThrow("Transaction not found or is archived");
+      await expect(repository.update(transaction)).rejects.toThrow(
+        "Transaction not found",
+      );
     });
 
-    it("should throw error when trying to update archived transaction", async () => {
+    it("should throw NOT_FOUND when userId does not match", async () => {
       // Arrange
-      const userId = faker.string.uuid();
-
-      // Create transaction first
-      const created = fakeTransaction({
-        userId,
-        currency: "USD",
-        description: "Will be archived",
-      });
+      const owner = faker.string.uuid();
+      const other = faker.string.uuid();
+      const created = fakeTransaction({ userId: owner });
       await repository.create(created);
 
-      // Archive the transaction
-      await repository.archive({ id: created.id, userId });
-
-      // Act & Assert - Try to update archived transaction
-      const updateInput = { description: "Should not work" };
+      // Act & Assert - Write as different user, partition key mismatch => condition fails
       await expect(
-        repository.update({ id: created.id, userId }, updateInput),
-      ).rejects.toThrow("Transaction not found or is archived");
-    });
-
-    it("should throw error when trying to update transaction belonging to another user", async () => {
-      // Arrange
-      const ownerUserId = faker.string.uuid();
-      const otherUserId = faker.string.uuid();
-
-      // Create transaction as owner
-      const created = fakeTransaction({
-        userId: ownerUserId,
-        description: "Belongs to owner",
-        categoryId: faker.string.uuid(),
-      });
-      await repository.create(created);
-
-      // Act & Assert - Try to update as different user
-      const updateInput = { description: "Hacker attempt" };
-      await expect(
-        repository.update({ id: created.id, userId: otherUserId }, updateInput),
-      ).rejects.toThrow("Transaction not found or is archived");
+        repository.update({ ...created, userId: other }),
+      ).rejects.toThrow("Transaction not found");
 
       // Verify original transaction is unchanged
       const original = await repository.findOneById({
         id: created.id,
-        userId: ownerUserId,
+        userId: owner,
       });
-      expect(original).toBeDefined();
-      expect(original?.description).toBe("Belongs to owner");
-      expect(original?.userId).toBe(ownerUserId);
+      expect(original).toEqual(created);
     });
 
-    it("should throw error for invalid parameters", async () => {
+    it("should preserve createdAtSortable GSI sort key across updates", async () => {
       // Arrange
-      const updateInput = { amount: 50.0 };
+      const userId = faker.string.uuid();
+      const created = fakeTransaction({ userId });
+      await repository.create(created);
 
-      // Act & Assert - Missing transaction ID
-      await expect(
-        repository.update({ id: "", userId: "user-id" }, updateInput),
-      ).rejects.toThrow("Transaction ID is required");
+      const client = createDynamoDBDocumentClient();
+      const { Item: before } = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { userId, id: created.id },
+        }),
+      );
 
-      // Act & Assert - Missing user ID
-      await expect(
-        repository.update({ id: "transaction-id", userId: "" }, updateInput),
-      ).rejects.toThrow("User ID is required");
+      // Act
+      await repository.update({
+        ...created,
+        amount: 999,
+        updatedAt: new Date().toISOString(),
+      });
+
+      // Assert
+      const { Item: after } = await client.send(
+        new GetCommand({
+          TableName: tableName,
+          Key: { userId, id: created.id },
+        }),
+      );
+      expect(after?.createdAtSortable).toBe(before?.createdAtSortable);
     });
   });
 
   describe("updateMany", () => {
-    it("should throw error for empty input array", async () => {
-      const updates: { id: string; input: UpdateTransactionInput }[] = [];
-      const userId = faker.string.uuid();
+    // Happy path
 
-      await expect(repository.updateMany(updates, userId)).rejects.toThrow(
-        "At least one transaction update is required",
+    it("should update multiple transactions atomically", async () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      const transactions = [
+        fakeTransaction({ userId, amount: 300.0 }),
+        fakeTransaction({ userId, amount: 150.0 }),
+      ];
+      await repository.createMany(transactions);
+
+      // Act
+      const updated = transactions.map((transaction) => ({
+        ...transaction,
+        amount: transaction.amount + 100,
+        description: "Updated",
+        updatedAt: new Date().toISOString(),
+      }));
+      await repository.updateMany(updated);
+
+      // Assert
+      for (const updatedTransaction of updated) {
+        const stored = await repository.findOneById({
+          id: updatedTransaction.id,
+          userId,
+        });
+        expect(stored).toEqual(updatedTransaction);
+      }
+    });
+
+    // Validation failures
+
+    it("should throw error for empty input array", async () => {
+      // Act & Assert
+      await expect(repository.updateMany([])).rejects.toThrow(
+        "At least one transaction is required",
       );
     });
 
-    it("should update multiple transactions successfully", async () => {
+    it("should throw NOT_FOUND when any transaction does not exist", async () => {
+      // Arrange
       const userId = faker.string.uuid();
+      const existing = fakeTransaction({ userId });
+      await repository.create(existing);
 
-      const transactions = [
-        fakeTransaction({
-          userId,
-          type: TransactionType.INCOME,
-          amount: 300.0,
-          currency: "USD",
-          date: toDateString("2024-01-01"),
-          description: "Test transaction 1",
-        }),
-        fakeTransaction({
-          userId,
-          type: TransactionType.EXPENSE,
-          amount: 150.0,
-          currency: "EUR",
-          date: toDateString("2024-01-02"),
-          description: "Test transaction 2",
-        }),
-      ];
+      const missing = fakeTransaction({ userId });
 
-      await repository.createMany(transactions);
+      // Act
+      const promise = repository.updateMany([
+        { ...existing, amount: 999, updatedAt: new Date().toISOString() },
+        missing,
+      ]);
 
-      const newAccountId1 = faker.string.uuid();
-      const newCategoryId1 = faker.string.uuid();
-      const newAccountId2 = faker.string.uuid();
-      const newCategoryId2 = faker.string.uuid();
+      // Assert
+      await expect(promise).rejects.toThrow(
+        "One or more transactions not found",
+      );
 
-      const updates: { id: string; input: UpdateTransactionInput }[] = [
-        {
-          id: transactions[0].id,
-          input: {
-            accountId: newAccountId1,
-            categoryId: newCategoryId1,
-            type: TransactionType.EXPENSE,
-            amount: 350.0,
-            currency: "EUR",
-            date: toDateString("2024-02-01"),
-            description: "New description 1",
-          },
-        },
-        {
-          id: transactions[1].id,
-          input: {
-            accountId: newAccountId2,
-            categoryId: newCategoryId2,
-            type: TransactionType.INCOME,
-            amount: 200.0,
-            currency: "USD",
-            date: toDateString("2024-02-02"),
-            description: "New description 2",
-          },
-        },
-      ];
-
-      await repository.updateMany(updates, userId);
-
-      const stored1 = await repository.findOneById({
-        id: transactions[0].id,
+      // Atomic rollback — the existing transaction was not modified
+      const stored = await repository.findOneById({
+        id: existing.id,
         userId,
       });
-
-      expect(stored1).toBeDefined();
-      expect(stored1?.accountId).toBe(newAccountId1);
-      expect(stored1?.categoryId).toBe(newCategoryId1);
-      expect(stored1?.type).toBe(TransactionType.EXPENSE);
-      expect(stored1?.amount).toBe(350.0);
-      expect(stored1?.currency).toBe("EUR");
-      expect(stored1?.date).toBe("2024-02-01");
-      expect(stored1?.description).toBe("New description 1");
-
-      const stored2 = await repository.findOneById({
-        id: transactions[1].id,
-        userId,
-      });
-
-      expect(stored2).toBeDefined();
-      expect(stored2?.accountId).toBe(newAccountId2);
-      expect(stored2?.categoryId).toBe(newCategoryId2);
-      expect(stored2?.type).toBe(TransactionType.INCOME);
-      expect(stored2?.amount).toBe(200.0);
-      expect(stored2?.currency).toBe("USD");
-      expect(stored2?.date).toBe("2024-02-02");
-      expect(stored2?.description).toBe("New description 2");
+      expect(stored).toEqual(existing);
     });
   });
 

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -23,7 +23,6 @@ import {
   TransactionEdge,
   TransactionFilterInput,
   TransactionRepository,
-  UpdateTransactionInput,
 } from "../ports/transaction-repository";
 import {
   DEFAULT_PAGE_SIZE,
@@ -540,38 +539,15 @@ export class DynTransactionRepository
     }
   }
 
-  async update(
-    { id, userId }: { id: string; userId: string },
-    input: UpdateTransactionInput,
-  ): Promise<Transaction> {
-    if (!id) {
-      throw new RepositoryError(
-        "Transaction ID is required",
-        "INVALID_PARAMETERS",
-      );
-    }
-
-    if (!userId) {
-      throw new RepositoryError("User ID is required", "INVALID_PARAMETERS");
-    }
-
-    const now = new Date().toISOString();
-    const updateParams = this.buildUpdateParams(input, now, userId, id);
+  async update(transaction: Transaction): Promise<void> {
+    const updateParams = this.buildUpdateParams(transaction);
 
     try {
       const command = new UpdateCommand(updateParams);
-
-      const result = await this.client.send(command);
-      return hydrate(transactionSchema, result.Attributes);
+      await this.client.send(command);
     } catch (error) {
-      if (
-        error instanceof Error &&
-        error.name === "ConditionalCheckFailedException"
-      ) {
-        throw new RepositoryError(
-          "Transaction not found or is archived",
-          "NOT_FOUND",
-        );
+      if (error instanceof ConditionalCheckFailedException) {
+        throw new RepositoryError("Transaction not found", "NOT_FOUND");
       }
 
       throw new RepositoryError(
@@ -582,38 +558,25 @@ export class DynTransactionRepository
     }
   }
 
-  async updateMany(
-    updates: { id: string; input: UpdateTransactionInput }[],
-    userId: string,
-  ): Promise<void> {
-    if (!updates.length) {
+  async updateMany(transactions: Transaction[]): Promise<void> {
+    if (!transactions.length) {
       throw new RepositoryError(
-        "At least one transaction update is required",
+        "At least one transaction is required",
         "INVALID_PARAMETERS",
       );
     }
 
-    if (updates.length > DYNAMODB_TRANSACT_WRITE_MAX_ITEMS) {
+    if (transactions.length > DYNAMODB_TRANSACT_WRITE_MAX_ITEMS) {
       throw new RepositoryError(
         `DynamoDB transactions support a maximum of ${DYNAMODB_TRANSACT_WRITE_MAX_ITEMS} items`,
         "TOO_MANY_ITEMS",
       );
     }
 
-    if (!userId) {
-      throw new RepositoryError("User ID is required", "INVALID_PARAMETERS");
-    }
-
-    const now = new Date().toISOString();
-
     try {
-      const transactItems = updates.map(({ id, input }) => {
-        const updateParams = this.buildUpdateParams(input, now, userId, id);
-
-        return {
-          Update: updateParams,
-        };
-      });
+      const transactItems = transactions.map((transaction) => ({
+        Update: this.buildUpdateParams(transaction),
+      }));
 
       const command = new TransactWriteCommand({
         TransactItems: transactItems,
@@ -623,12 +586,9 @@ export class DynTransactionRepository
     } catch (error) {
       console.error("Error updating transactions atomically:", error);
 
-      if (
-        error instanceof Error &&
-        error.name === "TransactionCanceledException"
-      ) {
+      if (error instanceof TransactionCanceledException) {
         throw new RepositoryError(
-          "One or more transactions not found or already archived",
+          "One or more transactions not found",
           "NOT_FOUND",
         );
       }
@@ -681,10 +641,7 @@ export class DynTransactionRepository
     } catch (error) {
       console.error("Error archiving transaction:", error);
 
-      if (
-        error instanceof Error &&
-        error.name === "ConditionalCheckFailedException"
-      ) {
+      if (error instanceof ConditionalCheckFailedException) {
         throw new RepositoryError(
           "Transaction not found or already archived",
           "NOT_FOUND",
@@ -750,10 +707,7 @@ export class DynTransactionRepository
     } catch (error) {
       console.error("Error archiving transactions atomically:", error);
 
-      if (
-        error instanceof Error &&
-        error.name === "TransactionCanceledException"
-      ) {
+      if (error instanceof TransactionCanceledException) {
         throw new RepositoryError(
           "One or more transactions not found or already archived",
           "NOT_FOUND",
@@ -1040,93 +994,73 @@ export class DynTransactionRepository
     };
   }
 
-  private buildUpdateParams(
-    input: UpdateTransactionInput,
-    timestamp: string,
-    userId: string,
-    id: string,
-  ): {
+  private buildUpdateParams(transaction: Transaction): {
     TableName: string;
     Key: { userId: string; id: string };
     UpdateExpression: string;
     ConditionExpression: string;
-    ExpressionAttributeNames?: Record<string, string>;
+    ExpressionAttributeNames: Record<string, string>;
     ExpressionAttributeValues: Record<string, unknown>;
-    ReturnValues: "ALL_NEW";
   } {
-    const setExpressionParts: string[] = ["updatedAt = :updatedAt"];
-    const removeExpressionParts: string[] = [];
-    const expressionAttributeValues: Record<string, unknown> = {
-      ":updatedAt": timestamp,
-      ":isArchived": true,
+    const setParts: string[] = [
+      "accountId = :accountId",
+      "#type = :type",
+      "amount = :amount",
+      "currency = :currency",
+      "#date = :date",
+      "isArchived = :isArchived",
+      "createdAt = :createdAt",
+      "updatedAt = :updatedAt",
+    ];
+    const removeParts: string[] = [];
+    const expressionAttributeNames: Record<string, string> = {
+      "#type": "type",
+      "#date": "date",
     };
-    const expressionAttributeNames: Record<string, string> = {};
+    const expressionAttributeValues: Record<string, unknown> = {
+      ":accountId": transaction.accountId,
+      ":type": transaction.type,
+      ":amount": transaction.amount,
+      ":currency": transaction.currency,
+      ":date": transaction.date,
+      ":isArchived": transaction.isArchived,
+      ":createdAt": transaction.createdAt,
+      ":updatedAt": transaction.updatedAt,
+    };
 
-    if (input.accountId !== undefined) {
-      setExpressionParts.push("accountId = :accountId");
-      expressionAttributeValues[":accountId"] = input.accountId;
+    if (transaction.categoryId !== undefined) {
+      setParts.push("categoryId = :categoryId");
+      expressionAttributeValues[":categoryId"] = transaction.categoryId;
+    } else {
+      removeParts.push("categoryId");
     }
 
-    if (input.categoryId !== undefined) {
-      if (input.categoryId === null) {
-        removeExpressionParts.push("categoryId");
-      } else {
-        setExpressionParts.push("categoryId = :categoryId");
-        expressionAttributeValues[":categoryId"] = input.categoryId;
-      }
+    if (transaction.description !== undefined) {
+      setParts.push("description = :description");
+      expressionAttributeValues[":description"] = transaction.description;
+    } else {
+      removeParts.push("description");
     }
 
-    if (input.type !== undefined) {
-      setExpressionParts.push("#type = :type");
-      expressionAttributeValues[":type"] = input.type;
-      expressionAttributeNames["#type"] = "type";
+    if (transaction.transferId !== undefined) {
+      setParts.push("transferId = :transferId");
+      expressionAttributeValues[":transferId"] = transaction.transferId;
+    } else {
+      removeParts.push("transferId");
     }
 
-    if (input.amount !== undefined) {
-      setExpressionParts.push("amount = :amount");
-      expressionAttributeValues[":amount"] = input.amount;
-    }
-
-    if (input.currency !== undefined) {
-      setExpressionParts.push("currency = :currency");
-      expressionAttributeValues[":currency"] = input.currency;
-    }
-
-    if (input.date !== undefined) {
-      setExpressionParts.push("#date = :date");
-      expressionAttributeValues[":date"] = input.date;
-      expressionAttributeNames["#date"] = "date";
-    }
-
-    if (input.description !== undefined) {
-      if (input.description === null) {
-        removeExpressionParts.push("description");
-      } else {
-        setExpressionParts.push("description = :description");
-        expressionAttributeValues[":description"] = input.description;
-      }
-    }
-
-    // Build UpdateExpression with both SET and REMOVE clauses
-    const updateExpressionParts: string[] = [];
-    if (setExpressionParts.length > 0) {
-      updateExpressionParts.push(`SET ${setExpressionParts.join(", ")}`);
-    }
-    if (removeExpressionParts.length > 0) {
-      updateExpressionParts.push(`REMOVE ${removeExpressionParts.join(", ")}`);
+    const updateExpressionParts: string[] = [`SET ${setParts.join(", ")}`];
+    if (removeParts.length > 0) {
+      updateExpressionParts.push(`REMOVE ${removeParts.join(", ")}`);
     }
 
     return {
       TableName: this.tableName,
-      Key: { userId, id },
+      Key: { userId: transaction.userId, id: transaction.id },
       UpdateExpression: updateExpressionParts.join(" "),
-      ConditionExpression:
-        "attribute_exists(userId) AND attribute_exists(id) AND isArchived <> :isArchived",
-      ...(Object.keys(expressionAttributeNames).length > 0 && {
-        ExpressionAttributeNames: expressionAttributeNames,
-      }),
+      ConditionExpression: "attribute_exists(userId) AND attribute_exists(id)",
+      ExpressionAttributeNames: expressionAttributeNames,
       ExpressionAttributeValues: expressionAttributeValues,
-      ReturnValues: "ALL_NEW",
     };
   }
 

--- a/backend/src/services/transaction-service.test.ts
+++ b/backend/src/services/transaction-service.test.ts
@@ -6,13 +6,11 @@ import {
   TransactionPatternType,
   TransactionType,
   createTransactionModel,
+  updateTransactionModel,
 } from "../models/transaction";
 import { toDateString } from "../types/date";
 import { MAX_PAGE_SIZE, MIN_PAGE_SIZE } from "../types/pagination";
-import {
-  DESCRIPTION_MAX_LENGTH,
-  MIN_SEARCH_TEXT_LENGTH,
-} from "../types/validation";
+import { MIN_SEARCH_TEXT_LENGTH } from "../types/validation";
 import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import {
@@ -44,18 +42,23 @@ describe("TransactionService", () => {
   let mockCreateTransactionModel: jest.MockedFunction<
     typeof createTransactionModel
   >;
+  let mockUpdateTransactionModel: jest.MockedFunction<
+    typeof updateTransactionModel
+  >;
 
   beforeEach(() => {
     mockTransactionRepository = createMockTransactionRepository();
     mockAccountRepository = createMockAccountRepository();
     mockCategoryRepository = createMockCategoryRepository();
     mockCreateTransactionModel = jest.fn<typeof createTransactionModel>();
+    mockUpdateTransactionModel = jest.fn<typeof updateTransactionModel>();
 
     service = new TransactionServiceImpl({
       accountRepository: mockAccountRepository,
       categoryRepository: mockCategoryRepository,
       transactionRepository: mockTransactionRepository,
       createTransactionModel: mockCreateTransactionModel,
+      updateTransactionModel: mockUpdateTransactionModel,
     });
     userId = faker.string.uuid();
 
@@ -956,48 +959,150 @@ describe("TransactionService", () => {
   });
 
   describe("updateTransaction", () => {
-    describe("validation", () => {
-      let transactionId: string;
+    // Happy path
 
-      beforeEach(() => {
-        const transaction = fakeTransaction({ userId });
-        transactionId = transaction.id;
-
-        mockTransactionRepository.findOneById.mockResolvedValue(transaction);
+    it("should return updated transaction", async () => {
+      // Arrange
+      const existing = fakeTransaction({ userId });
+      const account = fakeAccount({ userId });
+      const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
+      const updatedTransaction = fakeTransaction({
+        id: existing.id,
+        userId,
       });
 
-      it("should throw for amount of zero", async () => {
-        const promise = service.updateTransaction(transactionId, userId, {
-          amount: 0,
-        });
+      // Returns existing transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(existing);
+      // Returns new account owned by user
+      mockAccountRepository.findOneById.mockResolvedValue(account);
+      // Returns new category owned by user
+      mockCategoryRepository.findOneById.mockResolvedValue(category);
+      // Returns built updated transaction
+      mockUpdateTransactionModel.mockReturnValue(updatedTransaction);
 
-        await expect(promise).rejects.toThrow(BusinessError);
-        await expect(promise).rejects.toMatchObject({
-          message: "Transaction amount must be positive",
-        });
+      // Act
+      const result = await service.updateTransaction(existing.id, userId, {
+        accountId: account.id,
+        categoryId: category.id,
+        amount: 200,
       });
 
-      it("should throw for negative amount", async () => {
-        const promise = service.updateTransaction(transactionId, userId, {
-          amount: -50,
-        });
+      // Assert
+      expect(result).toBe(updatedTransaction);
+      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(existing, {
+        account,
+        category,
+        type: undefined,
+        amount: 200,
+        date: undefined,
+        description: undefined,
+      });
+      expect(mockTransactionRepository.update).toHaveBeenCalledWith(
+        updatedTransaction,
+      );
+    });
 
-        await expect(promise).rejects.toThrow(BusinessError);
-        await expect(promise).rejects.toMatchObject({
-          message: "Transaction amount must be positive",
-        });
+    it("should skip account lookup when accountId is omitted", async () => {
+      // Arrange
+      const existing = fakeTransaction({ userId });
+      // Returns existing transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(existing);
+      // Returns built updated transaction
+      mockUpdateTransactionModel.mockReturnValue(existing);
+
+      // Act
+      await service.updateTransaction(existing.id, userId, { amount: 5 });
+
+      // Assert
+      expect(mockAccountRepository.findOneById).not.toHaveBeenCalled();
+      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(
+        existing,
+        expect.objectContaining({ account: undefined }),
+      );
+    });
+
+    it("should clear category when categoryId is null", async () => {
+      // Arrange
+      const existing = fakeTransaction({ userId });
+      // Returns existing transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(existing);
+      // Returns built updated transaction
+      mockUpdateTransactionModel.mockReturnValue(existing);
+
+      // Act
+      await service.updateTransaction(existing.id, userId, {
+        categoryId: null,
       });
 
-      it("should throw for description exceeding maximum length", async () => {
-        const promise = service.updateTransaction(transactionId, userId, {
-          description: "x".repeat(DESCRIPTION_MAX_LENGTH + 1),
-        });
+      // Assert
+      expect(mockCategoryRepository.findOneById).not.toHaveBeenCalled();
+      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(
+        existing,
+        expect.objectContaining({ category: null }),
+      );
+    });
 
-        await expect(promise).rejects.toThrow(BusinessError);
-        await expect(promise).rejects.toMatchObject({
-          message: `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-        });
+    // Validation failures
+
+    it("should throw when transaction not found", async () => {
+      // Arrange
+      // Returns no transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(null);
+
+      // Act
+      const promise = service.updateTransaction("id", userId, { amount: 1 });
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Transaction not found or doesn't belong to user",
       });
+      expect(mockUpdateTransactionModel).not.toHaveBeenCalled();
+      expect(mockTransactionRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("should throw when account not found", async () => {
+      // Arrange
+      const existing = fakeTransaction({ userId });
+      // Returns existing transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(existing);
+      // Returns no account
+      mockAccountRepository.findOneById.mockResolvedValue(null);
+
+      // Act
+      const promise = service.updateTransaction(existing.id, userId, {
+        accountId: "missing",
+      });
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Account not found or doesn't belong to user",
+      });
+      expect(mockUpdateTransactionModel).not.toHaveBeenCalled();
+      expect(mockTransactionRepository.update).not.toHaveBeenCalled();
+    });
+
+    // Dependency failures
+
+    it("should propagate ModelError without persisting", async () => {
+      // Arrange
+      const existing = fakeTransaction({ userId });
+      // Returns existing transaction
+      mockTransactionRepository.findOneById.mockResolvedValue(existing);
+      // Model rejects input
+      mockUpdateTransactionModel.mockImplementation(() => {
+        throw new ModelError("Transaction amount must be positive");
+      });
+
+      // Act
+      const promise = service.updateTransaction(existing.id, userId, {
+        amount: -1,
+      });
+
+      // Assert
+      await expect(promise).rejects.toThrow(ModelError);
+      expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/services/transaction-service.test.ts
+++ b/backend/src/services/transaction-service.test.ts
@@ -1092,7 +1092,7 @@ describe("TransactionService", () => {
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
       // Model rejects input
       mockUpdateTransactionModel.mockImplementation(() => {
-        throw new ModelError("Transaction amount must be positive");
+        throw new ModelError("Amount must be positive");
       });
 
       // Act

--- a/backend/src/services/transaction-service.ts
+++ b/backend/src/services/transaction-service.ts
@@ -7,6 +7,7 @@ import {
   TransactionPatternType,
   TransactionType,
   createTransactionModel as defaultCreateTransactionModel,
+  updateTransactionModel as defaultUpdateTransactionModel,
 } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { CategoryRepository } from "../ports/category-repository";
@@ -14,7 +15,6 @@ import {
   TransactionConnection,
   TransactionFilterInput,
   TransactionRepository,
-  UpdateTransactionInput,
 } from "../ports/transaction-repository";
 import { DateString } from "../types/date";
 import {
@@ -22,10 +22,7 @@ import {
   MIN_PAGE_SIZE,
   PaginationInput,
 } from "../types/pagination";
-import {
-  DESCRIPTION_MAX_LENGTH,
-  MIN_SEARCH_TEXT_LENGTH,
-} from "../types/validation";
+import { MIN_SEARCH_TEXT_LENGTH } from "../types/validation";
 import { BusinessError } from "./business-error";
 
 export const DEFAULT_TRANSACTION_PATTERNS_LIMIT = 3;
@@ -105,22 +102,26 @@ export class TransactionServiceImpl implements TransactionService {
   private categoryRepository: CategoryRepository;
   private transactionRepository: TransactionRepository;
   private createTransactionModel: typeof defaultCreateTransactionModel;
+  private updateTransactionModel: typeof defaultUpdateTransactionModel;
 
   constructor({
     accountRepository,
     categoryRepository,
     transactionRepository,
     createTransactionModel = defaultCreateTransactionModel,
+    updateTransactionModel = defaultUpdateTransactionModel,
   }: {
     accountRepository: AccountRepository;
     categoryRepository: CategoryRepository;
     transactionRepository: TransactionRepository;
     createTransactionModel?: typeof defaultCreateTransactionModel;
+    updateTransactionModel?: typeof defaultUpdateTransactionModel;
   }) {
     this.accountRepository = accountRepository;
     this.categoryRepository = categoryRepository;
     this.transactionRepository = transactionRepository;
     this.createTransactionModel = createTransactionModel;
+    this.updateTransactionModel = updateTransactionModel;
   }
 
   /**
@@ -235,37 +236,34 @@ export class TransactionServiceImpl implements TransactionService {
       );
     }
 
-    // Validate cheap inputs before further async I/O
-    if (input.amount !== undefined) {
-      this.validateAmount(input.amount);
-    }
-    this.validateDescription(input.description);
+    const account = input.accountId
+      ? await this.validateAccount(input.accountId, userId)
+      : undefined;
 
-    // Validate account if provided
-    let account;
-    if (input.accountId) {
-      account = await this.validateAccount(input.accountId, userId);
-    } else {
-      // Get current account for reference
-      account = await this.validateAccount(
-        existingTransaction.accountId,
-        userId,
-      );
-    }
+    const transactionType = input.type ?? existingTransaction.type;
+    const category =
+      input.categoryId === undefined
+        ? undefined
+        : input.categoryId === null
+          ? null
+          : await this.validateCategory(
+              input.categoryId,
+              userId,
+              transactionType,
+            );
 
-    // Validate category if provided (only if transaction type is also provided or can be determined)
-    const transactionType = input.type || existingTransaction.type;
-    if (input.categoryId) {
-      await this.validateCategory(input.categoryId, userId, transactionType);
-    }
+    const updated = this.updateTransactionModel(existingTransaction, {
+      account,
+      category,
+      type: input.type,
+      amount: input.amount,
+      date: input.date,
+      description: input.description,
+    });
 
-    // Update the transaction through repository, including currency if account changed
-    const updateInput: UpdateTransactionInput = {
-      ...input,
-      ...(input.accountId && { currency: account.currency }),
-    };
+    await this.transactionRepository.update(updated);
 
-    return await this.transactionRepository.update({ id, userId }, updateInput);
+    return updated;
   }
 
   /**
@@ -467,30 +465,6 @@ export class TransactionServiceImpl implements TransactionService {
     ) {
       throw new BusinessError(
         "Filter dateAfter cannot be later than dateBefore",
-      );
-    }
-  }
-
-  /**
-   * Validate that the transaction amount is positive
-   * @param amount - The amount to validate
-   * @throws BusinessError if amount is zero or negative
-   */
-  private validateAmount(amount: number): void {
-    if (amount <= 0) {
-      throw new BusinessError("Transaction amount must be positive");
-    }
-  }
-
-  /**
-   * Validate that the transaction description does not exceed the maximum length
-   * @param description - The description to validate
-   * @throws BusinessError if description exceeds DESCRIPTION_MAX_LENGTH
-   */
-  private validateDescription(description: string | null | undefined): void {
-    if (description && description.length > DESCRIPTION_MAX_LENGTH) {
-      throw new BusinessError(
-        `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
       );
     }
   }

--- a/backend/src/services/transfer-service.test.ts
+++ b/backend/src/services/transfer-service.test.ts
@@ -1,10 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
-import { TransactionType, createTransactionModel } from "../models/transaction";
+import { ModelError } from "../models/model-error";
+import {
+  TransactionType,
+  createTransactionModel,
+  updateTransactionModel,
+} from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { TransactionRepository } from "../ports/transaction-repository";
 import { toDateString } from "../types/date";
-import { DESCRIPTION_MAX_LENGTH } from "../types/validation";
 import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
 import { createMockAccountRepository } from "../utils/test-utils/repositories/account-repository-mocks";
@@ -20,16 +24,21 @@ describe("TransferService", () => {
   let mockCreateTransactionModel: jest.MockedFunction<
     typeof createTransactionModel
   >;
+  let mockUpdateTransactionModel: jest.MockedFunction<
+    typeof updateTransactionModel
+  >;
 
   beforeEach(() => {
     mockAccountRepository = createMockAccountRepository();
     mockTransactionRepository = createMockTransactionRepository();
     mockCreateTransactionModel = jest.fn<typeof createTransactionModel>();
+    mockUpdateTransactionModel = jest.fn<typeof updateTransactionModel>();
 
     service = new TransferService({
       accountRepository: mockAccountRepository,
       transactionRepository: mockTransactionRepository,
       createTransactionModel: mockCreateTransactionModel,
+      updateTransactionModel: mockUpdateTransactionModel,
     });
 
     userId = faker.string.uuid();
@@ -216,7 +225,132 @@ describe("TransferService", () => {
   });
 
   describe("updateTransfer", () => {
+    // Happy path
+
     it("should update transfer and return result with updated transactions", async () => {
+      // Arrange
+      const transferId = faker.string.uuid();
+      const fromAccount = fakeAccount({ userId });
+      const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        transferId,
+        accountId: fromAccount.id,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        transferId,
+        accountId: toAccount.id,
+      });
+      const updatedOutbound = fakeTransaction({
+        id: outboundTransaction.id,
+        type: TransactionType.TRANSFER_OUT,
+      });
+      const updatedInbound = fakeTransaction({
+        id: inboundTransaction.id,
+        type: TransactionType.TRANSFER_IN,
+      });
+
+      // Returns existing pair, then updated pair on refetch
+      mockTransactionRepository.findManyByTransferId
+        .mockResolvedValueOnce([outboundTransaction, inboundTransaction])
+        .mockResolvedValueOnce([updatedOutbound, updatedInbound]);
+      // Returns accounts owned by user
+      mockAccountRepository.findOneById
+        .mockResolvedValueOnce(fromAccount)
+        .mockResolvedValueOnce(toAccount);
+      // Returns updated transactions
+      mockUpdateTransactionModel
+        .mockReturnValueOnce(updatedOutbound)
+        .mockReturnValueOnce(updatedInbound);
+
+      // Act
+      const result = await service.updateTransfer(transferId, userId, {
+        amount: 200,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        transferId,
+        outboundTransaction: updatedOutbound,
+        inboundTransaction: updatedInbound,
+      });
+      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
+        1,
+        outboundTransaction,
+        {
+          account: undefined,
+          amount: 200,
+          date: undefined,
+          description: undefined,
+        },
+      );
+      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
+        2,
+        inboundTransaction,
+        {
+          account: undefined,
+          amount: 200,
+          date: undefined,
+          description: undefined,
+        },
+      );
+      expect(mockTransactionRepository.updateMany).toHaveBeenCalledWith([
+        updatedOutbound,
+        updatedInbound,
+      ]);
+    });
+
+    it("should resolve new accounts when account ids change", async () => {
+      // Arrange
+      const transferId = faker.string.uuid();
+      const fromAccount = fakeAccount({ userId });
+      const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
+      const outboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        transferId,
+      });
+      const inboundTransaction = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        transferId,
+      });
+
+      // Returns existing pair on both lookups
+      mockTransactionRepository.findManyByTransferId
+        .mockResolvedValueOnce([outboundTransaction, inboundTransaction])
+        .mockResolvedValueOnce([outboundTransaction, inboundTransaction]);
+      // Returns accounts owned by user
+      mockAccountRepository.findOneById
+        .mockResolvedValueOnce(fromAccount)
+        .mockResolvedValueOnce(toAccount);
+      // Returns built updated sides
+      mockUpdateTransactionModel
+        .mockReturnValueOnce(outboundTransaction)
+        .mockReturnValueOnce(inboundTransaction);
+
+      // Act
+      await service.updateTransfer(transferId, userId, {
+        fromAccountId: fromAccount.id,
+        toAccountId: toAccount.id,
+      });
+
+      // Assert
+      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
+        1,
+        outboundTransaction,
+        expect.objectContaining({ account: fromAccount }),
+      );
+      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
+        2,
+        inboundTransaction,
+        expect.objectContaining({ account: toAccount }),
+      );
+    });
+
+    // Dependency failures
+
+    it("should propagate ModelError without persisting", async () => {
+      // Arrange
       const transferId = faker.string.uuid();
       const fromAccount = fakeAccount({ userId });
       const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
@@ -231,34 +365,27 @@ describe("TransferService", () => {
         accountId: toAccount.id,
       });
 
-      mockTransactionRepository.findManyByTransferId
-        .mockResolvedValueOnce([outboundTransaction, inboundTransaction])
-        .mockResolvedValueOnce([outboundTransaction, inboundTransaction]);
+      // Returns existing pair
+      mockTransactionRepository.findManyByTransferId.mockResolvedValueOnce([
+        outboundTransaction,
+        inboundTransaction,
+      ]);
+      // Returns accounts owned by user
       mockAccountRepository.findOneById
         .mockResolvedValueOnce(fromAccount)
         .mockResolvedValueOnce(toAccount);
-
-      const result = await service.updateTransfer(transferId, userId, {
-        amount: 200,
+      // Model rejects input
+      mockUpdateTransactionModel.mockImplementation(() => {
+        throw new ModelError("Transaction amount must be positive");
       });
 
-      expect(result).toEqual({
-        transferId,
-        outboundTransaction,
-        inboundTransaction,
-      });
-    });
-
-    it("should reject description exceeding maximum length", async () => {
-      const promise = service.updateTransfer(faker.string.uuid(), userId, {
-        description: "a".repeat(DESCRIPTION_MAX_LENGTH + 1),
+      // Act
+      const promise = service.updateTransfer(transferId, userId, {
+        amount: -1,
       });
 
-      await expect(promise).rejects.toThrow(BusinessError);
-      await expect(promise).rejects.toMatchObject({
-        message: `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-      });
-
+      // Assert
+      await expect(promise).rejects.toThrow(ModelError);
       expect(mockTransactionRepository.updateMany).not.toHaveBeenCalled();
     });
   });

--- a/backend/src/services/transfer-service.test.ts
+++ b/backend/src/services/transfer-service.test.ts
@@ -376,7 +376,7 @@ describe("TransferService", () => {
         .mockResolvedValueOnce(toAccount);
       // Model rejects input
       mockUpdateTransactionModel.mockImplementation(() => {
-        throw new ModelError("Transaction amount must be positive");
+        throw new ModelError("Amount must be positive");
       });
 
       // Act

--- a/backend/src/services/transfer-service.ts
+++ b/backend/src/services/transfer-service.ts
@@ -252,7 +252,6 @@ export class TransferService {
     });
 
     try {
-      // Update both transactions atomically using the new updateMany method
       await this.transactionRepository.updateMany([
         updatedOutbound,
         updatedInbound,

--- a/backend/src/services/transfer-service.ts
+++ b/backend/src/services/transfer-service.ts
@@ -4,11 +4,11 @@ import {
   Transaction,
   TransactionType,
   createTransactionModel as defaultCreateTransactionModel,
+  updateTransactionModel as defaultUpdateTransactionModel,
 } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { TransactionRepository } from "../ports/transaction-repository";
 import { DateString } from "../types/date";
-import { DESCRIPTION_MAX_LENGTH } from "../types/validation";
 import { BusinessError } from "./business-error";
 
 /**
@@ -50,19 +50,23 @@ export class TransferService {
   private accountRepository: AccountRepository;
   private transactionRepository: TransactionRepository;
   private createTransactionModel: typeof defaultCreateTransactionModel;
+  private updateTransactionModel: typeof defaultUpdateTransactionModel;
 
   constructor({
     accountRepository,
     transactionRepository,
     createTransactionModel = defaultCreateTransactionModel,
+    updateTransactionModel = defaultUpdateTransactionModel,
   }: {
     accountRepository: AccountRepository;
     transactionRepository: TransactionRepository;
     createTransactionModel?: typeof defaultCreateTransactionModel;
+    updateTransactionModel?: typeof defaultUpdateTransactionModel;
   }) {
     this.accountRepository = accountRepository;
     this.transactionRepository = transactionRepository;
     this.createTransactionModel = createTransactionModel;
+    this.updateTransactionModel = updateTransactionModel;
   }
 
   /**
@@ -206,12 +210,6 @@ export class TransferService {
     userId: string,
     input: UpdateTransferServiceInput,
   ): Promise<TransferResult> {
-    // Validate input parameters before any DB calls
-    if (input.amount !== undefined) {
-      this.validateAmount(input.amount);
-    }
-    this.validateDescription(input.description);
-
     // Find and validate the existing transfer
     const existingTransfer = await this.fetchValidatedTransfer(
       transferId,
@@ -224,18 +222,8 @@ export class TransferService {
 
     const { outboundTransaction, inboundTransaction } = existingTransfer;
 
-    // Merge input with existing values for partial updates
     const fromAccountId = input.fromAccountId ?? outboundTransaction.accountId;
     const toAccountId = input.toAccountId ?? inboundTransaction.accountId;
-    const amount = input.amount ?? outboundTransaction.amount;
-    const date = input.date ?? outboundTransaction.date;
-    // Note: Can't use ?? for description because we need to distinguish:
-    // - undefined = "field not provided" (keep existing value)
-    // - null = "field explicitly set to null" (clear the description)
-    const description =
-      input.description !== undefined
-        ? input.description
-        : outboundTransaction.description;
 
     // Validate not transferring to the same account (fail fast before DB calls)
     this.validateNotSelfTransfer(fromAccountId, toAccountId);
@@ -247,34 +235,28 @@ export class TransferService {
     // Validate accounts have the same currency
     this.validateCurrencyMatch(fromAccount, toAccount);
 
+    const sharedUpdate = {
+      amount: input.amount,
+      date: input.date,
+      description: input.description,
+    };
+
+    const updatedOutbound = this.updateTransactionModel(outboundTransaction, {
+      ...sharedUpdate,
+      account: input.fromAccountId ? fromAccount : undefined,
+    });
+
+    const updatedInbound = this.updateTransactionModel(inboundTransaction, {
+      ...sharedUpdate,
+      account: input.toAccountId ? toAccount : undefined,
+    });
+
     try {
       // Update both transactions atomically using the new updateMany method
-      const updates = [
-        {
-          id: outboundTransaction.id,
-          input: {
-            accountId: fromAccountId,
-            amount: amount,
-            currency: fromAccount.currency,
-            date: date,
-            description: description || undefined, // Convert null to undefined for repository layer
-            // Note: transferId is intentionally not included as it cannot be changed
-          },
-        },
-        {
-          id: inboundTransaction.id,
-          input: {
-            accountId: toAccountId,
-            amount: amount,
-            currency: toAccount.currency, // Should be same as fromAccount.currency due to validation
-            date: date,
-            description: description || undefined,
-            // Note: transferId is intentionally not included as it cannot be changed
-          },
-        },
-      ];
-
-      await this.transactionRepository.updateMany(updates, userId);
+      await this.transactionRepository.updateMany([
+        updatedOutbound,
+        updatedInbound,
+      ]);
 
       // Fetch and return the updated transfer
       const updatedTransfer = await this.fetchValidatedTransfer(
@@ -293,9 +275,9 @@ export class TransferService {
       // Log the error for debugging and monitoring
       console.error("Transfer update failed:", {
         transferId,
-        fromAccountId: fromAccountId,
-        toAccountId: toAccountId,
-        amount: amount,
+        fromAccountId,
+        toAccountId,
+        amount: input.amount,
         error,
       });
 
@@ -346,19 +328,6 @@ export class TransferService {
   }
 
   /**
-   * Validate that the description does not exceed the maximum allowed length
-   * @param description - The description to validate (null/undefined are allowed)
-   * @throws BusinessError if description exceeds maximum length
-   */
-  private validateDescription(description?: string | null): void {
-    if (description && description.length > DESCRIPTION_MAX_LENGTH) {
-      throw new BusinessError(
-        `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-      );
-    }
-  }
-
-  /**
    * Validate that an account exists and belongs to the user
    * @param accountId - The account ID to validate
    * @param userId - The user ID to check ownership
@@ -379,17 +348,6 @@ export class TransferService {
     }
 
     return account;
-  }
-
-  /**
-   * Validate that the transfer amount is valid (positive)
-   * @param amount - The amount to validate
-   * @throws BusinessError if amount is not positive
-   */
-  private validateAmount(amount: number): void {
-    if (amount <= 0) {
-      throw new BusinessError("Transfer amount must be positive");
-    }
   }
 
   /**


### PR DESCRIPTION
## context

Transaction update logic was split between services and the repository with overlapping responsibilities.

## before

- Repository `update`/`updateMany` accepted partial input DTOs and built the mutation internally
- Transaction invariants for updates lived in services

## after

- Repository `update`/`updateMany` accept `Transaction` entities
- Transaction invariants for updates live in the model