### PR TITLE
convert transaction model to entity class

### DIFF
--- a/backend/src/langchain/tools/aggregate-transactions.ts
+++ b/backend/src/langchain/tools/aggregate-transactions.ts
@@ -1,6 +1,6 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { TransactionType, getSignedAmount } from "../../models/transaction";
+import { TransactionType } from "../../models/transaction";
 import { TransactionRepository } from "../../ports/transaction-repository";
 import { toDateString } from "../../types/date";
 import { Failure, Success } from "../../types/result";
@@ -73,7 +73,7 @@ export const createAggregateTransactionsTool = ({
 
       for (const transaction of transactions) {
         const { currency } = transaction;
-        const signedAmount = getSignedAmount(transaction);
+        const signedAmount = transaction.signedAmount;
 
         sumByCurrency[currency] = (sumByCurrency[currency] ?? 0) + signedAmount;
         countByCurrency[currency] = (countByCurrency[currency] ?? 0) + 1;

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -7,19 +7,14 @@ import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import {
   fakeCreateTransactionInput,
   fakeTransaction,
+  fakeTransactionData,
 } from "../utils/test-utils/models/transaction-fakes";
 import { CategoryType } from "./category";
 import { ModelError } from "./model-error";
-import {
-  TransactionType,
-  archiveTransactionModel,
-  createTransactionModel,
-  getSignedAmount,
-  updateTransactionModel,
-} from "./transaction";
+import { TransactionEntity, TransactionType } from "./transaction";
 
-describe("transaction model", () => {
-  describe("createTransactionModel", () => {
+describe("TransactionEntity", () => {
+  describe("create", () => {
     const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
     const fixedIdGenerator = () => "fixed-uuid";
     const fixedDeps = { clock: fixedClock, idGenerator: fixedIdGenerator };
@@ -42,10 +37,10 @@ describe("transaction model", () => {
       });
 
       // Act
-      const result = createTransactionModel(input, fixedDeps);
+      const result = TransactionEntity.create(input, fixedDeps);
 
       // Assert
-      expect(result).toEqual({
+      expect(result.toData()).toEqual({
         id: "fixed-uuid",
         userId,
         accountId: account.id,
@@ -65,7 +60,7 @@ describe("transaction model", () => {
 
     it("builds transaction without category", () => {
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({ category: undefined }),
         fixedDeps,
       );
@@ -79,7 +74,7 @@ describe("transaction model", () => {
       const account = fakeAccount({ currency: "GBP" });
 
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({ userId: account.userId, account }),
         fixedDeps,
       );
@@ -90,7 +85,7 @@ describe("transaction model", () => {
 
     it("trims description", () => {
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({ description: "  spaced  " }),
         fixedDeps,
       );
@@ -105,7 +100,7 @@ describe("transaction model", () => {
       const padded = `  ${withinLimit}  `;
 
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({ description: padded }),
         fixedDeps,
       );
@@ -116,7 +111,7 @@ describe("transaction model", () => {
 
     it("sets description to undefined when empty after trim", () => {
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({ description: "   " }),
         fixedDeps,
       );
@@ -127,7 +122,7 @@ describe("transaction model", () => {
 
     it("defaults isArchived to false", () => {
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput(),
         fixedDeps,
       );
@@ -138,7 +133,7 @@ describe("transaction model", () => {
 
     it("sets createdAt equal to updatedAt", () => {
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput(),
         fixedDeps,
       );
@@ -149,7 +144,7 @@ describe("transaction model", () => {
 
     it("sets id and timestamps with default dependencies", () => {
       // Act
-      const result = createTransactionModel(fakeCreateTransactionInput());
+      const result = TransactionEntity.create(fakeCreateTransactionInput());
 
       // Assert
       expect(result.id).toBeDefined();
@@ -164,7 +159,7 @@ describe("transaction model", () => {
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
 
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({
           userId,
           account,
@@ -184,7 +179,7 @@ describe("transaction model", () => {
       const transferId = faker.string.uuid();
 
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({
           type: TransactionType.TRANSFER_OUT,
           transferId,
@@ -203,7 +198,7 @@ describe("transaction model", () => {
       const transferId = faker.string.uuid();
 
       // Act
-      const result = createTransactionModel(
+      const result = TransactionEntity.create(
         fakeCreateTransactionInput({
           type: TransactionType.TRANSFER_IN,
           transferId,
@@ -218,13 +213,13 @@ describe("transaction model", () => {
 
     // Validation failures
 
-    it("rejects when account belongs to different user", () => {
+    it("throws when account belongs to different user", () => {
       // Arrange
       const account = fakeAccount({ userId: faker.string.uuid() });
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             userId: faker.string.uuid(),
             account,
@@ -234,41 +229,41 @@ describe("transaction model", () => {
       ).toThrow(new ModelError("Account does not belong to user"));
     });
 
-    it("rejects when account is archived", () => {
+    it("throws when account is archived", () => {
       // Arrange
       const userId = faker.string.uuid();
       const account = fakeAccount({ userId, isArchived: true });
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ userId, account }),
           fixedDeps,
         ),
       ).toThrow(new ModelError("Account must not be archived"));
     });
 
-    it("rejects zero amount", () => {
+    it("throws on zero amount", () => {
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ amount: 0 }),
           fixedDeps,
         ),
       ).toThrow(new ModelError("Amount must be positive"));
     });
 
-    it("rejects negative amount", () => {
+    it("throws on negative amount", () => {
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ amount: -5 }),
           fixedDeps,
         ),
       ).toThrow(new ModelError("Amount must be positive"));
     });
 
-    it("rejects when category belongs to different user", () => {
+    it("throws when category belongs to different user", () => {
       // Arrange
       const userId = faker.string.uuid();
       const category = fakeCategory({
@@ -278,14 +273,14 @@ describe("transaction model", () => {
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ userId, category }),
           fixedDeps,
         ),
       ).toThrow(new ModelError("Category does not belong to user"));
     });
 
-    it("rejects when category is archived", () => {
+    it("throws when category is archived", () => {
       // Arrange
       const userId = faker.string.uuid();
       const category = fakeCategory({
@@ -296,21 +291,21 @@ describe("transaction model", () => {
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ userId, category }),
           fixedDeps,
         ),
       ).toThrow(new ModelError("Category must not be archived"));
     });
 
-    it("rejects INCOME category on EXPENSE transaction", () => {
+    it("throws on INCOME category for EXPENSE transaction", () => {
       // Arrange
       const userId = faker.string.uuid();
       const category = fakeCategory({ userId, type: CategoryType.INCOME });
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             userId,
             category,
@@ -323,14 +318,14 @@ describe("transaction model", () => {
       );
     });
 
-    it("rejects EXPENSE category on INCOME transaction", () => {
+    it("throws on EXPENSE category for INCOME transaction", () => {
       // Arrange
       const userId = faker.string.uuid();
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             userId,
             category,
@@ -343,13 +338,13 @@ describe("transaction model", () => {
       );
     });
 
-    it("rejects description exceeding max length", () => {
+    it("throws when description exceeds maximum length", () => {
       // Arrange
       const tooLong = "x".repeat(DESCRIPTION_MAX_LENGTH + 1);
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({ description: tooLong }),
           fixedDeps,
         ),
@@ -360,7 +355,7 @@ describe("transaction model", () => {
       );
     });
 
-    it("rejects transfer with category", () => {
+    it("throws on transfer with category", () => {
       // Arrange
       const userId = faker.string.uuid();
       const account = fakeAccount({ userId });
@@ -368,7 +363,7 @@ describe("transaction model", () => {
 
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             userId,
             account,
@@ -381,10 +376,10 @@ describe("transaction model", () => {
       ).toThrow(new ModelError("Transfer transactions cannot have a category"));
     });
 
-    it("rejects transfer without transferId", () => {
+    it("throws on transfer without transferId", () => {
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             type: TransactionType.TRANSFER_OUT,
             transferId: undefined,
@@ -396,10 +391,10 @@ describe("transaction model", () => {
       );
     });
 
-    it("rejects non-transfer with transferId", () => {
+    it("throws on non-transfer with transferId", () => {
       // Act & Assert
       expect(() =>
-        createTransactionModel(
+        TransactionEntity.create(
           fakeCreateTransactionInput({
             type: TransactionType.EXPENSE,
             transferId: faker.string.uuid(),
@@ -412,10 +407,135 @@ describe("transaction model", () => {
     });
   });
 
-  describe("updateTransactionModel", () => {
-    const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
-    const fixedDeps = { clock: fixedClock };
+  describe("fromPersistence", () => {
+    // Happy path
 
+    it("reconstructs instance from data", () => {
+      // Arrange
+      const data = fakeTransactionData();
+
+      // Act
+      const result = TransactionEntity.fromPersistence(data);
+
+      // Assert
+      expect(result.toData()).toEqual(data);
+    });
+
+    // Validation failures
+
+    it("throws on zero amount", () => {
+      // Arrange
+      const data = fakeTransactionData({ amount: 0 });
+
+      // Act & Assert
+      expect(() => TransactionEntity.fromPersistence(data)).toThrow(
+        new ModelError("Amount must be positive"),
+      );
+    });
+  });
+
+  describe("signedAmount", () => {
+    // Happy path
+
+    it("returns positive amount for INCOME transactions", () => {
+      // Arrange
+      const tx = fakeTransaction({
+        type: TransactionType.INCOME,
+        amount: 100,
+      });
+
+      // Act & Assert
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns positive amount for REFUND transactions", () => {
+      // Arrange
+      const tx = fakeTransaction({
+        type: TransactionType.REFUND,
+        amount: 100,
+      });
+
+      // Act & Assert
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns positive amount for TRANSFER_IN transactions", () => {
+      // Arrange
+      const tx = fakeTransaction({
+        type: TransactionType.TRANSFER_IN,
+        amount: 100,
+      });
+
+      // Act & Assert
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns negative amount for EXPENSE transactions", () => {
+      // Arrange
+      const tx = fakeTransaction({
+        type: TransactionType.EXPENSE,
+        amount: 100,
+      });
+
+      // Act & Assert
+      expect(tx.signedAmount).toBe(-100);
+    });
+
+    it("returns negative amount for TRANSFER_OUT transactions", () => {
+      // Arrange
+      const tx = fakeTransaction({
+        type: TransactionType.TRANSFER_OUT,
+        amount: 100,
+      });
+
+      // Act & Assert
+      expect(tx.signedAmount).toBe(-100);
+    });
+  });
+
+  describe("toData", () => {
+    // Happy path
+
+    it("returns plain object with all data fields", () => {
+      // Arrange
+      const data = fakeTransactionData();
+      const tx = TransactionEntity.fromPersistence(data);
+
+      // Act & Assert
+      expect(tx.toData()).toEqual(data);
+    });
+  });
+
+  describe("bumpVersion", () => {
+    // Happy path
+
+    it("increments version by 1", () => {
+      // Arrange
+      const existing = fakeTransaction({ version: 4 });
+
+      // Act
+      const result = existing.bumpVersion();
+
+      // Assert
+      expect(result.version).toBe(5);
+    });
+
+    it("preserves all other fields", () => {
+      // Arrange
+      const existing = fakeTransaction();
+
+      // Act
+      const result = existing.bumpVersion();
+
+      // Assert
+      expect(result.toData()).toEqual({
+        ...existing.toData(),
+        version: existing.version + 1,
+      });
+    });
+  });
+
+  describe("update", () => {
     // Happy path
 
     it("sets amount", () => {
@@ -423,11 +543,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ amount: 10 });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { amount: 20 },
-        fixedDeps,
-      );
+      const result = existing.update({ amount: 20 });
 
       // Assert
       expect(result.amount).toEqual(20);
@@ -440,11 +556,7 @@ describe("transaction model", () => {
       const newAccount = fakeAccount({ userId, currency: "EUR" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { account: newAccount },
-        fixedDeps,
-      );
+      const result = existing.update({ account: newAccount });
 
       // Assert
       expect(result.accountId).toBe(newAccount.id);
@@ -456,11 +568,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ currency: "GBP" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { account: undefined, amount: 1 },
-        fixedDeps,
-      );
+      const result = existing.update({ account: undefined, amount: 1 });
 
       // Assert
       expect(result.accountId).toBe(existing.accountId);
@@ -474,11 +582,7 @@ describe("transaction model", () => {
       const newCategory = fakeCategory({ userId, type: CategoryType.EXPENSE });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { category: newCategory },
-        fixedDeps,
-      );
+      const result = existing.update({ category: newCategory });
 
       // Assert
       expect(result.categoryId).toBe(newCategory.id);
@@ -489,11 +593,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ categoryId: faker.string.uuid() });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { category: null },
-        fixedDeps,
-      );
+      const result = existing.update({ category: null });
 
       // Assert
       expect(result.categoryId).toBeUndefined();
@@ -504,11 +604,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ categoryId: "existing-category" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { category: undefined, amount: 1 },
-        fixedDeps,
-      );
+      const result = existing.update({ category: undefined, amount: 1 });
 
       // Assert
       expect(result.categoryId).toBe("existing-category");
@@ -519,11 +615,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ description: "old" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { description: "  new  " },
-        fixedDeps,
-      );
+      const result = existing.update({ description: "  new  " });
 
       // Assert
       expect(result.description).toBe("new");
@@ -534,11 +626,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ description: "old" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { description: null },
-        fixedDeps,
-      );
+      const result = existing.update({ description: null });
 
       // Assert
       expect(result.description).toBeUndefined();
@@ -549,11 +637,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction({ description: "keep me" });
 
       // Act
-      const result = updateTransactionModel(
-        existing,
-        { description: undefined, amount: 1 },
-        fixedDeps,
-      );
+      const result = existing.update({ description: undefined, amount: 1 });
 
       // Assert
       expect(result.description).toBe("keep me");
@@ -571,7 +655,7 @@ describe("transaction model", () => {
       });
 
       // Act
-      const result = updateTransactionModel(existing, { amount: 1 }, fixedDeps);
+      const result = existing.update({ amount: 1 });
 
       // Assert
       expect(result.id).toBe("id-1");
@@ -582,11 +666,14 @@ describe("transaction model", () => {
     });
 
     it("sets updatedAt", () => {
+      const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
+      const fixedDeps = { clock: fixedClock };
+
       // Arrange
       const existing = fakeTransaction();
 
       // Act
-      const result = updateTransactionModel(existing, { amount: 1 }, fixedDeps);
+      const result = existing.update({ amount: 1 }, fixedDeps);
 
       // Assert
       expect(result.updatedAt).toBe("2000-01-02T10:11:12.000Z");
@@ -597,7 +684,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction();
 
       // Act
-      const result = updateTransactionModel(existing, { amount: 1 });
+      const result = existing.update({ amount: 1 });
 
       // Assert
       expect(result.updatedAt).toBeDefined();
@@ -605,60 +692,60 @@ describe("transaction model", () => {
 
     // Validation failures
 
-    it("rejects updating archived transaction", () => {
+    it("throws on updating archived transaction", () => {
       // Arrange
       const existing = fakeTransaction({ isArchived: true });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { amount: 5 }, fixedDeps),
-      ).toThrow(new ModelError("Cannot update archived transaction"));
+      expect(() => existing.update({ amount: 5 })).toThrow(
+        new ModelError("Cannot update archived transaction"),
+      );
     });
 
-    it("rejects zero amount", () => {
+    it("throws on zero amount", () => {
       // Arrange
       const existing = fakeTransaction();
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { amount: 0 }, fixedDeps),
-      ).toThrow(new ModelError("Amount must be positive"));
+      expect(() => existing.update({ amount: 0 })).toThrow(
+        new ModelError("Amount must be positive"),
+      );
     });
 
-    it("rejects negative amount", () => {
+    it("throws on negative amount", () => {
       // Arrange
       const existing = fakeTransaction();
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { amount: -1 }, fixedDeps),
-      ).toThrow(new ModelError("Amount must be positive"));
+      expect(() => existing.update({ amount: -1 })).toThrow(
+        new ModelError("Amount must be positive"),
+      );
     });
 
-    it("rejects account belonging to different user", () => {
+    it("throws when account belongs to different user", () => {
       // Arrange
       const existing = fakeTransaction({ userId: "user-a" });
       const account = fakeAccount({ userId: "user-b" });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { account }, fixedDeps),
-      ).toThrow(new ModelError("Account does not belong to user"));
+      expect(() => existing.update({ account })).toThrow(
+        new ModelError("Account does not belong to user"),
+      );
     });
 
-    it("rejects archived account", () => {
+    it("throws on archived account", () => {
       // Arrange
       const userId = faker.string.uuid();
       const existing = fakeTransaction({ userId });
       const account = fakeAccount({ userId, isArchived: true });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { account }, fixedDeps),
-      ).toThrow(new ModelError("Account must not be archived"));
+      expect(() => existing.update({ account })).toThrow(
+        new ModelError("Account must not be archived"),
+      );
     });
 
-    it("rejects category belonging to different user", () => {
+    it("throws when category belongs to different user", () => {
       // Arrange
       const existing = fakeTransaction({ userId: "user-a" });
       const category = fakeCategory({
@@ -667,12 +754,12 @@ describe("transaction model", () => {
       });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { category }, fixedDeps),
-      ).toThrow(new ModelError("Category does not belong to user"));
+      expect(() => existing.update({ category })).toThrow(
+        new ModelError("Category does not belong to user"),
+      );
     });
 
-    it("rejects archived category", () => {
+    it("throws on archived category", () => {
       // Arrange
       const userId = faker.string.uuid();
       const existing = fakeTransaction({ userId });
@@ -683,12 +770,12 @@ describe("transaction model", () => {
       });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { category }, fixedDeps),
-      ).toThrow(new ModelError("Category must not be archived"));
+      expect(() => existing.update({ category })).toThrow(
+        new ModelError("Category must not be archived"),
+      );
     });
 
-    it("rejects INCOME category on EXPENSE transaction", () => {
+    it("throws on INCOME category for EXPENSE transaction", () => {
       // Arrange
       const userId = faker.string.uuid();
       const existing = fakeTransaction({
@@ -698,14 +785,12 @@ describe("transaction model", () => {
       const category = fakeCategory({ userId, type: CategoryType.INCOME });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { category }, fixedDeps),
-      ).toThrow(
+      expect(() => existing.update({ category })).toThrow(
         new ModelError("Category type does not match transaction type"),
       );
     });
 
-    it("rejects setting category on transfer transaction", () => {
+    it("throws when setting category on transfer transaction", () => {
       // Arrange
       const userId = faker.string.uuid();
       const existing = fakeTransaction({
@@ -717,27 +802,25 @@ describe("transaction model", () => {
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { category }, fixedDeps),
-      ).toThrow(new ModelError("Transfer transactions cannot have a category"));
+      expect(() => existing.update({ category })).toThrow(
+        new ModelError("Transfer transactions cannot have a category"),
+      );
     });
 
-    it("rejects description exceeding max length", () => {
+    it("throws when description exceeds maximum length", () => {
       // Arrange
       const existing = fakeTransaction();
       const tooLong = "x".repeat(DESCRIPTION_MAX_LENGTH + 1);
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(existing, { description: tooLong }, fixedDeps),
-      ).toThrow(
+      expect(() => existing.update({ description: tooLong })).toThrow(
         new ModelError(
           `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
         ),
       );
     });
 
-    it("rejects switching non-transfer to transfer type", () => {
+    it("throws on switching non-transfer to transfer type", () => {
       // Arrange
       const existing = fakeTransaction({
         type: TransactionType.EXPENSE,
@@ -746,17 +829,13 @@ describe("transaction model", () => {
 
       // Act & Assert
       expect(() =>
-        updateTransactionModel(
-          existing,
-          { type: TransactionType.TRANSFER_OUT },
-          fixedDeps,
-        ),
+        existing.update({ type: TransactionType.TRANSFER_OUT }),
       ).toThrow(
         new ModelError("Transfer transactions must include transferId"),
       );
     });
 
-    it("rejects switching transfer to non-transfer type", () => {
+    it("throws on switching transfer to non-transfer type", () => {
       // Arrange
       const existing = fakeTransaction({
         type: TransactionType.TRANSFER_OUT,
@@ -765,22 +844,13 @@ describe("transaction model", () => {
       });
 
       // Act & Assert
-      expect(() =>
-        updateTransactionModel(
-          existing,
-          { type: TransactionType.EXPENSE },
-          fixedDeps,
-        ),
-      ).toThrow(
+      expect(() => existing.update({ type: TransactionType.EXPENSE })).toThrow(
         new ModelError("Only transfer transactions can include transferId"),
       );
     });
   });
 
-  describe("archiveTransactionModel", () => {
-    const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
-    const fixedDeps = { clock: fixedClock };
-
+  describe("archive", () => {
     // Happy path
 
     it("sets isArchived to true", () => {
@@ -788,7 +858,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction();
 
       // Act
-      const result = archiveTransactionModel(existing, fixedDeps);
+      const result = existing.archive();
 
       // Assert
       expect(result.isArchived).toBe(true);
@@ -796,10 +866,11 @@ describe("transaction model", () => {
 
     it("sets updatedAt", () => {
       // Arrange
+      const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
       const existing = fakeTransaction();
 
       // Act
-      const result = archiveTransactionModel(existing, fixedDeps);
+      const result = existing.archive({ clock: fixedClock });
 
       // Assert
       expect(result.updatedAt).toBe("2000-01-02T10:11:12.000Z");
@@ -810,7 +881,7 @@ describe("transaction model", () => {
       const existing = fakeTransaction();
 
       // Act
-      const result = archiveTransactionModel(existing);
+      const result = existing.archive();
 
       // Assert
       expect(result.updatedAt).toBeDefined();
@@ -818,64 +889,13 @@ describe("transaction model", () => {
 
     // Validation failures
 
-    it("rejects already archived transaction", () => {
+    it("throws on already archived transaction", () => {
       // Arrange
       const existing = fakeTransaction({ isArchived: true });
 
       // Act & Assert
-      expect(() => archiveTransactionModel(existing, fixedDeps)).toThrow(
+      expect(() => existing.archive()).toThrow(
         new ModelError("Cannot archive archived transaction"),
-      );
-    });
-  });
-
-  describe("getSignedAmount", () => {
-    it("returns positive amount for INCOME transactions", () => {
-      const transaction = fakeTransaction({
-        type: TransactionType.INCOME,
-        amount: 100,
-      });
-      expect(getSignedAmount(transaction)).toBe(100);
-    });
-
-    it("returns positive amount for REFUND transactions", () => {
-      const transaction = fakeTransaction({
-        type: TransactionType.REFUND,
-        amount: 100,
-      });
-      expect(getSignedAmount(transaction)).toBe(100);
-    });
-
-    it("returns positive amount for TRANSFER_IN transactions", () => {
-      const transaction = fakeTransaction({
-        type: TransactionType.TRANSFER_IN,
-        amount: 100,
-      });
-      expect(getSignedAmount(transaction)).toBe(100);
-    });
-
-    it("returns negative amount for EXPENSE transactions", () => {
-      const transaction = fakeTransaction({
-        type: TransactionType.EXPENSE,
-        amount: 100,
-      });
-      expect(getSignedAmount(transaction)).toBe(-100);
-    });
-
-    it("returns negative amount for TRANSFER_OUT transactions", () => {
-      const transaction = fakeTransaction({
-        type: TransactionType.TRANSFER_OUT,
-        amount: 100,
-      });
-      expect(getSignedAmount(transaction)).toBe(-100);
-    });
-
-    it("throws error for unknown transaction type", () => {
-      const transaction = fakeTransaction({
-        type: "UNKNOWN" as TransactionType,
-      });
-      expect(() => getSignedAmount(transaction)).toThrow(
-        "Unknown transaction type: UNKNOWN",
       );
     });
   });

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -10,9 +10,9 @@ import {
 } from "../utils/test-utils/models/transaction-fakes";
 import { CategoryType } from "./category";
 import { ModelError } from "./model-error";
-import { TransactionEntity, TransactionType } from "./transaction";
+import { Transaction, TransactionType } from "./transaction";
 
-describe("TransactionEntity", () => {
+describe("Transaction", () => {
   describe("create", () => {
     const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
     const fixedIdGenerator = () => "fixed-uuid";
@@ -36,7 +36,7 @@ describe("TransactionEntity", () => {
       });
 
       // Act
-      const result = TransactionEntity.create(input, fixedDeps);
+      const result = Transaction.create(input, fixedDeps);
 
       // Assert
       expect(result.toData()).toEqual({
@@ -59,7 +59,7 @@ describe("TransactionEntity", () => {
 
     it("builds transaction without category", () => {
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({ category: undefined }),
         fixedDeps,
       );
@@ -73,7 +73,7 @@ describe("TransactionEntity", () => {
       const account = fakeAccount({ currency: "GBP" });
 
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({ userId: account.userId, account }),
         fixedDeps,
       );
@@ -84,7 +84,7 @@ describe("TransactionEntity", () => {
 
     it("trims description", () => {
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({ description: "  spaced  " }),
         fixedDeps,
       );
@@ -99,7 +99,7 @@ describe("TransactionEntity", () => {
       const padded = `  ${withinLimit}  `;
 
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({ description: padded }),
         fixedDeps,
       );
@@ -110,7 +110,7 @@ describe("TransactionEntity", () => {
 
     it("sets description to undefined when empty after trim", () => {
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({ description: "   " }),
         fixedDeps,
       );
@@ -121,7 +121,7 @@ describe("TransactionEntity", () => {
 
     it("defaults isArchived to false", () => {
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput(),
         fixedDeps,
       );
@@ -132,7 +132,7 @@ describe("TransactionEntity", () => {
 
     it("sets createdAt equal to updatedAt", () => {
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput(),
         fixedDeps,
       );
@@ -143,7 +143,7 @@ describe("TransactionEntity", () => {
 
     it("sets id and timestamps with default dependencies", () => {
       // Act
-      const result = TransactionEntity.create(fakeCreateTransactionInput());
+      const result = Transaction.create(fakeCreateTransactionInput());
 
       // Assert
       expect(result.id).toBeDefined();
@@ -158,7 +158,7 @@ describe("TransactionEntity", () => {
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
 
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({
           userId,
           account,
@@ -178,7 +178,7 @@ describe("TransactionEntity", () => {
       const transferId = faker.string.uuid();
 
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({
           type: TransactionType.TRANSFER_OUT,
           transferId,
@@ -197,7 +197,7 @@ describe("TransactionEntity", () => {
       const transferId = faker.string.uuid();
 
       // Act
-      const result = TransactionEntity.create(
+      const result = Transaction.create(
         fakeCreateTransactionInput({
           type: TransactionType.TRANSFER_IN,
           transferId,
@@ -218,7 +218,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             userId: faker.string.uuid(),
             account,
@@ -235,7 +235,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ userId, account }),
           fixedDeps,
         ),
@@ -245,7 +245,7 @@ describe("TransactionEntity", () => {
     it("throws on zero amount", () => {
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ amount: 0 }),
           fixedDeps,
         ),
@@ -255,7 +255,7 @@ describe("TransactionEntity", () => {
     it("throws on negative amount", () => {
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ amount: -5 }),
           fixedDeps,
         ),
@@ -272,7 +272,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ userId, category }),
           fixedDeps,
         ),
@@ -290,7 +290,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ userId, category }),
           fixedDeps,
         ),
@@ -304,7 +304,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             userId,
             category,
@@ -324,7 +324,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             userId,
             category,
@@ -343,7 +343,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({ description: tooLong }),
           fixedDeps,
         ),
@@ -362,7 +362,7 @@ describe("TransactionEntity", () => {
 
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             userId,
             account,
@@ -378,7 +378,7 @@ describe("TransactionEntity", () => {
     it("throws on transfer without transferId", () => {
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             type: TransactionType.TRANSFER_OUT,
             transferId: undefined,
@@ -393,7 +393,7 @@ describe("TransactionEntity", () => {
     it("throws on non-transfer with transferId", () => {
       // Act & Assert
       expect(() =>
-        TransactionEntity.create(
+        Transaction.create(
           fakeCreateTransactionInput({
             type: TransactionType.EXPENSE,
             transferId: faker.string.uuid(),
@@ -414,7 +414,7 @@ describe("TransactionEntity", () => {
       const data = fakeTransaction().toData();
 
       // Act
-      const result = TransactionEntity.fromPersistence(data);
+      const result = Transaction.fromPersistence(data);
 
       // Assert
       expect(result.toData()).toEqual(data);
@@ -427,7 +427,7 @@ describe("TransactionEntity", () => {
       const data = { ...fakeTransaction().toData(), amount: 0 };
 
       // Act & Assert
-      expect(() => TransactionEntity.fromPersistence(data)).toThrow(
+      expect(() => Transaction.fromPersistence(data)).toThrow(
         new ModelError("Amount must be positive"),
       );
     });
@@ -498,7 +498,7 @@ describe("TransactionEntity", () => {
     it("returns plain object with all data fields", () => {
       // Arrange
       const data = fakeTransaction().toData();
-      const tx = TransactionEntity.fromPersistence(data);
+      const tx = Transaction.fromPersistence(data);
 
       // Act & Assert
       expect(tx.toData()).toEqual(data);

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -7,7 +7,6 @@ import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import {
   fakeCreateTransactionInput,
   fakeTransaction,
-  fakeTransactionData,
 } from "../utils/test-utils/models/transaction-fakes";
 import { CategoryType } from "./category";
 import { ModelError } from "./model-error";
@@ -412,7 +411,7 @@ describe("TransactionEntity", () => {
 
     it("reconstructs instance from data", () => {
       // Arrange
-      const data = fakeTransactionData();
+      const data = fakeTransaction().toData();
 
       // Act
       const result = TransactionEntity.fromPersistence(data);
@@ -425,7 +424,7 @@ describe("TransactionEntity", () => {
 
     it("throws on zero amount", () => {
       // Arrange
-      const data = fakeTransactionData({ amount: 0 });
+      const data = { ...fakeTransaction().toData(), amount: 0 };
 
       // Act & Assert
       expect(() => TransactionEntity.fromPersistence(data)).toThrow(
@@ -498,7 +497,7 @@ describe("TransactionEntity", () => {
 
     it("returns plain object with all data fields", () => {
       // Arrange
-      const data = fakeTransactionData();
+      const data = fakeTransaction().toData();
       const tx = TransactionEntity.fromPersistence(data);
 
       // Act & Assert

--- a/backend/src/models/transaction.test.ts
+++ b/backend/src/models/transaction.test.ts
@@ -431,6 +431,19 @@ describe("Transaction", () => {
         new ModelError("Amount must be positive"),
       );
     });
+
+    it("throws when transfer has categoryId", () => {
+      // Arrange
+      const data = {
+        ...fakeTransaction({ type: TransactionType.TRANSFER_OUT }).toData(),
+        categoryId: faker.string.uuid(),
+      };
+
+      // Act & Assert
+      expect(() => Transaction.fromPersistence(data)).toThrow(
+        new ModelError("Transfer transactions cannot have a category"),
+      );
+    });
   });
 
   describe("signedAmount", () => {
@@ -823,6 +836,7 @@ describe("Transaction", () => {
       // Arrange
       const existing = fakeTransaction({
         type: TransactionType.EXPENSE,
+        categoryId: undefined,
         transferId: undefined,
       });
 
@@ -832,6 +846,17 @@ describe("Transaction", () => {
       ).toThrow(
         new ModelError("Transfer transactions must include transferId"),
       );
+    });
+
+    it("throws when switching to transfer type without clearing category", () => {
+      // Arrange — existing transaction has categoryId; switching type to
+      // transfer surfaces the category invariant first
+      const existing = fakeTransaction({ type: TransactionType.EXPENSE });
+
+      // Act & Assert
+      expect(() =>
+        existing.update({ type: TransactionType.TRANSFER_OUT }),
+      ).toThrow(new ModelError("Transfer transactions cannot have a category"));
     });
 
     it("throws on switching transfer to non-transfer type", () => {

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -19,8 +19,7 @@ export type NonTransferTransactionType = Exclude<
 >;
 
 // Plain data shape.
-// Used anywhere a value (not a domain object) is needed.
-export interface TransactionData {
+interface TransactionData {
   userId: string;
   id: string;
   accountId: string;

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -18,21 +18,306 @@ export type NonTransferTransactionType = Exclude<
   TransactionType.TRANSFER_IN | TransactionType.TRANSFER_OUT
 >;
 
-export interface Transaction {
-  userId: string; // Partition key (same pattern as other entities)
-  id: string; // Sort key - UUID v4
-  accountId: string; // Foreign key to Account
-  categoryId?: string; // Optional foreign key to Category
-  type: TransactionType; // Transaction type (matches category type)
-  amount: number; // Transaction amount (positive value)
-  currency: string; // ISO currency code (inherited from account)
-  date: DateString; // Transaction date (YYYY-MM-DD format)
-  description?: string; // Optional description
-  transferId?: string; // Optional UUID linking paired transfer transactions
-  isArchived: boolean; // Soft delete flag
-  version: number; // OCC token
-  createdAt: string; // ISO timestamp
-  updatedAt: string; // ISO timestamp
+// Plain data shape.
+// Used anywhere a value (not a domain object) is needed.
+export interface TransactionData {
+  userId: string;
+  id: string;
+  accountId: string;
+  categoryId?: string;
+  type: TransactionType;
+  amount: number;
+  currency: string;
+  date: DateString;
+  description?: string;
+  transferId?: string;
+  isArchived: boolean;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Transaction extends TransactionData {
+  readonly signedAmount: number;
+  toData(): TransactionData;
+  bumpVersion(): Transaction;
+  update(
+    input: UpdateTransactionInput,
+    deps?: { clock?: () => Date },
+  ): Transaction;
+  archive(deps?: { clock?: () => Date }): Transaction;
+}
+
+export class TransactionEntity implements Transaction {
+  readonly userId: string;
+  readonly id: string;
+  readonly accountId: string;
+  readonly categoryId?: string;
+  readonly type: TransactionType;
+  readonly amount: number;
+  readonly currency: string;
+  readonly date: DateString;
+  readonly description?: string;
+  readonly transferId?: string;
+  readonly isArchived: boolean;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  static create(
+    input: CreateTransactionInput,
+    {
+      clock = () => new Date(),
+      idGenerator = randomUUID,
+    }: { clock?: () => Date; idGenerator?: () => string } = {},
+  ) {
+    const { account, category } = input;
+    const now = clock().toISOString();
+
+    const data: TransactionData = {
+      id: idGenerator(),
+      userId: input.userId,
+      accountId: account.id,
+      categoryId: category?.id,
+      type: input.type,
+      amount: input.amount,
+      currency: account.currency,
+      date: input.date,
+      description: normalizeDescription(input.description),
+      transferId: input.transferId,
+      isArchived: false,
+      version: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return new TransactionEntity(data, {
+      newAccount: account,
+      newCategory: category,
+    });
+  }
+
+  static fromPersistence(data: TransactionData): TransactionEntity {
+    return new TransactionEntity(data);
+  }
+
+  get signedAmount(): number {
+    switch (this.type) {
+      case TransactionType.INCOME:
+      case TransactionType.REFUND:
+      case TransactionType.TRANSFER_IN:
+        return this.amount;
+      case TransactionType.EXPENSE:
+      case TransactionType.TRANSFER_OUT:
+        return -this.amount;
+      default:
+        throw new Error(`Unknown transaction type: ${this.type}`);
+    }
+  }
+
+  toData(): TransactionData {
+    return {
+      userId: this.userId,
+      id: this.id,
+      accountId: this.accountId,
+      categoryId: this.categoryId,
+      type: this.type,
+      amount: this.amount,
+      currency: this.currency,
+      date: this.date,
+      description: this.description,
+      transferId: this.transferId,
+      isArchived: this.isArchived,
+      version: this.version,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  bumpVersion() {
+    return new TransactionEntity(
+      {
+        ...this.toData(),
+        version: this.version + 1,
+      },
+      undefined,
+      { skipInvariants: true },
+    );
+  }
+
+  update(
+    input: UpdateTransactionInput,
+    { clock = () => new Date() }: { clock?: () => Date } = {},
+  ): TransactionEntity {
+    if (this.isArchived) {
+      throw new ModelError("Cannot update archived transaction");
+    }
+
+    const { account, category } = input;
+    const now = clock().toISOString();
+
+    const newCategoryId =
+      category === undefined // Keep existing category
+        ? this.categoryId
+        : category === null // Remove category
+          ? undefined
+          : category.id;
+
+    const newDescription =
+      input.description === undefined // Keep existing description
+        ? this.description
+        : input.description === null // Remove description
+          ? undefined
+          : normalizeDescription(input.description);
+
+    const data: TransactionData = {
+      ...this.toData(),
+      ...(account && { accountId: account.id, currency: account.currency }),
+      categoryId: newCategoryId,
+      type: input.type ?? this.type,
+      amount: input.amount ?? this.amount,
+      date: input.date ?? this.date,
+      description: newDescription,
+      updatedAt: now,
+    };
+
+    return new TransactionEntity(data, {
+      newAccount: account,
+      newCategory: category ?? undefined,
+    });
+  }
+
+  archive({
+    clock = () => new Date(),
+  }: { clock?: () => Date } = {}): TransactionEntity {
+    if (this.isArchived) {
+      throw new ModelError("Cannot archive archived transaction");
+    }
+
+    const now = clock().toISOString();
+
+    const data: TransactionData = {
+      ...this.toData(),
+      isArchived: true,
+      updatedAt: now,
+    };
+
+    return new TransactionEntity(data);
+  }
+
+  private constructor(
+    data: TransactionData,
+    transientRelations?: { newAccount?: Account; newCategory?: Category },
+    { skipInvariants = false }: { skipInvariants?: boolean } = {},
+  ) {
+    if (!skipInvariants) {
+      TransactionEntity.assertInvariants(data, transientRelations);
+    }
+
+    this.userId = data.userId;
+    this.id = data.id;
+    this.accountId = data.accountId;
+    this.categoryId = data.categoryId;
+    this.type = data.type;
+    this.amount = data.amount;
+    this.currency = data.currency;
+    this.date = data.date;
+    this.description = data.description;
+    this.transferId = data.transferId;
+    this.isArchived = data.isArchived;
+    this.version = data.version;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+
+  private static assertInvariants(
+    data: TransactionData,
+    transientRelations?: { newAccount?: Account; newCategory?: Category },
+  ): void {
+    const newAccount = transientRelations?.newAccount;
+    const newCategory = transientRelations?.newCategory;
+
+    if (newAccount) {
+      if (newAccount.userId !== data.userId) {
+        throw new ModelError("Account does not belong to user");
+      }
+
+      if (newAccount.isArchived) {
+        throw new ModelError("Account must not be archived");
+      }
+    }
+
+    if (data.amount <= 0) {
+      throw new ModelError("Amount must be positive");
+    }
+
+    const isTransfer =
+      data.type === TransactionType.TRANSFER_IN ||
+      data.type === TransactionType.TRANSFER_OUT;
+
+    if (isTransfer && newCategory) {
+      throw new ModelError("Transfer transactions cannot have a category");
+    }
+
+    if (isTransfer) {
+      if (!data.transferId) {
+        throw new ModelError("Transfer transactions must include transferId");
+      }
+    } else {
+      if (data.transferId) {
+        throw new ModelError(
+          "Only transfer transactions can include transferId",
+        );
+      }
+    }
+
+    if (newCategory) {
+      if (newCategory.userId !== data.userId) {
+        throw new ModelError("Category does not belong to user");
+      }
+
+      if (newCategory.isArchived) {
+        throw new ModelError("Category must not be archived");
+      }
+
+      const typeMismatch =
+        (newCategory.type === CategoryType.INCOME &&
+          data.type !== TransactionType.INCOME) ||
+        (newCategory.type === CategoryType.EXPENSE &&
+          data.type !== TransactionType.EXPENSE &&
+          data.type !== TransactionType.REFUND);
+
+      if (typeMismatch) {
+        throw new ModelError("Category type does not match transaction type");
+      }
+    }
+
+    if (data.description && data.description.length > DESCRIPTION_MAX_LENGTH) {
+      throw new ModelError(
+        `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+      );
+    }
+  }
+}
+
+export interface CreateTransactionInput {
+  userId: string;
+  account: Account;
+  category?: Category;
+  type: TransactionType;
+  amount: number;
+  date: DateString;
+  description?: string;
+  transferId?: string;
+}
+
+export interface UpdateTransactionInput {
+  account?: Account;
+  category?: Category | null;
+  type?: TransactionType;
+  amount?: number;
+  date?: DateString;
+  description?: string | null;
 }
 
 // Most popular combinations of account and category
@@ -47,213 +332,6 @@ export enum TransactionPatternType {
   INCOME = "INCOME",
   EXPENSE = "EXPENSE",
   REFUND = "REFUND",
-}
-
-export interface CreateTransactionInput {
-  userId: string;
-  account: Account;
-  category?: Category;
-  type: TransactionType;
-  amount: number;
-  date: DateString;
-  description?: string;
-  transferId?: string;
-}
-
-export function createTransactionModel(
-  input: CreateTransactionInput,
-  {
-    clock = () => new Date(),
-    idGenerator = randomUUID,
-  }: { clock?: () => Date; idGenerator?: () => string } = {},
-): Transaction {
-  const { account, category } = input;
-  const now = clock().toISOString();
-
-  const transaction: Transaction = {
-    id: idGenerator(),
-    userId: input.userId,
-    accountId: account.id,
-    categoryId: category?.id,
-    type: input.type,
-    amount: input.amount,
-    currency: account.currency,
-    date: input.date,
-    description: normalizeDescription(input.description),
-    transferId: input.transferId,
-    isArchived: false,
-    version: 0,
-    createdAt: now,
-    updatedAt: now,
-  };
-
-  assertTransactionInvariants({
-    transaction,
-    newAccount: account,
-    newCategory: category,
-  });
-
-  return transaction;
-}
-
-export interface UpdateTransactionInput {
-  account?: Account;
-  category?: Category | null;
-  type?: TransactionType;
-  amount?: number;
-  date?: DateString;
-  description?: string | null;
-}
-
-export function updateTransactionModel(
-  transaction: Transaction,
-  input: UpdateTransactionInput,
-  { clock = () => new Date() }: { clock?: () => Date } = {},
-): Transaction {
-  if (transaction.isArchived) {
-    throw new ModelError("Cannot update archived transaction");
-  }
-
-  const { account, category } = input;
-  const now = clock().toISOString();
-
-  const newCategoryId =
-    category === undefined // Not overriding category
-      ? transaction.categoryId
-      : category === null // Explicitly removing category
-        ? undefined
-        : category.id;
-
-  const newDescription =
-    input.description === undefined // Not overriding description
-      ? transaction.description
-      : input.description === null // Explicitly removing description
-        ? undefined
-        : normalizeDescription(input.description);
-
-  const updatedTransaction: Transaction = {
-    ...transaction,
-    accountId: account ? account.id : transaction.accountId,
-    categoryId: newCategoryId,
-    type: input.type ?? transaction.type,
-    amount: input.amount ?? transaction.amount,
-    currency: account ? account.currency : transaction.currency,
-    date: input.date ?? transaction.date,
-    description: newDescription,
-    updatedAt: now,
-  };
-
-  assertTransactionInvariants({
-    transaction: updatedTransaction,
-    newAccount: account,
-    newCategory: category ?? undefined,
-  });
-
-  return updatedTransaction;
-}
-
-export function archiveTransactionModel(
-  transaction: Transaction,
-  { clock = () => new Date() }: { clock?: () => Date } = {},
-): Transaction {
-  if (transaction.isArchived) {
-    throw new ModelError("Cannot archive archived transaction");
-  }
-
-  return {
-    ...transaction,
-    isArchived: true,
-    updatedAt: clock().toISOString(),
-  };
-}
-
-// Get signed amount based on transaction type
-// Positive for INCOME, REFUND, TRANSFER_IN
-// Negative for EXPENSE, TRANSFER_OUT
-export function getSignedAmount(transaction: Transaction): number {
-  switch (transaction.type) {
-    case TransactionType.INCOME:
-    case TransactionType.REFUND:
-    case TransactionType.TRANSFER_IN:
-      return transaction.amount;
-    case TransactionType.EXPENSE:
-    case TransactionType.TRANSFER_OUT:
-      return -transaction.amount;
-    default:
-      throw new Error(`Unknown transaction type: ${transaction.type}`);
-  }
-}
-
-function assertTransactionInvariants({
-  transaction,
-  newAccount,
-  newCategory,
-}: {
-  transaction: Transaction;
-  newAccount?: Account;
-  newCategory?: Category;
-}): void {
-  if (newAccount) {
-    if (newAccount.userId !== transaction.userId) {
-      throw new ModelError("Account does not belong to user");
-    }
-
-    if (newAccount.isArchived) {
-      throw new ModelError("Account must not be archived");
-    }
-  }
-
-  if (transaction.amount <= 0) {
-    throw new ModelError("Amount must be positive");
-  }
-
-  const isTransfer =
-    transaction.type === TransactionType.TRANSFER_IN ||
-    transaction.type === TransactionType.TRANSFER_OUT;
-
-  if (isTransfer && newCategory) {
-    throw new ModelError("Transfer transactions cannot have a category");
-  }
-
-  if (isTransfer) {
-    if (!transaction.transferId) {
-      throw new ModelError("Transfer transactions must include transferId");
-    }
-  } else {
-    if (transaction.transferId) {
-      throw new ModelError("Only transfer transactions can include transferId");
-    }
-  }
-
-  if (newCategory) {
-    if (newCategory.userId !== transaction.userId) {
-      throw new ModelError("Category does not belong to user");
-    }
-
-    if (newCategory.isArchived) {
-      throw new ModelError("Category must not be archived");
-    }
-
-    const typeMismatch =
-      (newCategory.type === CategoryType.INCOME &&
-        transaction.type !== TransactionType.INCOME) ||
-      (newCategory.type === CategoryType.EXPENSE &&
-        transaction.type !== TransactionType.EXPENSE &&
-        transaction.type !== TransactionType.REFUND);
-
-    if (typeMismatch) {
-      throw new ModelError("Category type does not match transaction type");
-    }
-  }
-
-  if (
-    transaction.description &&
-    transaction.description.length > DESCRIPTION_MAX_LENGTH
-  ) {
-    throw new ModelError(
-      `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-    );
-  }
 }
 
 function normalizeDescription(description?: string | null): string | undefined {

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -21,7 +21,7 @@ export type NonTransferTransactionType = Exclude<
 const defaultClock = () => new Date();
 
 // Plain data shape.
-interface TransactionData {
+export interface TransactionData {
   userId: string;
   id: string;
   accountId: string;
@@ -60,7 +60,7 @@ export class Transaction implements TransactionData {
       clock = defaultClock,
       idGenerator = randomUUID,
     }: { clock?: () => Date; idGenerator?: () => string } = {},
-  ) {
+  ): Transaction {
     const { account, category } = input;
     const now = clock().toISOString();
 
@@ -100,8 +100,6 @@ export class Transaction implements TransactionData {
       case TransactionType.EXPENSE:
       case TransactionType.TRANSFER_OUT:
         return -this.amount;
-      default:
-        throw new Error(`Unknown transaction type: ${this.type}`);
     }
   }
 
@@ -124,7 +122,7 @@ export class Transaction implements TransactionData {
     };
   }
 
-  bumpVersion() {
+  bumpVersion(): Transaction {
     return new Transaction(
       {
         ...this.toData(),
@@ -245,7 +243,7 @@ export class Transaction implements TransactionData {
       data.type === TransactionType.TRANSFER_IN ||
       data.type === TransactionType.TRANSFER_OUT;
 
-    if (isTransfer && newCategory) {
+    if (isTransfer && data.categoryId) {
       throw new ModelError("Transfer transactions cannot have a category");
     }
 

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -38,7 +38,7 @@ interface TransactionData {
   updatedAt: string;
 }
 
-export class Transaction {
+export class Transaction implements TransactionData {
   readonly userId: string;
   readonly id: string;
   readonly accountId: string;

--- a/backend/src/models/transaction.ts
+++ b/backend/src/models/transaction.ts
@@ -18,6 +18,8 @@ export type NonTransferTransactionType = Exclude<
   TransactionType.TRANSFER_IN | TransactionType.TRANSFER_OUT
 >;
 
+const defaultClock = () => new Date();
+
 // Plain data shape.
 interface TransactionData {
   userId: string;
@@ -36,18 +38,7 @@ interface TransactionData {
   updatedAt: string;
 }
 
-export interface Transaction extends TransactionData {
-  readonly signedAmount: number;
-  toData(): TransactionData;
-  bumpVersion(): Transaction;
-  update(
-    input: UpdateTransactionInput,
-    deps?: { clock?: () => Date },
-  ): Transaction;
-  archive(deps?: { clock?: () => Date }): Transaction;
-}
-
-export class TransactionEntity implements Transaction {
+export class Transaction {
   readonly userId: string;
   readonly id: string;
   readonly accountId: string;
@@ -66,7 +57,7 @@ export class TransactionEntity implements Transaction {
   static create(
     input: CreateTransactionInput,
     {
-      clock = () => new Date(),
+      clock = defaultClock,
       idGenerator = randomUUID,
     }: { clock?: () => Date; idGenerator?: () => string } = {},
   ) {
@@ -90,14 +81,14 @@ export class TransactionEntity implements Transaction {
       updatedAt: now,
     };
 
-    return new TransactionEntity(data, {
+    return new Transaction(data, {
       newAccount: account,
       newCategory: category,
     });
   }
 
-  static fromPersistence(data: TransactionData): TransactionEntity {
-    return new TransactionEntity(data);
+  static fromPersistence(data: TransactionData): Transaction {
+    return new Transaction(data);
   }
 
   get signedAmount(): number {
@@ -134,20 +125,21 @@ export class TransactionEntity implements Transaction {
   }
 
   bumpVersion() {
-    return new TransactionEntity(
+    return new Transaction(
       {
         ...this.toData(),
         version: this.version + 1,
       },
       undefined,
+      // Version bump leaves all invariant-bearing fields unchanged.
       { skipInvariants: true },
     );
   }
 
   update(
     input: UpdateTransactionInput,
-    { clock = () => new Date() }: { clock?: () => Date } = {},
-  ): TransactionEntity {
+    { clock = defaultClock }: { clock?: () => Date } = {},
+  ): Transaction {
     if (this.isArchived) {
       throw new ModelError("Cannot update archived transaction");
     }
@@ -171,6 +163,7 @@ export class TransactionEntity implements Transaction {
 
     const data: TransactionData = {
       ...this.toData(),
+      // Override account fields only when a new account is provided.
       ...(account && { accountId: account.id, currency: account.currency }),
       categoryId: newCategoryId,
       type: input.type ?? this.type,
@@ -180,15 +173,13 @@ export class TransactionEntity implements Transaction {
       updatedAt: now,
     };
 
-    return new TransactionEntity(data, {
+    return new Transaction(data, {
       newAccount: account,
       newCategory: category ?? undefined,
     });
   }
 
-  archive({
-    clock = () => new Date(),
-  }: { clock?: () => Date } = {}): TransactionEntity {
+  archive({ clock = defaultClock }: { clock?: () => Date } = {}): Transaction {
     if (this.isArchived) {
       throw new ModelError("Cannot archive archived transaction");
     }
@@ -201,7 +192,7 @@ export class TransactionEntity implements Transaction {
       updatedAt: now,
     };
 
-    return new TransactionEntity(data);
+    return new Transaction(data);
   }
 
   private constructor(
@@ -210,7 +201,7 @@ export class TransactionEntity implements Transaction {
     { skipInvariants = false }: { skipInvariants?: boolean } = {},
   ) {
     if (!skipInvariants) {
-      TransactionEntity.assertInvariants(data, transientRelations);
+      Transaction.assertInvariants(data, transientRelations);
     }
 
     this.userId = data.userId;

--- a/backend/src/repositories/dyn-transaction-repository.test.ts
+++ b/backend/src/repositories/dyn-transaction-repository.test.ts
@@ -7,6 +7,7 @@ import { faker } from "@faker-js/faker";
 import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
 import {
   Transaction,
+  TransactionEntity,
   TransactionPatternType,
   TransactionType,
 } from "../models/transaction";
@@ -1807,17 +1808,19 @@ describe("DynTransactionRepository", () => {
       await repository.create(created);
 
       // Act
-      const updated = await repository.update({
-        ...created,
-        accountId: faker.string.uuid(),
-        categoryId: faker.string.uuid(),
-        type: TransactionType.INCOME,
-        amount: 100.0,
-        currency: "EUR",
-        date: toDateString("2024-02-01"),
-        description: "Updated description",
-        updatedAt: new Date().toISOString(),
-      });
+      const updated = await repository.update(
+        TransactionEntity.fromPersistence({
+          ...created.toData(),
+          accountId: faker.string.uuid(),
+          categoryId: faker.string.uuid(),
+          type: TransactionType.INCOME,
+          amount: 100.0,
+          currency: "EUR",
+          date: toDateString("2024-02-01"),
+          description: "Updated description",
+          updatedAt: new Date().toISOString(),
+        }),
+      );
 
       // Assert
       const stored = await repository.findOneById({
@@ -1833,7 +1836,9 @@ describe("DynTransactionRepository", () => {
       await repository.create(created);
 
       // Act
-      const updated = await repository.update({ ...created, amount: 50 });
+      const updated = await repository.update(
+        TransactionEntity.fromPersistence({ ...created.toData(), amount: 50 }),
+      );
 
       // Assert
       expect(updated.version).toBe(created.version + 1);
@@ -1856,12 +1861,14 @@ describe("DynTransactionRepository", () => {
       await repository.create(created);
 
       // Act
-      await repository.update({
-        ...created,
-        description: undefined,
-        categoryId: undefined,
-        updatedAt: new Date().toISOString(),
-      });
+      await repository.update(
+        TransactionEntity.fromPersistence({
+          ...created.toData(),
+          description: undefined,
+          categoryId: undefined,
+          updatedAt: new Date().toISOString(),
+        }),
+      );
 
       // Assert
       const stored = await repository.findOneById({
@@ -1887,11 +1894,13 @@ describe("DynTransactionRepository", () => {
       );
 
       // Act
-      await repository.update({
-        ...created,
-        amount: 999,
-        updatedAt: new Date().toISOString(),
-      });
+      await repository.update(
+        TransactionEntity.fromPersistence({
+          ...created.toData(),
+          amount: 999,
+          updatedAt: new Date().toISOString(),
+        }),
+      );
 
       // Assert
       const { Item: after } = await client.send(
@@ -1909,10 +1918,15 @@ describe("DynTransactionRepository", () => {
       // Arrange — row at v0, then bumped to v1 by a first update
       const created = fakeTransaction({ version: 0 });
       await repository.create(created);
-      await repository.update({ ...created, amount: 50 });
+      await repository.update(
+        TransactionEntity.fromPersistence({ ...created.toData(), amount: 50 }),
+      );
 
       // Stale write expects v0 but disk is at v1
-      const staleUpdate = { ...created, amount: 99 };
+      const staleUpdate = TransactionEntity.fromPersistence({
+        ...created.toData(),
+        amount: 99,
+      });
 
       // Act & Assert
       await expect(repository.update(staleUpdate)).rejects.toThrow(
@@ -1939,7 +1953,12 @@ describe("DynTransactionRepository", () => {
 
       // Act & Assert - Write as different user, partition key mismatch => condition fails
       await expect(
-        repository.update({ ...created, userId: other }),
+        repository.update(
+          TransactionEntity.fromPersistence({
+            ...created.toData(),
+            userId: other,
+          }),
+        ),
       ).rejects.toThrow("Transaction not found");
 
       // Verify original transaction is unchanged
@@ -1965,12 +1984,14 @@ describe("DynTransactionRepository", () => {
 
       // Act
       const updatedTransactions = await repository.updateMany(
-        transactions.map((transaction) => ({
-          ...transaction,
-          amount: transaction.amount + 100,
-          description: "Updated",
-          updatedAt: new Date().toISOString(),
-        })),
+        transactions.map((transaction) =>
+          TransactionEntity.fromPersistence({
+            ...transaction.toData(),
+            amount: transaction.amount + 100,
+            description: "Updated",
+            updatedAt: new Date().toISOString(),
+          }),
+        ),
       );
 
       // Assert
@@ -1994,7 +2015,12 @@ describe("DynTransactionRepository", () => {
 
       // Act
       const updated = await repository.updateMany(
-        transactions.map((transaction) => ({ ...transaction, amount: 50 })),
+        transactions.map((transaction) =>
+          TransactionEntity.fromPersistence({
+            ...transaction.toData(),
+            amount: 50,
+          }),
+        ),
       );
 
       // Assert
@@ -2022,9 +2048,16 @@ describe("DynTransactionRepository", () => {
       // Act & Assert
       await expect(
         repository.updateMany([
-          { ...transaction1, amount: 11 },
+          TransactionEntity.fromPersistence({
+            ...transaction1.toData(),
+            amount: 11,
+          }),
           // transaction2 is stale because current version is 2, update assumes it's 1
-          { ...transaction2, amount: 22, version: 1 },
+          TransactionEntity.fromPersistence({
+            ...transaction2.toData(),
+            amount: 22,
+            version: 1,
+          }),
         ]),
       ).rejects.toThrow(VersionConflictError);
 
@@ -2052,7 +2085,11 @@ describe("DynTransactionRepository", () => {
 
       // Act
       const promise = repository.updateMany([
-        { ...existing, amount: 999, updatedAt: new Date().toISOString() },
+        TransactionEntity.fromPersistence({
+          ...existing.toData(),
+          amount: 999,
+          updatedAt: new Date().toISOString(),
+        }),
         missing,
       ]);
 

--- a/backend/src/repositories/dyn-transaction-repository.test.ts
+++ b/backend/src/repositories/dyn-transaction-repository.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { faker } from "@faker-js/faker";
 import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import { CategoryType } from "../models/category";
 import {
   Transaction,
   TransactionEntity,
@@ -16,6 +17,8 @@ import { toDateString } from "../types/date";
 import { createDynamoDBDocumentClient } from "../utils/dynamo-client";
 import { requireEnv } from "../utils/require-env";
 import { truncateTable } from "../utils/test-utils/dynamodb-helpers";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
 import { DynTransactionRepository } from "./dyn-transaction-repository";
 
@@ -1803,22 +1806,21 @@ describe("DynTransactionRepository", () => {
         currency: "USD",
         date: toDateString("2024-01-20"),
         description: "Original description",
-        categoryId: faker.string.uuid(),
       });
       await repository.create(created);
 
+      const newAccount = fakeAccount({ userId, currency: "EUR" });
+      const newCategory = fakeCategory({ userId, type: CategoryType.INCOME });
+
       // Act
       const updated = await repository.update(
-        TransactionEntity.fromPersistence({
-          ...created.toData(),
-          accountId: faker.string.uuid(),
-          categoryId: faker.string.uuid(),
+        created.update({
+          account: newAccount,
+          category: newCategory,
           type: TransactionType.INCOME,
           amount: 100.0,
-          currency: "EUR",
           date: toDateString("2024-02-01"),
           description: "Updated description",
-          updatedAt: new Date().toISOString(),
         }),
       );
 
@@ -1836,9 +1838,7 @@ describe("DynTransactionRepository", () => {
       await repository.create(created);
 
       // Act
-      const updated = await repository.update(
-        TransactionEntity.fromPersistence({ ...created.toData(), amount: 50 }),
-      );
+      const updated = await repository.update(created.update({ amount: 50 }));
 
       // Assert
       expect(updated.version).toBe(created.version + 1);
@@ -1862,12 +1862,7 @@ describe("DynTransactionRepository", () => {
 
       // Act
       await repository.update(
-        TransactionEntity.fromPersistence({
-          ...created.toData(),
-          description: undefined,
-          categoryId: undefined,
-          updatedAt: new Date().toISOString(),
-        }),
+        created.update({ description: null, category: null }),
       );
 
       // Assert
@@ -1894,13 +1889,7 @@ describe("DynTransactionRepository", () => {
       );
 
       // Act
-      await repository.update(
-        TransactionEntity.fromPersistence({
-          ...created.toData(),
-          amount: 999,
-          updatedAt: new Date().toISOString(),
-        }),
-      );
+      await repository.update(created.update({ amount: 999 }));
 
       // Assert
       const { Item: after } = await client.send(
@@ -1918,15 +1907,10 @@ describe("DynTransactionRepository", () => {
       // Arrange — row at v0, then bumped to v1 by a first update
       const created = fakeTransaction({ version: 0 });
       await repository.create(created);
-      await repository.update(
-        TransactionEntity.fromPersistence({ ...created.toData(), amount: 50 }),
-      );
+      await repository.update(created.update({ amount: 50 }));
 
       // Stale write expects v0 but disk is at v1
-      const staleUpdate = TransactionEntity.fromPersistence({
-        ...created.toData(),
-        amount: 99,
-      });
+      const staleUpdate = created.update({ amount: 99 });
 
       // Act & Assert
       await expect(repository.update(staleUpdate)).rejects.toThrow(
@@ -1985,11 +1969,9 @@ describe("DynTransactionRepository", () => {
       // Act
       const updatedTransactions = await repository.updateMany(
         transactions.map((transaction) =>
-          TransactionEntity.fromPersistence({
-            ...transaction.toData(),
+          transaction.update({
             amount: transaction.amount + 100,
             description: "Updated",
-            updatedAt: new Date().toISOString(),
           }),
         ),
       );
@@ -2015,12 +1997,7 @@ describe("DynTransactionRepository", () => {
 
       // Act
       const updated = await repository.updateMany(
-        transactions.map((transaction) =>
-          TransactionEntity.fromPersistence({
-            ...transaction.toData(),
-            amount: 50,
-          }),
-        ),
+        transactions.map((transaction) => transaction.update({ amount: 50 })),
       );
 
       // Assert
@@ -2048,10 +2025,7 @@ describe("DynTransactionRepository", () => {
       // Act & Assert
       await expect(
         repository.updateMany([
-          TransactionEntity.fromPersistence({
-            ...transaction1.toData(),
-            amount: 11,
-          }),
+          transaction1.update({ amount: 11 }),
           // transaction2 is stale because current version is 2, update assumes it's 1
           TransactionEntity.fromPersistence({
             ...transaction2.toData(),
@@ -2085,11 +2059,7 @@ describe("DynTransactionRepository", () => {
 
       // Act
       const promise = repository.updateMany([
-        TransactionEntity.fromPersistence({
-          ...existing.toData(),
-          amount: 999,
-          updatedAt: new Date().toISOString(),
-        }),
+        existing.update({ amount: 999 }),
         missing,
       ]);
 

--- a/backend/src/repositories/dyn-transaction-repository.test.ts
+++ b/backend/src/repositories/dyn-transaction-repository.test.ts
@@ -2333,7 +2333,6 @@ describe("DynTransactionRepository", () => {
       const categoryIncome = faker.string.uuid();
       const categoryExpense = faker.string.uuid();
       const categoryRefund = faker.string.uuid();
-      const categoryTransfer = faker.string.uuid();
 
       const transactions = [
         // Income transactions
@@ -2379,7 +2378,6 @@ describe("DynTransactionRepository", () => {
         fakeTransaction({
           userId,
           accountId,
-          categoryId: categoryTransfer,
           type: TransactionType.TRANSFER_IN,
         }),
       ];

--- a/backend/src/repositories/dyn-transaction-repository.test.ts
+++ b/backend/src/repositories/dyn-transaction-repository.test.ts
@@ -8,7 +8,6 @@ import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
 import { CategoryType } from "../models/category";
 import {
   Transaction,
-  TransactionEntity,
   TransactionPatternType,
   TransactionType,
 } from "../models/transaction";
@@ -1938,7 +1937,7 @@ describe("DynTransactionRepository", () => {
       // Act & Assert - Write as different user, partition key mismatch => condition fails
       await expect(
         repository.update(
-          TransactionEntity.fromPersistence({
+          Transaction.fromPersistence({
             ...created.toData(),
             userId: other,
           }),
@@ -2027,7 +2026,7 @@ describe("DynTransactionRepository", () => {
         repository.updateMany([
           transaction1.update({ amount: 11 }),
           // transaction2 is stale because current version is 2, update assumes it's 1
-          TransactionEntity.fromPersistence({
+          Transaction.fromPersistence({
             ...transaction2.toData(),
             amount: 22,
             version: 1,

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -123,7 +123,7 @@ function toTransaction(dbItem: TransactionDbItem): Transaction {
 }
 
 // Transform Transaction to TransactionDbItem by adding createdAtSortable
-function toTransactionDbItemToCreate(
+function toTransactionDbItemForCreate(
   transaction: Transaction,
 ): TransactionDbItem {
   const data = transaction.toData();
@@ -476,7 +476,7 @@ export class DynTransactionRepository
   async create(transaction: Readonly<Transaction>): Promise<void> {
     try {
       const dbItem: TransactionDbItem =
-        toTransactionDbItemToCreate(transaction);
+        toTransactionDbItemForCreate(transaction);
 
       const command = new PutCommand({
         TableName: this.tableName,
@@ -521,7 +521,7 @@ export class DynTransactionRepository
 
     try {
       const transactItems = transactions.map((transaction) => {
-        const dbItem = toTransactionDbItemToCreate(transaction);
+        const dbItem = toTransactionDbItemForCreate(transaction);
 
         return {
           Put: {

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -13,6 +13,8 @@ import { monotonicFactory } from "ulidx";
 import { z } from "zod";
 import {
   Transaction,
+  TransactionData,
+  TransactionEntity,
   TransactionPattern,
   TransactionPatternType,
   TransactionType,
@@ -39,7 +41,6 @@ import { DynBaseRepository } from "./dyn-base-repository";
 import {
   TransactionDbItem,
   transactionDbItemSchema,
-  transactionSchema,
 } from "./schemas/transaction";
 import { hydrate } from "./utils/hydrate";
 import { paginateQuery } from "./utils/query";
@@ -119,11 +120,11 @@ function decodeCursor(cursor: string): CursorData {
  */
 function toTransaction(dbItem: TransactionDbItem): Transaction {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { createdAtSortable, ...transaction } = dbItem;
-  return transaction;
+  const { createdAtSortable, ...data } = dbItem;
+  return TransactionEntity.fromPersistence(data);
 }
 
-function buildCreatedAtSortable(transaction: Transaction): string {
+function buildCreatedAtSortable(transaction: TransactionData): string {
   return `${transaction.createdAt}#${ulid()}`;
 }
 
@@ -161,14 +162,14 @@ export class DynTransactionRepository
         return null;
       }
 
-      const transaction = hydrate(transactionSchema, result.Item);
+      const dbItem = hydrate(transactionDbItemSchema, result.Item);
 
       // Return null if transaction is archived (soft deleted)
-      if (transaction.isArchived) {
+      if (dbItem.isArchived) {
         return null;
       }
 
-      return transaction;
+      return toTransaction(dbItem);
     } catch (error) {
       console.error("Error finding transaction by ID:", error);
       throw new RepositoryError(
@@ -191,7 +192,7 @@ export class DynTransactionRepository
       // Build query parameters (index selection, key condition, filters)
       const queryParams = this.buildQueryParams(userId, filters);
 
-      const { items } = await paginateQuery<Transaction>({
+      const { items } = await paginateQuery({
         client: this.client,
         params: {
           TableName: this.tableName,
@@ -205,10 +206,10 @@ export class DynTransactionRepository
           ScanIndexForward: false, // Descending order (newest first)
         },
         pageSize: undefined, // No pageSize = get all items
-        schema: transactionSchema,
+        schema: transactionDbItemSchema,
       });
 
-      return items;
+      return items.map((dbItem) => toTransaction(dbItem));
     } catch (error) {
       console.error("Error finding transactions by user ID:", error);
       throw new RepositoryError(
@@ -248,34 +249,32 @@ export class DynTransactionRepository
       const decodedAfter = after ? decodeCursor(after) : null;
 
       // Execute query
-      const { items: dbItems, hasNextPage } =
-        await paginateQuery<TransactionDbItem>({
-          client: this.client,
-          params: {
-            TableName: this.tableName,
-            IndexName: queryParams.indexName,
-            KeyConditionExpression: queryParams.keyConditionExpression,
-            FilterExpression: queryParams.filterExpression,
-            ...(Object.keys(queryParams.expressionAttributeNames).length >
-              0 && {
-              ExpressionAttributeNames: queryParams.expressionAttributeNames,
-            }),
-            ExpressionAttributeValues: queryParams.expressionAttributeValues,
-            ScanIndexForward: false, // Descending order (newest first)
-            ...(decodedAfter && {
-              ExclusiveStartKey: {
-                userId: userId,
-                id: decodedAfter.id,
-                [queryParams.sortKeyName]:
-                  queryParams.sortKeyName === SORT_KEY_DATE
-                    ? decodedAfter.date
-                    : decodedAfter.createdAtSortable,
-              },
-            }),
-          },
-          pageSize: first,
-          schema: transactionDbItemSchema,
-        });
+      const { items: dbItems, hasNextPage } = await paginateQuery({
+        client: this.client,
+        params: {
+          TableName: this.tableName,
+          IndexName: queryParams.indexName,
+          KeyConditionExpression: queryParams.keyConditionExpression,
+          FilterExpression: queryParams.filterExpression,
+          ...(Object.keys(queryParams.expressionAttributeNames).length > 0 && {
+            ExpressionAttributeNames: queryParams.expressionAttributeNames,
+          }),
+          ExpressionAttributeValues: queryParams.expressionAttributeValues,
+          ScanIndexForward: false, // Descending order (newest first)
+          ...(decodedAfter && {
+            ExclusiveStartKey: {
+              userId: userId,
+              id: decodedAfter.id,
+              [queryParams.sortKeyName]:
+                queryParams.sortKeyName === SORT_KEY_DATE
+                  ? decodedAfter.date
+                  : decodedAfter.createdAtSortable,
+            },
+          }),
+        },
+        pageSize: first,
+        schema: transactionDbItemSchema,
+      });
 
       // Create edges with cursors
       const edges: TransactionEdge[] = dbItems.map((dbItem) => ({
@@ -329,7 +328,7 @@ export class DynTransactionRepository
     }
 
     try {
-      const { items } = await paginateQuery<Transaction>({
+      const { items } = await paginateQuery({
         client: this.client,
         params: {
           TableName: this.tableName,
@@ -343,10 +342,10 @@ export class DynTransactionRepository
           },
         },
         pageSize: undefined, // No pageSize = get all items
-        schema: transactionSchema,
+        schema: transactionDbItemSchema,
       });
 
-      return items;
+      return items.map((dbItem) => toTransaction(dbItem));
     } catch (error) {
       console.error("Error finding transactions by account ID:", error);
       throw new RepositoryError(
@@ -376,7 +375,7 @@ export class DynTransactionRepository
     }
 
     try {
-      const { items } = await paginateQuery<Transaction>({
+      const { items } = await paginateQuery({
         client: this.client,
         params: {
           TableName: this.tableName,
@@ -390,10 +389,10 @@ export class DynTransactionRepository
           },
         },
         pageSize: undefined, // No pageSize = get all items
-        schema: transactionSchema,
+        schema: transactionDbItemSchema,
       });
 
-      return items;
+      return items.map((dbItem) => toTransaction(dbItem));
     } catch (error) {
       console.error("Error finding transactions by transfer ID:", error);
       throw new RepositoryError(
@@ -432,7 +431,7 @@ export class DynTransactionRepository
     try {
       // Query recent transactions by user, ordered by creation time (newest first)
       // Use DynamoDB's native contains() function for efficient server-side filtering
-      const { items: transactions } = await paginateQuery<Transaction>({
+      const { items: transactions } = await paginateQuery({
         client: this.client,
         params: {
           TableName: this.tableName,
@@ -448,10 +447,10 @@ export class DynTransactionRepository
           ScanIndexForward: false, // Newest first (descending createdAtSortable order)
         },
         pageSize: limit,
-        schema: transactionSchema,
+        schema: transactionDbItemSchema,
       });
 
-      return transactions;
+      return transactions.map((dbItem) => toTransaction(dbItem));
     } catch (error) {
       console.error("Error searching transactions by description:", error);
       throw new RepositoryError(
@@ -464,9 +463,10 @@ export class DynTransactionRepository
 
   async create(transaction: Readonly<Transaction>): Promise<void> {
     try {
+      const data = transaction.toData();
       const dbItem: TransactionDbItem = {
-        ...transaction,
-        createdAtSortable: buildCreatedAtSortable(transaction),
+        ...data,
+        createdAtSortable: buildCreatedAtSortable(data),
       };
 
       const command = new PutCommand({
@@ -511,16 +511,19 @@ export class DynTransactionRepository
     }
 
     try {
-      const transactItems = transactions.map((transaction) => ({
-        Put: {
-          TableName: this.tableName,
-          Item: {
-            ...transaction,
-            createdAtSortable: buildCreatedAtSortable(transaction),
+      const transactItems = transactions.map((transaction) => {
+        const data = transaction.toData();
+        return {
+          Put: {
+            TableName: this.tableName,
+            Item: {
+              ...data,
+              createdAtSortable: buildCreatedAtSortable(data),
+            },
+            ConditionExpression: "attribute_not_exists(id)",
           },
-          ConditionExpression: "attribute_not_exists(id)",
-        },
-      }));
+        };
+      });
 
       const command = new TransactWriteCommand({
         TransactItems: transactItems,
@@ -553,7 +556,7 @@ export class DynTransactionRepository
         ReturnValuesOnConditionCheckFailure: "ALL_OLD",
       });
       await this.client.send(command);
-      return { ...transaction, version: transaction.version + 1 };
+      return transaction.bumpVersion();
     } catch (error) {
       if (error instanceof ConditionalCheckFailedException) {
         // ReturnValuesOnConditionCheckFailure returns the pre-write row.
@@ -603,10 +606,7 @@ export class DynTransactionRepository
       });
 
       await this.client.send(command);
-      return transactions.map((transaction) => ({
-        ...transaction,
-        version: transaction.version + 1,
-      }));
+      return transactions.map((transaction) => transaction.bumpVersion());
     } catch (error) {
       if (error instanceof TransactionCanceledException) {
         const reasons = error.CancellationReasons ?? [];
@@ -717,7 +717,7 @@ export class DynTransactionRepository
 
     try {
       // Query up to sampleSize transactions of the specified type, ordered by creation time (newest first)
-      const { items: transactions } = await paginateQuery<Transaction>({
+      const { items } = await paginateQuery({
         client: this.client,
         params: {
           TableName: this.tableName,
@@ -735,12 +735,12 @@ export class DynTransactionRepository
           ScanIndexForward: false, // Newest first
         },
         pageSize: sampleSize, // Limit to sampleSize transactions
-        schema: transactionSchema,
+        schema: transactionDbItemSchema,
       });
 
       // Filter transactions that have both accountId and categoryId
-      const transactionsWithCategory = transactions.filter(
-        (transaction) => transaction.accountId && transaction.categoryId,
+      const dbItemsWithCategory = items.filter(
+        (dbItem) => dbItem.accountId && dbItem.categoryId,
       );
 
       // Group by account+category combination and count occurrences
@@ -749,16 +749,16 @@ export class DynTransactionRepository
         { accountId: string; categoryId: string; usageCount: number }
       >();
 
-      for (const transaction of transactionsWithCategory) {
-        const key = `${transaction.accountId}:${transaction.categoryId}`;
+      for (const dbItem of dbItemsWithCategory) {
+        const key = `${dbItem.accountId}:${dbItem.categoryId}`;
         const existing = patternCounts.get(key);
 
         if (existing) {
           existing.usageCount++;
         } else {
           patternCounts.set(key, {
-            accountId: transaction.accountId,
-            categoryId: transaction.categoryId as string, // Already filtered for non-null categoryId
+            accountId: dbItem.accountId,
+            categoryId: dbItem.categoryId as string, // Already filtered for non-null categoryId
             usageCount: 1,
           });
         }

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -124,10 +124,14 @@ function toTransaction(dbItem: TransactionDbItem): Transaction {
 }
 
 // Transform Transaction to TransactionDbItem by adding createdAtSortable
-function toTransactionDbItem(transaction: Transaction): TransactionDbItem {
+function toTransactionDbItemToCreate(
+  transaction: Transaction,
+): TransactionDbItem {
   const data = transaction.toData();
   const dbItem: TransactionDbItem = {
     ...data,
+    // Set createdAtSortable only on create
+    // to preserve original creation order.
     createdAtSortable: buildCreatedAtSortable(transaction),
   };
   return dbItem;
@@ -472,7 +476,8 @@ export class DynTransactionRepository
 
   async create(transaction: Readonly<Transaction>): Promise<void> {
     try {
-      const dbItem: TransactionDbItem = toTransactionDbItem(transaction);
+      const dbItem: TransactionDbItem =
+        toTransactionDbItemToCreate(transaction);
 
       const command = new PutCommand({
         TableName: this.tableName,
@@ -517,7 +522,7 @@ export class DynTransactionRepository
 
     try {
       const transactItems = transactions.map((transaction) => {
-        const dbItem = toTransactionDbItem(transaction);
+        const dbItem = toTransactionDbItemToCreate(transaction);
 
         return {
           Put: {

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -13,7 +13,6 @@ import { monotonicFactory } from "ulidx";
 import { z } from "zod";
 import {
   Transaction,
-  TransactionData,
   TransactionEntity,
   TransactionPattern,
   TransactionPatternType,
@@ -124,7 +123,17 @@ function toTransaction(dbItem: TransactionDbItem): Transaction {
   return TransactionEntity.fromPersistence(data);
 }
 
-function buildCreatedAtSortable(transaction: TransactionData): string {
+// Transform Transaction to TransactionDbItem by adding createdAtSortable
+function toTransactionDbItem(transaction: Transaction): TransactionDbItem {
+  const data = transaction.toData();
+  const dbItem: TransactionDbItem = {
+    ...data,
+    createdAtSortable: buildCreatedAtSortable(transaction),
+  };
+  return dbItem;
+}
+
+function buildCreatedAtSortable(transaction: Transaction): string {
   return `${transaction.createdAt}#${ulid()}`;
 }
 
@@ -463,11 +472,7 @@ export class DynTransactionRepository
 
   async create(transaction: Readonly<Transaction>): Promise<void> {
     try {
-      const data = transaction.toData();
-      const dbItem: TransactionDbItem = {
-        ...data,
-        createdAtSortable: buildCreatedAtSortable(data),
-      };
+      const dbItem: TransactionDbItem = toTransactionDbItem(transaction);
 
       const command = new PutCommand({
         TableName: this.tableName,
@@ -512,14 +517,12 @@ export class DynTransactionRepository
 
     try {
       const transactItems = transactions.map((transaction) => {
-        const data = transaction.toData();
+        const dbItem = toTransactionDbItem(transaction);
+
         return {
           Put: {
             TableName: this.tableName,
-            Item: {
-              ...data,
-              createdAtSortable: buildCreatedAtSortable(data),
-            },
+            Item: dbItem,
             ConditionExpression: "attribute_not_exists(id)",
           },
         };

--- a/backend/src/repositories/dyn-transaction-repository.ts
+++ b/backend/src/repositories/dyn-transaction-repository.ts
@@ -13,7 +13,6 @@ import { monotonicFactory } from "ulidx";
 import { z } from "zod";
 import {
   Transaction,
-  TransactionEntity,
   TransactionPattern,
   TransactionPatternType,
   TransactionType,
@@ -120,7 +119,7 @@ function decodeCursor(cursor: string): CursorData {
 function toTransaction(dbItem: TransactionDbItem): Transaction {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { createdAtSortable, ...data } = dbItem;
-  return TransactionEntity.fromPersistence(data);
+  return Transaction.fromPersistence(data);
 }
 
 // Transform Transaction to TransactionDbItem by adding createdAtSortable

--- a/backend/src/repositories/schemas/transaction.ts
+++ b/backend/src/repositories/schemas/transaction.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { TransactionData } from "../../models/transaction";
 import { TransactionType } from "../../models/transaction";
 import { toDateString } from "../../types/date";
 
@@ -19,6 +20,6 @@ export const transactionDbItemSchema = z.object({
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
   createdAtSortable: z.string().min(1),
-});
+}) satisfies z.ZodType<TransactionData & { createdAtSortable: string }>;
 
 export type TransactionDbItem = z.infer<typeof transactionDbItemSchema>;

--- a/backend/src/repositories/schemas/transaction.ts
+++ b/backend/src/repositories/schemas/transaction.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import type { Transaction } from "../../models/transaction";
 import { TransactionType } from "../../models/transaction";
 import { toDateString } from "../../types/date";
 
-export const transactionSchema = z.object({
+// Database item schema: adds createdAtSortable
+export const transactionDbItemSchema = z.object({
   userId: z.uuid(),
   id: z.uuid(),
   accountId: z.uuid(),
@@ -18,10 +18,6 @@ export const transactionSchema = z.object({
   version: z.int().nonnegative(),
   createdAt: z.iso.datetime(),
   updatedAt: z.iso.datetime(),
-}) satisfies z.ZodType<Transaction>;
-
-// Database item schema extends Transaction schema with createdAtSortable
-export const transactionDbItemSchema = transactionSchema.extend({
   createdAtSortable: z.string().min(1),
 });
 

--- a/backend/src/services/account-service.ts
+++ b/backend/src/services/account-service.ts
@@ -1,5 +1,4 @@
 import { Account } from "../models/account";
-import { getSignedAmount } from "../models/transaction";
 import {
   AccountRepository,
   CreateAccountInput,
@@ -154,7 +153,7 @@ export class AccountServiceImpl implements AccountService {
 
     // Calculate balance: initialBalance + INCOME + REFUND + TRANSFER_IN - EXPENSE - TRANSFER_OUT
     const balance = transactions.reduce(
-      (sum, transaction) => sum + getSignedAmount(transaction),
+      (sum, transaction) => sum + transaction.signedAmount,
       account.initialBalance,
     );
 

--- a/backend/src/services/by-category-report-service.ts
+++ b/backend/src/services/by-category-report-service.ts
@@ -1,9 +1,5 @@
 import { ReportType } from "../models/report";
-import {
-  Transaction,
-  TransactionType,
-  getSignedAmount,
-} from "../models/transaction";
+import { Transaction, TransactionType } from "../models/transaction";
 import { CategoryRepository } from "../ports/category-repository";
 import { TransactionRepository } from "../ports/transaction-repository";
 import { toDateString } from "../types/date";
@@ -82,22 +78,18 @@ export class ByCategoryReportService {
     // Function to get signed amount based on report type
     // For EXPENSE: expenses are positive, refunds are negative
     // For INCOME: amounts are as-is
-    let amountGetter: typeof getSignedAmount;
-
-    // Negate to get expenses as positive, refunds as negative
-    const negatedSignedAmount = (transaction: Transaction) =>
-      -getSignedAmount(transaction);
+    let amountGetter: (transaction: Transaction) => number;
 
     if (type === ReportType.EXPENSE) {
       transactionTypesToFetch = [
         TransactionType.EXPENSE,
         TransactionType.REFUND,
       ];
-
-      amountGetter = negatedSignedAmount;
+      // Negate to get expenses as positive, refunds as negative
+      amountGetter = (transaction) => -transaction.signedAmount;
     } else if (type === ReportType.INCOME) {
       transactionTypesToFetch = [TransactionType.INCOME];
-      amountGetter = getSignedAmount;
+      amountGetter = (transaction) => transaction.signedAmount;
     } else {
       throw new Error("Invalid report type");
     }

--- a/backend/src/services/transaction-service.test.ts
+++ b/backend/src/services/transaction-service.test.ts
@@ -2,13 +2,7 @@ import { faker } from "@faker-js/faker";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { CategoryType } from "../models/category";
 import { ModelError } from "../models/model-error";
-import {
-  TransactionPatternType,
-  TransactionType,
-  archiveTransactionModel,
-  createTransactionModel,
-  updateTransactionModel,
-} from "../models/transaction";
+import { TransactionPatternType, TransactionType } from "../models/transaction";
 import { VersionConflictError } from "../ports/repository-error";
 import { toDateString } from "../types/date";
 import { MAX_PAGE_SIZE, MIN_PAGE_SIZE } from "../types/pagination";
@@ -41,31 +35,16 @@ describe("TransactionService", () => {
   >;
   let mockAccountRepository: ReturnType<typeof createMockAccountRepository>;
   let mockCategoryRepository: ReturnType<typeof createMockCategoryRepository>;
-  let mockCreateTransactionModel: jest.MockedFunction<
-    typeof createTransactionModel
-  >;
-  let mockUpdateTransactionModel: jest.MockedFunction<
-    typeof updateTransactionModel
-  >;
-  let mockArchiveTransactionModel: jest.MockedFunction<
-    typeof archiveTransactionModel
-  >;
 
   beforeEach(() => {
     mockTransactionRepository = createMockTransactionRepository();
     mockAccountRepository = createMockAccountRepository();
     mockCategoryRepository = createMockCategoryRepository();
-    mockCreateTransactionModel = jest.fn<typeof createTransactionModel>();
-    mockUpdateTransactionModel = jest.fn<typeof updateTransactionModel>();
-    mockArchiveTransactionModel = jest.fn<typeof archiveTransactionModel>();
 
     service = new TransactionServiceImpl({
       accountRepository: mockAccountRepository,
       categoryRepository: mockCategoryRepository,
       transactionRepository: mockTransactionRepository,
-      createTransactionModel: mockCreateTransactionModel,
-      updateTransactionModel: mockUpdateTransactionModel,
-      archiveTransactionModel: mockArchiveTransactionModel,
     });
     userId = faker.string.uuid();
 
@@ -834,19 +813,19 @@ describe("TransactionService", () => {
       // Arrange
       const account = fakeAccount({ userId });
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
-      const createdTransaction = fakeTransaction();
-      const input = fakeCreateTransactionServiceInput({
+      const input = {
         accountId: account.id,
+        amount: 42.5,
         categoryId: category.id,
-        type: TransactionType.EXPENSE,
-      });
+        date: toDateString("2000-12-31"),
+        description: "Test transaction",
+        type: TransactionType.EXPENSE as const,
+      };
 
       // Returns account owned by user
       mockAccountRepository.findOneById.mockResolvedValue(account);
       // Returns category owned by user
       mockCategoryRepository.findOneById.mockResolvedValue(category);
-      // Returns built transaction
-      mockCreateTransactionModel.mockReturnValue(createdTransaction);
       // Persists transaction
       mockTransactionRepository.create.mockResolvedValue();
 
@@ -854,18 +833,18 @@ describe("TransactionService", () => {
       const result = await service.createTransaction(input, userId);
 
       // Assert
-      expect(result).toBe(createdTransaction);
-      expect(mockCreateTransactionModel).toHaveBeenCalledTimes(1);
-      expect(mockCreateTransactionModel).toHaveBeenCalledWith({
-        ...input,
+      expect(result).toMatchObject({
+        accountId: account.id,
+        amount: 42.5,
+        categoryId: category.id,
+        currency: account.currency,
+        date: toDateString("2000-12-31"),
+        description: "Test transaction",
+        type: TransactionType.EXPENSE,
         userId,
-        account,
-        category,
       });
       expect(mockTransactionRepository.create).toHaveBeenCalledTimes(1);
-      expect(mockTransactionRepository.create).toHaveBeenCalledWith(
-        createdTransaction,
-      );
+      expect(mockTransactionRepository.create).toHaveBeenCalledWith(result);
     });
 
     it("skips category when categoryId is omitted", async () => {
@@ -875,20 +854,16 @@ describe("TransactionService", () => {
       });
 
       // Returns account owned by user
-      mockAccountRepository.findOneById.mockResolvedValue(fakeAccount());
-      // Returns built transaction
-      mockCreateTransactionModel.mockReturnValue(fakeTransaction());
+      mockAccountRepository.findOneById.mockResolvedValue(
+        fakeAccount({ userId }),
+      );
 
       // Act
-      await service.createTransaction(input, userId);
+      const result = await service.createTransaction(input, userId);
 
       // Assert
+      expect(result.categoryId).toBeUndefined();
       expect(mockCategoryRepository.findOneById).not.toHaveBeenCalled();
-      expect(mockCreateTransactionModel).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: undefined,
-        }),
-      );
     });
 
     // Validation failures
@@ -910,7 +885,6 @@ describe("TransactionService", () => {
       await expect(promise).rejects.toMatchObject({
         message: "Account not found or doesn't belong to user",
       });
-      expect(mockCreateTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.create).not.toHaveBeenCalled();
     });
 
@@ -936,22 +910,20 @@ describe("TransactionService", () => {
         id: categoryId,
         userId,
       });
-      expect(mockCreateTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.create).not.toHaveBeenCalled();
     });
 
-    it("propagates factory errors without persisting", async () => {
+    it("propagates ModelError without persisting", async () => {
       // Arrange
       const input = fakeCreateTransactionServiceInput({
         categoryId: undefined,
+        amount: -1, // Invalid amount
       });
 
       // Returns account owned by user
-      mockAccountRepository.findOneById.mockResolvedValue(fakeAccount());
-      // Factory rejects input
-      mockCreateTransactionModel.mockImplementation(() => {
-        throw new ModelError("Invalid transaction data");
-      });
+      mockAccountRepository.findOneById.mockResolvedValue(
+        fakeAccount({ userId }),
+      );
 
       // Act
       const promise = service.createTransaction(input, userId);
@@ -959,7 +931,7 @@ describe("TransactionService", () => {
       // Assert
       await expect(promise).rejects.toThrow(ModelError);
       await expect(promise).rejects.toMatchObject({
-        message: "Invalid transaction data",
+        message: "Amount must be positive",
       });
       expect(mockTransactionRepository.create).not.toHaveBeenCalled();
     });
@@ -970,13 +942,12 @@ describe("TransactionService", () => {
 
     it("returns updated transaction", async () => {
       // Arrange
-      const existing = fakeTransaction({ userId });
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.INCOME,
+      });
       const account = fakeAccount({ userId });
       const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
-      const updatedTransaction = fakeTransaction({
-        id: existing.id,
-        userId,
-      });
 
       // Returns existing transaction
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
@@ -984,71 +955,82 @@ describe("TransactionService", () => {
       mockAccountRepository.findOneById.mockResolvedValue(account);
       // Returns new category owned by user
       mockCategoryRepository.findOneById.mockResolvedValue(category);
-      // Returns built updated transaction
-      mockUpdateTransactionModel.mockReturnValue(updatedTransaction);
-      // Saves and returns updated transaction
-      mockTransactionRepository.update.mockResolvedValue(updatedTransaction);
+      // Saves and returns updated transaction (with bumped version)
+      mockTransactionRepository.update.mockImplementation(
+        async (transaction) => transaction,
+      );
 
       // Act
       const result = await service.updateTransaction(existing.id, userId, {
         accountId: account.id,
-        categoryId: category.id,
         amount: 200,
+        categoryId: category.id,
+        date: toDateString("2000-12-31"),
+        description: "Updated transaction",
+        type: TransactionType.EXPENSE,
       });
 
       // Assert
-      expect(result).toBe(updatedTransaction);
-      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(existing, {
-        account,
-        category,
-        type: undefined,
+      expect(result).toMatchObject({
+        accountId: account.id,
         amount: 200,
-        date: undefined,
-        description: undefined,
+        categoryId: category.id,
+        currency: account.currency,
+        date: toDateString("2000-12-31"),
+        description: "Updated transaction",
+        id: existing.id,
+        type: TransactionType.EXPENSE,
+        userId,
       });
-      expect(mockTransactionRepository.update).toHaveBeenCalledWith(
-        updatedTransaction,
-      );
+      expect(mockTransactionRepository.update).toHaveBeenCalledWith(result);
     });
 
     it("skips account lookup when accountId is omitted", async () => {
       // Arrange
-      const existing = fakeTransaction({ userId });
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.EXPENSE,
+      });
       // Returns existing transaction
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
-      // Returns built updated transaction
-      mockUpdateTransactionModel.mockReturnValue(existing);
+      // Saves and returns updated transaction
+      mockTransactionRepository.update.mockImplementation(
+        async (transaction) => transaction,
+      );
 
       // Act
-      await service.updateTransaction(existing.id, userId, { amount: 5 });
+      const result = await service.updateTransaction(existing.id, userId, {
+        amount: 5,
+      });
 
       // Assert
+      expect(result.accountId).toBe(existing.accountId);
+      expect(result.amount).toBe(5);
       expect(mockAccountRepository.findOneById).not.toHaveBeenCalled();
-      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(
-        existing,
-        expect.objectContaining({ account: undefined }),
-      );
     });
 
     it("clears category when categoryId is null", async () => {
       // Arrange
-      const existing = fakeTransaction({ userId });
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.EXPENSE,
+        categoryId: faker.string.uuid(),
+      });
       // Returns existing transaction
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
-      // Returns built updated transaction
-      mockUpdateTransactionModel.mockReturnValue(existing);
+      // Saves and returns updated transaction
+      mockTransactionRepository.update.mockImplementation(
+        async (transaction) => transaction,
+      );
 
       // Act
-      await service.updateTransaction(existing.id, userId, {
+      const result = await service.updateTransaction(existing.id, userId, {
         categoryId: null,
       });
 
       // Assert
+      expect(result.categoryId).toBeUndefined();
       expect(mockCategoryRepository.findOneById).not.toHaveBeenCalled();
-      expect(mockUpdateTransactionModel).toHaveBeenCalledWith(
-        existing,
-        expect.objectContaining({ category: null }),
-      );
     });
 
     // Validation failures
@@ -1066,7 +1048,6 @@ describe("TransactionService", () => {
       await expect(promise).rejects.toMatchObject({
         message: "Transaction not found or doesn't belong to user",
       });
-      expect(mockUpdateTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
 
@@ -1088,21 +1069,17 @@ describe("TransactionService", () => {
       await expect(promise).rejects.toMatchObject({
         message: "Account not found or doesn't belong to user",
       });
-      expect(mockUpdateTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
 
-    // Dependency failures
-
     it("propagates ModelError without persisting", async () => {
       // Arrange
-      const existing = fakeTransaction({ userId });
+      const existing = fakeTransaction({
+        userId,
+        type: TransactionType.EXPENSE,
+      });
       // Returns existing transaction
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
-      // Model rejects input
-      mockUpdateTransactionModel.mockImplementation(() => {
-        throw new ModelError("Amount must be positive");
-      });
 
       // Act
       const promise = service.updateTransaction(existing.id, userId, {
@@ -1111,10 +1088,15 @@ describe("TransactionService", () => {
 
       // Assert
       await expect(promise).rejects.toThrow(ModelError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Amount must be positive",
+      });
       expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
 
-    it("maps VersionConflictError from repo to BusinessError", async () => {
+    // Dependency failures
+
+    it("maps VersionConflictError to BusinessError", async () => {
       // Arrange
       const existing = fakeTransaction({ userId });
       // Returns existing transaction
@@ -1145,22 +1127,21 @@ describe("TransactionService", () => {
     it("archives transaction and returns it", async () => {
       // Arrange
       const existing = fakeTransaction({ userId });
-      const archived = fakeTransaction({ userId });
 
       // Returns existing transaction
       mockTransactionRepository.findOneById.mockResolvedValue(existing);
-      // Returns built archived transaction
-      mockArchiveTransactionModel.mockReturnValue(archived);
       // Saves and returns archived transaction
-      mockTransactionRepository.update.mockResolvedValue(archived);
+      mockTransactionRepository.update.mockImplementation(
+        async (transaction) => transaction,
+      );
 
       // Act
       const result = await service.deleteTransaction(existing.id, userId);
 
       // Assert
-      expect(result).toBe(archived);
-      expect(mockArchiveTransactionModel).toHaveBeenCalledWith(existing);
-      expect(mockTransactionRepository.update).toHaveBeenCalledWith(archived);
+      expect(result.id).toBe(existing.id);
+      expect(result.isArchived).toBe(true);
+      expect(mockTransactionRepository.update).toHaveBeenCalledWith(result);
     });
 
     it("returns existing transaction when already archived", async () => {
@@ -1174,7 +1155,6 @@ describe("TransactionService", () => {
 
       // Assert
       expect(result).toBe(existing);
-      expect(mockArchiveTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
 
@@ -1193,13 +1173,12 @@ describe("TransactionService", () => {
       await expect(promise).rejects.toMatchObject({
         message: "Transaction not found or doesn't belong to user",
       });
-      expect(mockArchiveTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.update).not.toHaveBeenCalled();
     });
 
     // Dependency failures
 
-    it("maps VersionConflictError from repo to BusinessError", async () => {
+    it("maps VersionConflictError to BusinessError", async () => {
       // Arrange
       const existing = fakeTransaction({ userId });
       // Returns existing transaction

--- a/backend/src/services/transaction-service.ts
+++ b/backend/src/services/transaction-service.ts
@@ -3,7 +3,6 @@ import { Category, CategoryType } from "../models/category";
 import {
   NonTransferTransactionType,
   Transaction,
-  TransactionEntity,
   TransactionPattern,
   TransactionPatternType,
   TransactionType,
@@ -166,7 +165,7 @@ export class TransactionServiceImpl implements TransactionService {
       }
     }
 
-    const transaction = TransactionEntity.create({
+    const transaction = Transaction.create({
       ...input,
       userId,
       account,

--- a/backend/src/services/transaction-service.ts
+++ b/backend/src/services/transaction-service.ts
@@ -3,12 +3,10 @@ import { Category, CategoryType } from "../models/category";
 import {
   NonTransferTransactionType,
   Transaction,
+  TransactionEntity,
   TransactionPattern,
   TransactionPatternType,
   TransactionType,
-  archiveTransactionModel as defaultArchiveTransactionModel,
-  createTransactionModel as defaultCreateTransactionModel,
-  updateTransactionModel as defaultUpdateTransactionModel,
 } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { CategoryRepository } from "../ports/category-repository";
@@ -103,27 +101,15 @@ export class TransactionServiceImpl implements TransactionService {
   private accountRepository: AccountRepository;
   private categoryRepository: CategoryRepository;
   private transactionRepository: TransactionRepository;
-  private createTransactionModel: typeof defaultCreateTransactionModel;
-  private updateTransactionModel: typeof defaultUpdateTransactionModel;
-  private archiveTransactionModel: typeof defaultArchiveTransactionModel;
 
   constructor(deps: {
     accountRepository: AccountRepository;
     categoryRepository: CategoryRepository;
     transactionRepository: TransactionRepository;
-    createTransactionModel?: typeof defaultCreateTransactionModel;
-    updateTransactionModel?: typeof defaultUpdateTransactionModel;
-    archiveTransactionModel?: typeof defaultArchiveTransactionModel;
   }) {
     this.accountRepository = deps.accountRepository;
     this.categoryRepository = deps.categoryRepository;
     this.transactionRepository = deps.transactionRepository;
-    this.createTransactionModel =
-      deps.createTransactionModel ?? defaultCreateTransactionModel;
-    this.updateTransactionModel =
-      deps.updateTransactionModel ?? defaultUpdateTransactionModel;
-    this.archiveTransactionModel =
-      deps.archiveTransactionModel ?? defaultArchiveTransactionModel;
   }
 
   /**
@@ -180,7 +166,7 @@ export class TransactionServiceImpl implements TransactionService {
       }
     }
 
-    const transaction = this.createTransactionModel({
+    const transaction = TransactionEntity.create({
       ...input,
       userId,
       account,
@@ -254,7 +240,7 @@ export class TransactionServiceImpl implements TransactionService {
               transactionType,
             );
 
-    const updated = this.updateTransactionModel(existingTransaction, {
+    const updated = existingTransaction.update({
       account,
       category,
       type: input.type,
@@ -292,7 +278,7 @@ export class TransactionServiceImpl implements TransactionService {
       return existingTransaction;
     }
 
-    const archived = this.archiveTransactionModel(existingTransaction);
+    const archived = existingTransaction.archive();
 
     return handleVersionConflict("Transaction", () =>
       this.transactionRepository.update(archived),

--- a/backend/src/services/transfer-service.test.ts
+++ b/backend/src/services/transfer-service.test.ts
@@ -1,12 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { ModelError } from "../models/model-error";
-import {
-  TransactionType,
-  archiveTransactionModel,
-  createTransactionModel,
-  updateTransactionModel,
-} from "../models/transaction";
+import { TransactionType } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { VersionConflictError } from "../ports/repository-error";
 import { TransactionRepository } from "../ports/transaction-repository";
@@ -23,29 +18,14 @@ describe("TransferService", () => {
   let userId: string;
   let mockTransactionRepository: jest.Mocked<TransactionRepository>;
   let mockAccountRepository: jest.Mocked<AccountRepository>;
-  let mockCreateTransactionModel: jest.MockedFunction<
-    typeof createTransactionModel
-  >;
-  let mockUpdateTransactionModel: jest.MockedFunction<
-    typeof updateTransactionModel
-  >;
-  let mockArchiveTransactionModel: jest.MockedFunction<
-    typeof archiveTransactionModel
-  >;
 
   beforeEach(() => {
     mockAccountRepository = createMockAccountRepository();
     mockTransactionRepository = createMockTransactionRepository();
-    mockCreateTransactionModel = jest.fn<typeof createTransactionModel>();
-    mockUpdateTransactionModel = jest.fn<typeof updateTransactionModel>();
-    mockArchiveTransactionModel = jest.fn<typeof archiveTransactionModel>();
 
     service = new TransferService({
       accountRepository: mockAccountRepository,
       transactionRepository: mockTransactionRepository,
-      createTransactionModel: mockCreateTransactionModel,
-      updateTransactionModel: mockUpdateTransactionModel,
-      archiveTransactionModel: mockArchiveTransactionModel,
     });
 
     userId = faker.string.uuid();
@@ -176,19 +156,10 @@ describe("TransferService", () => {
     it("creates transfer and returns result with outbound and inbound transactions", async () => {
       const fromAccount = fakeAccount({ userId });
       const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
-      const outboundTransaction = fakeTransaction({
-        type: TransactionType.TRANSFER_OUT,
-      });
-      const inboundTransaction = fakeTransaction({
-        type: TransactionType.TRANSFER_IN,
-      });
 
       mockAccountRepository.findOneById
         .mockResolvedValueOnce(fromAccount)
         .mockResolvedValueOnce(toAccount);
-      mockCreateTransactionModel
-        .mockReturnValueOnce(outboundTransaction)
-        .mockReturnValueOnce(inboundTransaction);
       mockTransactionRepository.createMany.mockResolvedValue();
 
       const result = await service.createTransfer(
@@ -201,32 +172,30 @@ describe("TransferService", () => {
         userId,
       );
 
-      expect(result).toEqual({
-        transferId: expect.any(String),
-        outboundTransaction,
-        inboundTransaction,
-      });
-      expect(mockCreateTransactionModel).toHaveBeenNthCalledWith(1, {
-        userId,
-        account: fromAccount,
-        type: TransactionType.TRANSFER_OUT,
-        amount: 100,
-        date: toDateString("2024-01-01"),
-        description: undefined,
-        transferId: result.transferId,
-      });
-      expect(mockCreateTransactionModel).toHaveBeenNthCalledWith(2, {
-        userId,
-        account: toAccount,
-        type: TransactionType.TRANSFER_IN,
-        amount: 100,
-        date: toDateString("2024-01-01"),
-        description: undefined,
-        transferId: result.transferId,
-      });
+      expect(result.transferId).toEqual(expect.any(String));
+      expect(result.outboundTransaction).toEqual(
+        expect.objectContaining({
+          userId,
+          accountId: fromAccount.id,
+          type: TransactionType.TRANSFER_OUT,
+          amount: 100,
+          date: toDateString("2024-01-01"),
+          transferId: result.transferId,
+        }),
+      );
+      expect(result.inboundTransaction).toEqual(
+        expect.objectContaining({
+          userId,
+          accountId: toAccount.id,
+          type: TransactionType.TRANSFER_IN,
+          amount: 100,
+          date: toDateString("2024-01-01"),
+          transferId: result.transferId,
+        }),
+      );
       expect(mockTransactionRepository.createMany).toHaveBeenCalledWith([
-        outboundTransaction,
-        inboundTransaction,
+        result.outboundTransaction,
+        result.inboundTransaction,
       ]);
     });
   });
@@ -240,23 +209,21 @@ describe("TransferService", () => {
       const fromAccount = fakeAccount({ userId });
       const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
       const outboundTransaction = fakeTransaction({
+        userId,
         type: TransactionType.TRANSFER_OUT,
         transferId,
         accountId: fromAccount.id,
+        currency: fromAccount.currency,
       });
       const inboundTransaction = fakeTransaction({
+        userId,
         type: TransactionType.TRANSFER_IN,
         transferId,
         accountId: toAccount.id,
+        currency: toAccount.currency,
       });
-      const updatedOutbound = fakeTransaction({
-        id: outboundTransaction.id,
-        type: TransactionType.TRANSFER_OUT,
-      });
-      const updatedInbound = fakeTransaction({
-        id: inboundTransaction.id,
-        type: TransactionType.TRANSFER_IN,
-      });
+      const updatedOutbound = outboundTransaction.update({ amount: 200 });
+      const updatedInbound = inboundTransaction.update({ amount: 200 });
 
       // Returns existing pair, then updated pair on refetch
       mockTransactionRepository.findManyByTransferId
@@ -266,10 +233,9 @@ describe("TransferService", () => {
       mockAccountRepository.findOneById
         .mockResolvedValueOnce(fromAccount)
         .mockResolvedValueOnce(toAccount);
-      // Returns updated transactions
-      mockUpdateTransactionModel
-        .mockReturnValueOnce(updatedOutbound)
-        .mockReturnValueOnce(updatedInbound);
+      mockTransactionRepository.updateMany.mockImplementation(async (txs) => [
+        ...txs,
+      ]);
 
       // Act
       const result = await service.updateTransfer(transferId, userId, {
@@ -277,34 +243,20 @@ describe("TransferService", () => {
       });
 
       // Assert
-      expect(result).toEqual({
-        transferId,
-        outboundTransaction: updatedOutbound,
-        inboundTransaction: updatedInbound,
-      });
-      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
-        1,
-        outboundTransaction,
-        {
-          account: undefined,
-          amount: 200,
-          date: undefined,
-          description: undefined,
-        },
-      );
-      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
-        2,
-        inboundTransaction,
-        {
-          account: undefined,
-          amount: 200,
-          date: undefined,
-          description: undefined,
-        },
-      );
+      expect(result.transferId).toBe(transferId);
+      expect(result.outboundTransaction.amount).toBe(200);
+      expect(result.inboundTransaction.amount).toBe(200);
       expect(mockTransactionRepository.updateMany).toHaveBeenCalledWith([
-        updatedOutbound,
-        updatedInbound,
+        expect.objectContaining({
+          id: outboundTransaction.id,
+          amount: 200,
+          accountId: fromAccount.id,
+        }),
+        expect.objectContaining({
+          id: inboundTransaction.id,
+          amount: 200,
+          accountId: toAccount.id,
+        }),
       ]);
     });
 
@@ -314,12 +266,16 @@ describe("TransferService", () => {
       const fromAccount = fakeAccount({ userId });
       const toAccount = fakeAccount({ userId, currency: fromAccount.currency });
       const outboundTransaction = fakeTransaction({
+        userId,
         type: TransactionType.TRANSFER_OUT,
         transferId,
+        currency: fromAccount.currency,
       });
       const inboundTransaction = fakeTransaction({
+        userId,
         type: TransactionType.TRANSFER_IN,
         transferId,
+        currency: toAccount.currency,
       });
 
       // Returns existing pair on both lookups
@@ -330,10 +286,9 @@ describe("TransferService", () => {
       mockAccountRepository.findOneById
         .mockResolvedValueOnce(fromAccount)
         .mockResolvedValueOnce(toAccount);
-      // Returns built updated sides
-      mockUpdateTransactionModel
-        .mockReturnValueOnce(outboundTransaction)
-        .mockReturnValueOnce(inboundTransaction);
+      mockTransactionRepository.updateMany.mockImplementation(async (txs) => [
+        ...txs,
+      ]);
 
       // Act
       await service.updateTransfer(transferId, userId, {
@@ -342,16 +297,10 @@ describe("TransferService", () => {
       });
 
       // Assert
-      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
-        1,
-        outboundTransaction,
-        expect.objectContaining({ account: fromAccount }),
-      );
-      expect(mockUpdateTransactionModel).toHaveBeenNthCalledWith(
-        2,
-        inboundTransaction,
-        expect.objectContaining({ account: toAccount }),
-      );
+      expect(mockTransactionRepository.updateMany).toHaveBeenCalledWith([
+        expect.objectContaining({ accountId: fromAccount.id }),
+        expect.objectContaining({ accountId: toAccount.id }),
+      ]);
     });
 
     // Dependency failures
@@ -422,10 +371,6 @@ describe("TransferService", () => {
       mockAccountRepository.findOneById
         .mockResolvedValueOnce(fromAccount)
         .mockResolvedValueOnce(toAccount);
-      // Model rejects input
-      mockUpdateTransactionModel.mockImplementation(() => {
-        throw new ModelError("Amount must be positive");
-      });
 
       // Act
       const promise = service.updateTransfer(transferId, userId, {
@@ -434,6 +379,9 @@ describe("TransferService", () => {
 
       // Assert
       await expect(promise).rejects.toThrow(ModelError);
+      await expect(promise).rejects.toMatchObject({
+        message: "Amount must be positive",
+      });
       expect(mockTransactionRepository.updateMany).not.toHaveBeenCalled();
     });
   });
@@ -446,34 +394,29 @@ describe("TransferService", () => {
       const transferId = faker.string.uuid();
       const outboundTransaction = fakeTransaction();
       const inboundTransaction = fakeTransaction();
-      const archivedOutbound = fakeTransaction();
-      const archivedInbound = fakeTransaction();
 
       // Returns existing pair
       mockTransactionRepository.findManyByTransferId.mockResolvedValue([
         outboundTransaction,
         inboundTransaction,
       ]);
-      // Returns archived sides
-      mockArchiveTransactionModel
-        .mockReturnValueOnce(archivedOutbound)
-        .mockReturnValueOnce(archivedInbound);
+      mockTransactionRepository.updateMany.mockImplementation(async (txs) => [
+        ...txs,
+      ]);
 
       // Act
       await service.deleteTransfer(transferId, userId);
 
       // Assert
-      expect(mockArchiveTransactionModel).toHaveBeenNthCalledWith(
-        1,
-        outboundTransaction,
-      );
-      expect(mockArchiveTransactionModel).toHaveBeenNthCalledWith(
-        2,
-        inboundTransaction,
-      );
       expect(mockTransactionRepository.updateMany).toHaveBeenCalledWith([
-        archivedOutbound,
-        archivedInbound,
+        expect.objectContaining({
+          id: outboundTransaction.id,
+          isArchived: true,
+        }),
+        expect.objectContaining({
+          id: inboundTransaction.id,
+          isArchived: true,
+        }),
       ]);
     });
 
@@ -492,7 +435,6 @@ describe("TransferService", () => {
       await expect(promise).rejects.toMatchObject({
         message: "Transfer not found or doesn't belong to user",
       });
-      expect(mockArchiveTransactionModel).not.toHaveBeenCalled();
       expect(mockTransactionRepository.updateMany).not.toHaveBeenCalled();
     });
 

--- a/backend/src/services/transfer-service.ts
+++ b/backend/src/services/transfer-service.ts
@@ -2,10 +2,8 @@ import { randomUUID } from "crypto";
 import { Account } from "../models/account";
 import {
   Transaction,
+  TransactionEntity,
   TransactionType,
-  archiveTransactionModel as defaultArchiveTransactionModel,
-  createTransactionModel as defaultCreateTransactionModel,
-  updateTransactionModel as defaultUpdateTransactionModel,
 } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { TransactionRepository } from "../ports/transaction-repository";
@@ -51,25 +49,13 @@ export interface TransferResult {
 export class TransferService {
   private accountRepository: AccountRepository;
   private transactionRepository: TransactionRepository;
-  private createTransactionModel: typeof defaultCreateTransactionModel;
-  private updateTransactionModel: typeof defaultUpdateTransactionModel;
-  private archiveTransactionModel: typeof defaultArchiveTransactionModel;
 
   constructor(deps: {
     accountRepository: AccountRepository;
     transactionRepository: TransactionRepository;
-    createTransactionModel?: typeof defaultCreateTransactionModel;
-    updateTransactionModel?: typeof defaultUpdateTransactionModel;
-    archiveTransactionModel?: typeof defaultArchiveTransactionModel;
   }) {
     this.accountRepository = deps.accountRepository;
     this.transactionRepository = deps.transactionRepository;
-    this.createTransactionModel =
-      deps.createTransactionModel ?? defaultCreateTransactionModel;
-    this.updateTransactionModel =
-      deps.updateTransactionModel ?? defaultUpdateTransactionModel;
-    this.archiveTransactionModel =
-      deps.archiveTransactionModel ?? defaultArchiveTransactionModel;
   }
 
   /**
@@ -112,7 +98,7 @@ export class TransferService {
     const transferId = randomUUID();
 
     // Build the outbound transaction (TRANSFER_OUT)
-    const outboundTransaction = this.createTransactionModel({
+    const outboundTransaction = TransactionEntity.create({
       userId,
       account: fromAccount,
       type: TransactionType.TRANSFER_OUT,
@@ -123,7 +109,7 @@ export class TransferService {
     });
 
     // Build the inbound transaction (TRANSFER_IN)
-    const inboundTransaction = this.createTransactionModel({
+    const inboundTransaction = TransactionEntity.create({
       userId,
       account: toAccount,
       type: TransactionType.TRANSFER_IN,
@@ -183,7 +169,7 @@ export class TransferService {
 
     try {
       const archivedTransactions = transferTransactions.map((transaction) =>
-        this.archiveTransactionModel(transaction),
+        transaction.archive(),
       );
 
       await handleVersionConflict("Transfer", () =>
@@ -250,12 +236,12 @@ export class TransferService {
       description: input.description,
     };
 
-    const updatedOutbound = this.updateTransactionModel(outboundTransaction, {
+    const updatedOutbound = outboundTransaction.update({
       ...sharedUpdate,
       account: input.fromAccountId ? fromAccount : undefined,
     });
 
-    const updatedInbound = this.updateTransactionModel(inboundTransaction, {
+    const updatedInbound = inboundTransaction.update({
       ...sharedUpdate,
       account: input.toAccountId ? toAccount : undefined,
     });

--- a/backend/src/services/transfer-service.ts
+++ b/backend/src/services/transfer-service.ts
@@ -1,10 +1,6 @@
 import { randomUUID } from "crypto";
 import { Account } from "../models/account";
-import {
-  Transaction,
-  TransactionEntity,
-  TransactionType,
-} from "../models/transaction";
+import { Transaction, TransactionType } from "../models/transaction";
 import { AccountRepository } from "../ports/account-repository";
 import { TransactionRepository } from "../ports/transaction-repository";
 import { DateString } from "../types/date";
@@ -98,7 +94,7 @@ export class TransferService {
     const transferId = randomUUID();
 
     // Build the outbound transaction (TRANSFER_OUT)
-    const outboundTransaction = TransactionEntity.create({
+    const outboundTransaction = Transaction.create({
       userId,
       account: fromAccount,
       type: TransactionType.TRANSFER_OUT,
@@ -109,7 +105,7 @@ export class TransferService {
     });
 
     // Build the inbound transaction (TRANSFER_IN)
-    const inboundTransaction = TransactionEntity.create({
+    const inboundTransaction = Transaction.create({
       userId,
       account: toAccount,
       type: TransactionType.TRANSFER_IN,

--- a/backend/src/utils/test-utils/models/transaction-fakes.ts
+++ b/backend/src/utils/test-utils/models/transaction-fakes.ts
@@ -1,27 +1,33 @@
 import { faker } from "@faker-js/faker";
 import {
   CreateTransactionInput,
-  Transaction,
+  TransactionData,
+  TransactionEntity,
   TransactionPattern,
   TransactionType,
 } from "../../../models/transaction";
 import { toDateString } from "../../../types/date";
 import { fakeAccount } from "./account-fakes";
 
-export const fakeTransaction = (
-  overrides: Partial<Transaction> = {},
-): Transaction => {
+export const fakeTransactionData = (
+  overrides: Partial<TransactionData> = {},
+): TransactionData => {
   const now = new Date().toISOString();
+  const type = overrides.type ?? TransactionType.EXPENSE;
+  const isTransfer =
+    type === TransactionType.TRANSFER_IN ||
+    type === TransactionType.TRANSFER_OUT;
   return {
     id: faker.string.uuid(),
     userId: faker.string.uuid(),
     accountId: faker.string.uuid(),
     amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
-    type: TransactionType.EXPENSE,
-    currency: "USD",
+    type,
+    currency: faker.helpers.arrayElement(["EUR", "USD"]),
     description: faker.finance.transactionDescription(),
     date: toDateString(faker.date.recent().toISOString().split("T")[0]),
-    categoryId: faker.string.uuid(),
+    categoryId: isTransfer ? undefined : faker.string.uuid(),
+    transferId: isTransfer ? faker.string.uuid() : undefined,
     isArchived: false,
     version: faker.number.int({ min: 1, max: 100 }),
     createdAt: now,
@@ -29,6 +35,11 @@ export const fakeTransaction = (
     ...overrides,
   };
 };
+
+export const fakeTransaction = (
+  overrides: Partial<TransactionData> = {},
+): TransactionEntity =>
+  TransactionEntity.fromPersistence(fakeTransactionData(overrides));
 
 export const fakeCreateTransactionInput = (
   overrides: Partial<CreateTransactionInput> = {},

--- a/backend/src/utils/test-utils/models/transaction-fakes.ts
+++ b/backend/src/utils/test-utils/models/transaction-fakes.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import {
   CreateTransactionInput,
   Transaction,
+  TransactionData,
   TransactionPattern,
   TransactionType,
 } from "../../../models/transaction";
@@ -9,7 +10,7 @@ import { toDateString } from "../../../types/date";
 import { fakeAccount } from "./account-fakes";
 
 export const fakeTransaction = (
-  overrides: Partial<Transaction> = {},
+  overrides: Partial<TransactionData> = {},
 ): Transaction => {
   const now = new Date().toISOString();
   const type = overrides.type ?? TransactionType.EXPENSE;

--- a/backend/src/utils/test-utils/models/transaction-fakes.ts
+++ b/backend/src/utils/test-utils/models/transaction-fakes.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import {
   CreateTransactionInput,
-  TransactionData,
+  Transaction,
   TransactionEntity,
   TransactionPattern,
   TransactionType,
@@ -9,37 +9,33 @@ import {
 import { toDateString } from "../../../types/date";
 import { fakeAccount } from "./account-fakes";
 
-export const fakeTransactionData = (
-  overrides: Partial<TransactionData> = {},
-): TransactionData => {
+export const fakeTransaction = (
+  overrides: Partial<Transaction> = {},
+): Transaction => {
   const now = new Date().toISOString();
   const type = overrides.type ?? TransactionType.EXPENSE;
   const isTransfer =
     type === TransactionType.TRANSFER_IN ||
     type === TransactionType.TRANSFER_OUT;
-  return {
+
+  return TransactionEntity.fromPersistence({
     id: faker.string.uuid(),
     userId: faker.string.uuid(),
     accountId: faker.string.uuid(),
+    categoryId: isTransfer ? undefined : faker.string.uuid(),
     amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
     type,
     currency: faker.helpers.arrayElement(["EUR", "USD"]),
-    description: faker.finance.transactionDescription(),
     date: toDateString(faker.date.recent().toISOString().split("T")[0]),
-    categoryId: isTransfer ? undefined : faker.string.uuid(),
+    description: faker.finance.transactionDescription(),
     transferId: isTransfer ? faker.string.uuid() : undefined,
     isArchived: false,
     version: faker.number.int({ min: 1, max: 100 }),
     createdAt: now,
     updatedAt: now,
     ...overrides,
-  };
+  });
 };
-
-export const fakeTransaction = (
-  overrides: Partial<TransactionData> = {},
-): TransactionEntity =>
-  TransactionEntity.fromPersistence(fakeTransactionData(overrides));
 
 export const fakeCreateTransactionInput = (
   overrides: Partial<CreateTransactionInput> = {},

--- a/backend/src/utils/test-utils/models/transaction-fakes.ts
+++ b/backend/src/utils/test-utils/models/transaction-fakes.ts
@@ -2,7 +2,6 @@ import { faker } from "@faker-js/faker";
 import {
   CreateTransactionInput,
   Transaction,
-  TransactionEntity,
   TransactionPattern,
   TransactionType,
 } from "../../../models/transaction";
@@ -18,7 +17,7 @@ export const fakeTransaction = (
     type === TransactionType.TRANSFER_IN ||
     type === TransactionType.TRANSFER_OUT;
 
-  return TransactionEntity.fromPersistence({
+  return Transaction.fromPersistence({
     id: faker.string.uuid(),
     userId: faker.string.uuid(),
     accountId: faker.string.uuid(),

--- a/docs/superpowers/plans/2026-04-24-transaction-entity.md
+++ b/docs/superpowers/plans/2026-04-24-transaction-entity.md
@@ -1,0 +1,1299 @@
+# Transaction Domain Entity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert `backend/src/models/transaction.ts` from interface + free functions into a DDD-style immutable entity (`TransactionEntity` class implementing an extended `Transaction` interface). Migrate every consumer.
+
+**Architecture:** Split the existing `Transaction` interface into `TransactionData` (pure data shape) and `Transaction` (data + domain methods). Add `TransactionEntity` class with `readonly` fields, static factories `create` / `fromPersistence`, instance methods `update` / `archive` / `toData`, and `signedAmount` getter. Version bump (OCC) stays in the repository. Drop dependency-injected model functions from services. Migration is staged so main stays green (typecheck + full test suite) after each task. Final task deletes the free functions and tightens the `Transaction` interface to include methods.
+
+**Tech Stack:** TypeScript strict, Jest, Zod, DynamoDB (via AWS SDK).
+
+**Reference spec:** [`docs/superpowers/specs/2026-04-24-transaction-entity-design.md`](../specs/2026-04-24-transaction-entity-design.md).
+
+**Commit policy:** Never run `git commit` as part of task execution. When a step reads "Commit" below, it means "this is a natural stopping point where the user may choose to commit; stage the files and wait." Leave the working tree with staged changes and move to the next task.
+
+**Required skills:**
+- **`jest-tests`** — MUST be invoked via the Skill tool *immediately before* every individual step that writes or modifies a Jest test. Every such step is tagged `[requires jest-tests skill]` inline. Invoke the skill once per tagged step, not once per task — it is easy to forget when a task contains multiple test batches. Invocations are cheap; skipping is not.
+
+---
+
+## File Structure
+
+Files created:
+
+- `backend/src/models/transaction-entity.test.ts` — new test file for the class (replaces the old `transaction.test.ts` at the end).
+
+Files modified:
+
+- `backend/src/models/transaction.ts` — adds `TransactionData`, adds `TransactionEntity` class, extends `Transaction` interface, removes free functions.
+- `backend/src/repositories/schemas/transaction.ts` — Zod schema `satisfies z.ZodType<TransactionData>`.
+- `backend/src/repositories/dyn-transaction-repository.ts` — hydrate via `TransactionEntity.fromPersistence`; serialize via `.toData()`; return instances on writes.
+- `backend/src/utils/test-utils/models/transaction-fakes.ts` — `fakeTransaction` returns `TransactionEntity` instance.
+- `backend/src/services/transaction-service.ts` — drop injected model functions, call `TransactionEntity` statics + instance methods.
+- `backend/src/services/transfer-service.ts` — same migration.
+- `backend/src/services/account-service.ts` — `getSignedAmount(t)` → `t.signedAmount`.
+- `backend/src/services/by-category-report-service.ts` — `getSignedAmount(t)` → `t.signedAmount`.
+- `backend/src/langchain/tools/aggregate-transactions.ts` — `getSignedAmount(t)` → `t.signedAmount`.
+- Any service test that injected fake `createTransactionModel` / `updateTransactionModel` / `archiveTransactionModel` — drop the injection.
+
+Files deleted:
+
+- `backend/src/models/transaction.test.ts` — superseded by `transaction-entity.test.ts`.
+
+---
+
+## Task 1: Add `TransactionData` alongside existing `Transaction`
+
+**Files:**
+- Modify: `backend/src/models/transaction.ts`
+
+- [ ] **Step 1: Add `TransactionData` interface mirroring current `Transaction` shape**
+
+In `backend/src/models/transaction.ts`, right above the existing `export interface Transaction` block, add:
+
+```ts
+// Plain data shape. Used by Zod, DynamoDB, and anywhere a value (not a domain object) is needed.
+export interface TransactionData {
+  userId: string;
+  id: string;
+  accountId: string;
+  categoryId?: string;
+  type: TransactionType;
+  amount: number;
+  currency: string;
+  date: DateString;
+  description?: string;
+  transferId?: string;
+  isArchived: boolean;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+Leave the existing `Transaction` interface unchanged. Task 9 will rewire it to `extends TransactionData`.
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `npm --prefix backend run typecheck`
+Expected: clean (no errors).
+
+- [ ] **Step 3: Verify full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all tests pass (no behavioral change yet).
+
+- [ ] **Step 4: Stage changes**
+
+```bash
+git add backend/src/models/transaction.ts
+```
+
+---
+
+## Task 2: Create failing test file for `TransactionEntity.create`
+
+**Files:**
+- Create: `backend/src/models/transaction-entity.test.ts`
+
+- [ ] **Step 1: Scaffold test file with one failing case for `create`** `[requires jest-tests skill]`
+
+Create `backend/src/models/transaction-entity.test.ts`:
+
+```ts
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "@jest/globals";
+import { toDateString } from "../types/date";
+import { DESCRIPTION_MAX_LENGTH } from "../types/validation";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
+import { fakeCreateTransactionInput } from "../utils/test-utils/models/transaction-fakes";
+import { CategoryType } from "./category";
+import { ModelError } from "./model-error";
+import { TransactionEntity, TransactionType } from "./transaction";
+
+describe("TransactionEntity", () => {
+  describe("create", () => {
+    const fixedClock = () => new Date("2000-01-02T10:11:12.000Z");
+    const fixedIdGenerator = () => "fixed-uuid";
+    const fixedDeps = { clock: fixedClock, idGenerator: fixedIdGenerator };
+
+    it("builds transaction with all fields populated", () => {
+      const userId = faker.string.uuid();
+      const account = fakeAccount({ userId, currency: "EUR" });
+      const category = fakeCategory({ userId, type: CategoryType.EXPENSE });
+      const input = fakeCreateTransactionInput({
+        userId,
+        account,
+        category,
+        type: TransactionType.EXPENSE,
+        amount: 42.5,
+        date: toDateString("2000-01-02"),
+        description: "lunch",
+      });
+
+      const result = TransactionEntity.create(input, fixedDeps);
+
+      expect(result.toData()).toEqual({
+        id: "fixed-uuid",
+        userId,
+        accountId: account.id,
+        categoryId: category.id,
+        type: TransactionType.EXPENSE,
+        amount: 42.5,
+        currency: "EUR",
+        date: "2000-01-02",
+        description: "lunch",
+        transferId: undefined,
+        isArchived: false,
+        version: 0,
+        createdAt: "2000-01-02T10:11:12.000Z",
+        updatedAt: "2000-01-02T10:11:12.000Z",
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm --prefix backend test -- src/models/transaction-entity.test.ts`
+Expected: FAIL with "TransactionEntity is not exported" (or similar — `TransactionEntity` does not exist yet).
+
+---
+
+## Task 3: Implement `TransactionEntity` class with `create` and invariants
+
+**Files:**
+- Modify: `backend/src/models/transaction.ts`
+
+- [ ] **Step 1: Add minimal `TransactionEntity` class below the `Transaction` interface block**
+
+At the end of `backend/src/models/transaction.ts` (before the closing of the file and after the existing free functions — free functions stay in place for now), add:
+
+```ts
+export class TransactionEntity {
+  readonly userId: string;
+  readonly id: string;
+  readonly accountId: string;
+  readonly categoryId?: string;
+  readonly type: TransactionType;
+  readonly amount: number;
+  readonly currency: string;
+  readonly date: DateString;
+  readonly description?: string;
+  readonly transferId?: string;
+  readonly isArchived: boolean;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  private constructor(
+    data: TransactionData,
+    relations?: { newAccount?: Account; newCategory?: Category },
+  ) {
+    this.userId = data.userId;
+    this.id = data.id;
+    this.accountId = data.accountId;
+    this.categoryId = data.categoryId;
+    this.type = data.type;
+    this.amount = data.amount;
+    this.currency = data.currency;
+    this.date = data.date;
+    this.description = data.description;
+    this.transferId = data.transferId;
+    this.isArchived = data.isArchived;
+    this.version = data.version;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+    TransactionEntity.assertInvariants(data, relations);
+  }
+
+  static create(
+    input: CreateTransactionInput,
+    {
+      clock = () => new Date(),
+      idGenerator = randomUUID,
+    }: { clock?: () => Date; idGenerator?: () => string } = {},
+  ): TransactionEntity {
+    const { account, category } = input;
+    const now = clock().toISOString();
+
+    const data: TransactionData = {
+      id: idGenerator(),
+      userId: input.userId,
+      accountId: account.id,
+      categoryId: category?.id,
+      type: input.type,
+      amount: input.amount,
+      currency: account.currency,
+      date: input.date,
+      description: normalizeDescription(input.description),
+      transferId: input.transferId,
+      isArchived: false,
+      version: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return new TransactionEntity(data, {
+      newAccount: account,
+      newCategory: category,
+    });
+  }
+
+  static fromPersistence(data: TransactionData): TransactionEntity {
+    return new TransactionEntity(data);
+  }
+
+  get signedAmount(): number {
+    switch (this.type) {
+      case TransactionType.INCOME:
+      case TransactionType.REFUND:
+      case TransactionType.TRANSFER_IN:
+        return this.amount;
+      case TransactionType.EXPENSE:
+      case TransactionType.TRANSFER_OUT:
+        return -this.amount;
+      default:
+        throw new Error(`Unknown transaction type: ${this.type}`);
+    }
+  }
+
+  update(
+    input: UpdateTransactionInput,
+    { clock = () => new Date() }: { clock?: () => Date } = {},
+  ): TransactionEntity {
+    if (this.isArchived) {
+      throw new ModelError("Cannot update archived transaction");
+    }
+
+    const { account, category } = input;
+    const now = clock().toISOString();
+
+    const newCategoryId =
+      category === undefined
+        ? this.categoryId
+        : category === null
+          ? undefined
+          : category.id;
+
+    const newDescription =
+      input.description === undefined
+        ? this.description
+        : input.description === null
+          ? undefined
+          : normalizeDescription(input.description);
+
+    const data: TransactionData = {
+      userId: this.userId,
+      id: this.id,
+      accountId: account ? account.id : this.accountId,
+      categoryId: newCategoryId,
+      type: input.type ?? this.type,
+      amount: input.amount ?? this.amount,
+      currency: account ? account.currency : this.currency,
+      date: input.date ?? this.date,
+      description: newDescription,
+      transferId: this.transferId,
+      isArchived: this.isArchived,
+      version: this.version,
+      createdAt: this.createdAt,
+      updatedAt: now,
+    };
+
+    return new TransactionEntity(data, {
+      newAccount: account,
+      newCategory: category ?? undefined,
+    });
+  }
+
+  archive({
+    clock = () => new Date(),
+  }: { clock?: () => Date } = {}): TransactionEntity {
+    if (this.isArchived) {
+      throw new ModelError("Cannot archive archived transaction");
+    }
+
+    const data: TransactionData = {
+      userId: this.userId,
+      id: this.id,
+      accountId: this.accountId,
+      categoryId: this.categoryId,
+      type: this.type,
+      amount: this.amount,
+      currency: this.currency,
+      date: this.date,
+      description: this.description,
+      transferId: this.transferId,
+      isArchived: true,
+      version: this.version,
+      createdAt: this.createdAt,
+      updatedAt: clock().toISOString(),
+    };
+
+    return new TransactionEntity(data);
+  }
+
+  toData(): TransactionData {
+    return {
+      userId: this.userId,
+      id: this.id,
+      accountId: this.accountId,
+      categoryId: this.categoryId,
+      type: this.type,
+      amount: this.amount,
+      currency: this.currency,
+      date: this.date,
+      description: this.description,
+      transferId: this.transferId,
+      isArchived: this.isArchived,
+      version: this.version,
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    };
+  }
+
+  private static assertInvariants(
+    data: TransactionData,
+    relations?: { newAccount?: Account; newCategory?: Category },
+  ): void {
+    const newAccount = relations?.newAccount;
+    const newCategory = relations?.newCategory;
+
+    if (newAccount) {
+      if (newAccount.userId !== data.userId) {
+        throw new ModelError("Account does not belong to user");
+      }
+
+      if (newAccount.isArchived) {
+        throw new ModelError("Account must not be archived");
+      }
+    }
+
+    if (data.amount <= 0) {
+      throw new ModelError("Amount must be positive");
+    }
+
+    const isTransfer =
+      data.type === TransactionType.TRANSFER_IN ||
+      data.type === TransactionType.TRANSFER_OUT;
+
+    if (isTransfer && newCategory) {
+      throw new ModelError("Transfer transactions cannot have a category");
+    }
+
+    if (isTransfer) {
+      if (!data.transferId) {
+        throw new ModelError("Transfer transactions must include transferId");
+      }
+    } else {
+      if (data.transferId) {
+        throw new ModelError(
+          "Only transfer transactions can include transferId",
+        );
+      }
+    }
+
+    if (newCategory) {
+      if (newCategory.userId !== data.userId) {
+        throw new ModelError("Category does not belong to user");
+      }
+
+      if (newCategory.isArchived) {
+        throw new ModelError("Category must not be archived");
+      }
+
+      const typeMismatch =
+        (newCategory.type === CategoryType.INCOME &&
+          data.type !== TransactionType.INCOME) ||
+        (newCategory.type === CategoryType.EXPENSE &&
+          data.type !== TransactionType.EXPENSE &&
+          data.type !== TransactionType.REFUND);
+
+      if (typeMismatch) {
+        throw new ModelError("Category type does not match transaction type");
+      }
+    }
+
+    if (
+      data.description &&
+      data.description.length > DESCRIPTION_MAX_LENGTH
+    ) {
+      throw new ModelError(
+        `Description cannot exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run the new test file to confirm the first case passes**
+
+Run: `npm --prefix backend test -- src/models/transaction-entity.test.ts`
+Expected: PASS (the single case).
+
+- [ ] **Step 3: Run full test suite to confirm nothing else broke**
+
+Run: `npm --prefix backend test`
+Expected: all pass. The old `transaction.test.ts` still exercises the free functions, which are untouched.
+
+- [ ] **Step 4: Stage changes**
+
+```bash
+git add backend/src/models/transaction.ts backend/src/models/transaction-entity.test.ts
+```
+
+---
+
+## Task 4: Port remaining test cases from `transaction.test.ts`
+
+Port every remaining `describe` block from the existing `backend/src/models/transaction.test.ts` into `transaction-entity.test.ts`, mapping free functions to class members. **Do not delete the old file yet** — it keeps the free functions covered until Task 11.
+
+Mapping:
+
+- `createTransactionModel(input, deps)` → `TransactionEntity.create(input, deps)`
+- `updateTransactionModel(existing, input, deps)` → `existing.update(input, deps)` (where `existing` comes from `fakeTransaction()` which returns an instance — see Task 6)
+- `archiveTransactionModel(existing, deps)` → `existing.archive(deps)`
+- `getSignedAmount(transaction)` → `transaction.signedAmount`
+
+At this point `fakeTransaction()` still returns a plain object. Use `TransactionEntity.fromPersistence(fakeTransaction())` inside the ported tests for every case that currently passes the fake into an update/archive/getSignedAmount function. This is temporary — Task 6 converts `fakeTransaction` to return an instance, then remove the `fromPersistence` wrapper.
+
+- [ ] **Step 1: Add `describe("fromPersistence")` block to `transaction-entity.test.ts`** `[requires jest-tests skill]`
+
+Append after the existing `describe("create")`:
+
+```ts
+  describe("fromPersistence", () => {
+    it("reconstructs an instance from data", () => {
+      const data = fakeTransactionData();
+      const result = TransactionEntity.fromPersistence(data);
+
+      expect(result.toData()).toEqual(data);
+    });
+
+    it("rejects data with non-positive amount", () => {
+      const data = fakeTransactionData({ amount: 0 });
+
+      expect(() => TransactionEntity.fromPersistence(data)).toThrow(
+        new ModelError("Amount must be positive"),
+      );
+    });
+
+    it("rejects non-transfer data with transferId", () => {
+      const data = fakeTransactionData({
+        type: TransactionType.EXPENSE,
+        transferId: faker.string.uuid(),
+      });
+
+      expect(() => TransactionEntity.fromPersistence(data)).toThrow(
+        new ModelError("Only transfer transactions can include transferId"),
+      );
+    });
+
+    it("rejects transfer data without transferId", () => {
+      const data = fakeTransactionData({
+        type: TransactionType.TRANSFER_OUT,
+        transferId: undefined,
+        categoryId: undefined,
+      });
+
+      expect(() => TransactionEntity.fromPersistence(data)).toThrow(
+        new ModelError("Transfer transactions must include transferId"),
+      );
+    });
+
+    it("does not require an account argument", () => {
+      // Sanity: even if the stored record references an account we never load,
+      // fromPersistence succeeds because ownership checks only run when relations
+      // are supplied.
+      const data = fakeTransactionData();
+      expect(() => TransactionEntity.fromPersistence(data)).not.toThrow();
+    });
+  });
+```
+
+`fakeTransactionData` does not exist yet. Add it to `transaction-fakes.ts` now:
+
+```ts
+export const fakeTransactionData = (
+  overrides: Partial<TransactionData> = {},
+): TransactionData => {
+  const now = new Date().toISOString();
+  return {
+    id: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    accountId: faker.string.uuid(),
+    amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
+    type: TransactionType.EXPENSE,
+    currency: "USD",
+    description: faker.finance.transactionDescription(),
+    date: toDateString(faker.date.recent().toISOString().split("T")[0]),
+    categoryId: faker.string.uuid(),
+    isArchived: false,
+    version: faker.number.int({ min: 1, max: 100 }),
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+```
+
+Update the import in `transaction-fakes.ts` to pull `TransactionData` from `../../../models/transaction`.
+
+Update the test file to import `fakeTransactionData` from the fakes module.
+
+- [ ] **Step 2: Add `describe("signedAmount")` block** `[requires jest-tests skill]`
+
+```ts
+  describe("signedAmount", () => {
+    it("returns positive amount for INCOME transactions", () => {
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({ type: TransactionType.INCOME, amount: 100 }),
+      );
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns positive amount for REFUND transactions", () => {
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({ type: TransactionType.REFUND, amount: 100 }),
+      );
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns positive amount for TRANSFER_IN transactions", () => {
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({
+          type: TransactionType.TRANSFER_IN,
+          amount: 100,
+          transferId: faker.string.uuid(),
+          categoryId: undefined,
+        }),
+      );
+      expect(tx.signedAmount).toBe(100);
+    });
+
+    it("returns negative amount for EXPENSE transactions", () => {
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({ type: TransactionType.EXPENSE, amount: 100 }),
+      );
+      expect(tx.signedAmount).toBe(-100);
+    });
+
+    it("returns negative amount for TRANSFER_OUT transactions", () => {
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({
+          type: TransactionType.TRANSFER_OUT,
+          amount: 100,
+          transferId: faker.string.uuid(),
+          categoryId: undefined,
+        }),
+      );
+      expect(tx.signedAmount).toBe(-100);
+    });
+
+    it("throws error for unknown transaction type", () => {
+      // Bypass invariants via Object.assign on a valid instance, because
+      // fromPersistence would reject the unknown type.
+      const tx = TransactionEntity.fromPersistence(
+        fakeTransactionData({ type: TransactionType.EXPENSE }),
+      );
+      Object.defineProperty(tx, "type", { value: "UNKNOWN" });
+      expect(() => tx.signedAmount).toThrow(
+        "Unknown transaction type: UNKNOWN",
+      );
+    });
+  });
+```
+
+- [ ] **Step 3: Port the remaining `describe("createTransactionModel")` cases into `describe("create")`** `[requires jest-tests skill]`
+
+Open `backend/src/models/transaction.test.ts`. For every `it(...)` under `describe("createTransactionModel", ...)` other than the first (already ported), copy it into the `describe("create", ...)` block in `transaction-entity.test.ts` and replace `createTransactionModel(...)` with `TransactionEntity.create(...)`. Replace any assertion that expects a plain object shape (e.g. `expect(result).toEqual({ ... })`) with `expect(result.toData()).toEqual({ ... })`. For assertions on single fields (e.g. `expect(result.categoryId).toBeUndefined()`), access works directly on the instance — no `.toData()` needed.
+
+- [ ] **Step 4: Port `describe("updateTransactionModel")` cases into `describe("update")`** `[requires jest-tests skill]`
+
+For each `it(...)`:
+
+- Replace `const existing = fakeTransaction({ ... })` with `const existing = TransactionEntity.fromPersistence(fakeTransactionData({ ... }))`. (Task 6 changes `fakeTransaction` to return an instance — these `fromPersistence` wrappers will be removed in Task 6.)
+- Replace `updateTransactionModel(existing, input, fixedDeps)` with `existing.update(input, fixedDeps)`.
+- Replace `updateTransactionModel(existing, input)` (no deps) with `existing.update(input)`.
+- Field assertions work directly on the returned instance.
+
+- [ ] **Step 5: Port `describe("archiveTransactionModel")` cases into `describe("archive")`** `[requires jest-tests skill]`
+
+Same pattern. `archiveTransactionModel(existing, deps)` → `existing.archive(deps)`.
+
+- [ ] **Step 6: Add `describe("toData")` block** `[requires jest-tests skill]`
+
+```ts
+  describe("toData", () => {
+    it("returns a plain object with all data fields", () => {
+      const data = fakeTransactionData();
+      const tx = TransactionEntity.fromPersistence(data);
+
+      expect(tx.toData()).toEqual(data);
+    });
+
+    it("does not expose instance methods on the returned object", () => {
+      const tx = TransactionEntity.fromPersistence(fakeTransactionData());
+      const result = tx.toData() as unknown as Record<string, unknown>;
+
+      expect(result.update).toBeUndefined();
+      expect(result.archive).toBeUndefined();
+      expect(result.toData).toBeUndefined();
+      expect(result.signedAmount).toBeUndefined();
+    });
+  });
+```
+
+- [ ] **Step 7: Run the new test file**
+
+Run: `npm --prefix backend test -- src/models/transaction-entity.test.ts`
+Expected: all cases pass.
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass (the old `transaction.test.ts` still passes against free functions).
+
+- [ ] **Step 9: Stage changes**
+
+```bash
+git add backend/src/models/transaction-entity.test.ts backend/src/utils/test-utils/models/transaction-fakes.ts
+```
+
+---
+
+## Task 5: Re-point Zod schema to `TransactionData`
+
+**Files:**
+- Modify: `backend/src/repositories/schemas/transaction.ts`
+
+- [ ] **Step 1: Update type assertion on the schema**
+
+Replace:
+
+```ts
+import type { Transaction } from "../../models/transaction";
+...
+}) satisfies z.ZodType<Transaction>;
+```
+
+with:
+
+```ts
+import type { TransactionData } from "../../models/transaction";
+...
+}) satisfies z.ZodType<TransactionData>;
+```
+
+No other changes — the `z.object({ ... })` body stays identical because `TransactionData` currently has the same shape as `Transaction`.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm --prefix backend run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Run full tests**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 4: Stage changes**
+
+```bash
+git add backend/src/repositories/schemas/transaction.ts
+```
+
+---
+
+## Task 6: Update `fakeTransaction` to return a `TransactionEntity` instance
+
+**Files:**
+- Modify: `backend/src/utils/test-utils/models/transaction-fakes.ts`
+- Modify: `backend/src/models/transaction-entity.test.ts`
+
+- [ ] **Step 1: Rewrite `fakeTransaction`**
+
+In `backend/src/utils/test-utils/models/transaction-fakes.ts`, change the existing `fakeTransaction` body to delegate through `fakeTransactionData`:
+
+```ts
+import {
+  CreateTransactionInput,
+  Transaction,
+  TransactionData,
+  TransactionEntity,
+  TransactionPattern,
+  TransactionType,
+} from "../../../models/transaction";
+import { toDateString } from "../../../types/date";
+import { fakeAccount } from "./account-fakes";
+
+export const fakeTransactionData = (
+  overrides: Partial<TransactionData> = {},
+): TransactionData => {
+  const now = new Date().toISOString();
+  return {
+    id: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    accountId: faker.string.uuid(),
+    amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
+    type: TransactionType.EXPENSE,
+    currency: "USD",
+    description: faker.finance.transactionDescription(),
+    date: toDateString(faker.date.recent().toISOString().split("T")[0]),
+    categoryId: faker.string.uuid(),
+    isArchived: false,
+    version: faker.number.int({ min: 1, max: 100 }),
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+};
+
+export const fakeTransaction = (
+  overrides: Partial<TransactionData> = {},
+): Transaction => TransactionEntity.fromPersistence(fakeTransactionData(overrides));
+```
+
+Keep `fakeCreateTransactionInput` and `fakeTransactionPattern` unchanged.
+
+Note: the parameter type of `fakeTransaction` changes from `Partial<Transaction>` to `Partial<TransactionData>`. This is safe: no call site of `fakeTransaction` passes a method — grep with `rg 'fakeTransaction\(\{[^}]*(update|archive|signedAmount|toData)'` to confirm.
+
+- [ ] **Step 2: Remove temporary `fromPersistence` wrappers from `transaction-entity.test.ts`** `[requires jest-tests skill]`
+
+Inside `transaction-entity.test.ts`, every `TransactionEntity.fromPersistence(fakeTransactionData({ ... }))` that was introduced as a bridge in Task 4 Steps 4–5 (for update/archive/signedAmount cases where the existing transaction instance is needed) collapses back to `fakeTransaction({ ... })`. Cases in the `fromPersistence` describe block keep using `fakeTransactionData` (the data shape under test).
+
+- [ ] **Step 3: Run new test file**
+
+Run: `npm --prefix backend test -- src/models/transaction-entity.test.ts`
+Expected: all pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass. The old `transaction.test.ts` still passes because free functions accept either the plain `Transaction` shape or an entity instance (instance has all the data fields via readonly).
+
+- [ ] **Step 5: Stage changes**
+
+```bash
+git add backend/src/utils/test-utils/models/transaction-fakes.ts backend/src/models/transaction-entity.test.ts
+```
+
+---
+
+## Task 7: Migrate `DynTransactionRepository` to use the entity
+
+**Files:**
+- Modify: `backend/src/repositories/dyn-transaction-repository.ts`
+
+- [ ] **Step 1: Import `TransactionEntity` and wrap Zod outputs**
+
+At the top of `dyn-transaction-repository.ts`, add `TransactionEntity` to the existing import from `../models/transaction`:
+
+```ts
+import {
+  Transaction,
+  TransactionEntity,
+  TransactionPattern,
+  TransactionPatternType,
+  TransactionType,
+} from "../models/transaction";
+```
+
+- [ ] **Step 2: Wrap each `hydrate(transactionSchema, ...)` call with `TransactionEntity.fromPersistence`**
+
+Every read method currently builds a `Transaction` from the Zod parse. For each occurrence, wrap the parsed data in `TransactionEntity.fromPersistence(...)`. The locations (from grep on the current file):
+
+- `const transaction = hydrate(transactionSchema, result.Item);` → `const transaction = TransactionEntity.fromPersistence(hydrate(transactionSchema, result.Item));`
+- Any `items.map((item) => hydrate(transactionSchema, item))` pattern → `items.map((item) => TransactionEntity.fromPersistence(hydrate(transactionSchema, item)))`
+- For the pagination call that uses `transactionDbItemSchema`: the returned items carry `createdAtSortable`. Strip `createdAtSortable` before calling `fromPersistence`:
+
+  ```ts
+  items.map((item) => {
+    const dbItem = hydrate(transactionDbItemSchema, item);
+    const { createdAtSortable: _createdAtSortable, ...data } = dbItem;
+    return TransactionEntity.fromPersistence(data);
+  });
+  ```
+
+  (Name the unused destructured field with a leading underscore or use whatever convention the codebase uses for ignored destructuring.)
+
+- [ ] **Step 3: Serialize via `.toData()` on writes**
+
+In `create`, replace `const dbItem: TransactionDbItem = { ...transaction, createdAtSortable: ... }` with:
+
+```ts
+const data = transaction.toData();
+const dbItem: TransactionDbItem = {
+  ...data,
+  createdAtSortable: buildCreatedAtSortable(data),
+};
+```
+
+(Preserve whatever exact expression the current code uses to compute `createdAtSortable`.)
+
+In `createMany`, apply the same `.toData()` pattern inside the `.map(...)` that builds `dbItem`s.
+
+In `update` and `updateMany`, the function `buildUpdateParams(transaction)` is called. Open `buildUpdateParams` in the same file and change its signature from accepting `Transaction` to accepting either `Transaction` (still works — fields are readable) or to internally call `.toData()`. Simplest: at the top of `buildUpdateParams`, do:
+
+```ts
+const data = transaction.toData();
+```
+
+and reference `data.foo` instead of `transaction.foo` for the rest of the function body. This guarantees serialization consistency.
+
+- [ ] **Step 4: Return `Transaction` instance from `update` and `updateMany`**
+
+Current `update` returns `{ ...transaction, version: transaction.version + 1 }`. Change to:
+
+```ts
+return TransactionEntity.fromPersistence({
+  ...transaction.toData(),
+  version: transaction.version + 1,
+});
+```
+
+Current `updateMany` returns an array of similar plain objects. Change to:
+
+```ts
+return transactions.map((transaction) =>
+  TransactionEntity.fromPersistence({
+    ...transaction.toData(),
+    version: transaction.version + 1,
+  }),
+);
+```
+
+- [ ] **Step 5: Run repository integration test**
+
+Run: `npm --prefix backend test -- src/repositories/dyn-transaction-repository.test.ts`
+Expected: all pass. Any failures likely involve assertions comparing returned objects to plain-object literals — Jest's `toEqual` treats instances with matching fields as equal, so this usually works. If a strict `toStrictEqual` is used, convert expected values through `TransactionEntity.fromPersistence(fakeTransactionData({ ... }))` or assert on `.toData()` equality.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 7: Stage changes**
+
+```bash
+git add backend/src/repositories/dyn-transaction-repository.ts
+```
+
+---
+
+## Task 8: Drop injected model functions from `TransactionServiceImpl`
+
+**Files:**
+- Modify: `backend/src/services/transaction-service.ts`
+- Modify: `backend/src/services/transaction-service.test.ts`
+
+- [ ] **Step 1: Update imports in `transaction-service.ts`**
+
+Replace:
+
+```ts
+import {
+  NonTransferTransactionType,
+  Transaction,
+  TransactionPattern,
+  TransactionPatternType,
+  TransactionType,
+  archiveTransactionModel as defaultArchiveTransactionModel,
+  createTransactionModel as defaultCreateTransactionModel,
+  updateTransactionModel as defaultUpdateTransactionModel,
+} from "../models/transaction";
+```
+
+with:
+
+```ts
+import {
+  NonTransferTransactionType,
+  Transaction,
+  TransactionEntity,
+  TransactionPattern,
+  TransactionPatternType,
+  TransactionType,
+} from "../models/transaction";
+```
+
+- [ ] **Step 2: Drop injected model fields and constructor params**
+
+In `TransactionServiceImpl`, delete these private fields:
+
+```ts
+private createTransactionModel: typeof defaultCreateTransactionModel;
+private updateTransactionModel: typeof defaultUpdateTransactionModel;
+private archiveTransactionModel: typeof defaultArchiveTransactionModel;
+```
+
+Delete their constructor-param counterparts in the `deps` object type. Delete their assignments in the constructor body. The remaining constructor takes only `accountRepository`, `categoryRepository`, `transactionRepository`.
+
+- [ ] **Step 3: Replace `createTransaction` body's model call**
+
+Replace:
+
+```ts
+const transaction = this.createTransactionModel({
+  ...input,
+  userId,
+  account,
+  category,
+});
+```
+
+with:
+
+```ts
+const transaction = TransactionEntity.create({
+  ...input,
+  userId,
+  account,
+  category,
+});
+```
+
+- [ ] **Step 4: Replace `updateTransaction` body's model call**
+
+Replace:
+
+```ts
+const updated = this.updateTransactionModel(existingTransaction, {
+  account,
+  category,
+  type: input.type,
+  amount: input.amount,
+  date: input.date,
+  description: input.description,
+});
+```
+
+with:
+
+```ts
+const updated = existingTransaction.update({
+  account,
+  category,
+  type: input.type,
+  amount: input.amount,
+  date: input.date,
+  description: input.description,
+});
+```
+
+- [ ] **Step 5: Replace `deleteTransaction` body's model call**
+
+Replace:
+
+```ts
+const archived = this.archiveTransactionModel(existingTransaction);
+```
+
+with:
+
+```ts
+const archived = existingTransaction.archive();
+```
+
+- [ ] **Step 6: Remove model-function injections from `transaction-service.test.ts`** `[requires jest-tests skill]`
+
+Search for any test setup that builds `TransactionServiceImpl` with injected `createTransactionModel`, `updateTransactionModel`, or `archiveTransactionModel`. Delete those injections. If a test asserts a mock was called (e.g. `expect(mockCreateTransactionModel).toHaveBeenCalledWith(...)`), rewrite the assertion to check the persisted state on the repository mock instead — e.g. `expect(transactionRepository.create).toHaveBeenCalledWith(expect.objectContaining({ amount: 42 }))`.
+
+- [ ] **Step 7: Run service test**
+
+Run: `npm --prefix backend test -- src/services/transaction-service.test.ts`
+Expected: all pass.
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 9: Stage changes**
+
+```bash
+git add backend/src/services/transaction-service.ts backend/src/services/transaction-service.test.ts
+```
+
+---
+
+## Task 9: Drop injected model functions from `TransferService`
+
+**Files:**
+- Modify: `backend/src/services/transfer-service.ts`
+- Modify: `backend/src/services/transfer-service.test.ts`
+
+- [ ] **Step 1: Update imports**
+
+Replace:
+
+```ts
+import {
+  Transaction,
+  TransactionType,
+  archiveTransactionModel as defaultArchiveTransactionModel,
+  createTransactionModel as defaultCreateTransactionModel,
+  updateTransactionModel as defaultUpdateTransactionModel,
+} from "../models/transaction";
+```
+
+with:
+
+```ts
+import {
+  Transaction,
+  TransactionEntity,
+  TransactionType,
+} from "../models/transaction";
+```
+
+- [ ] **Step 2: Drop injected fields and constructor params**
+
+Delete the three private model fields and their constructor wiring (mirror Task 8 Step 2).
+
+- [ ] **Step 3: Replace model calls in `createTransfer`**
+
+Replace the two `this.createTransactionModel({ ... })` calls (lines 115 and 126 in the current file) with `TransactionEntity.create({ ... })`. Arguments unchanged.
+
+- [ ] **Step 4: Replace model call in `deleteTransfer`**
+
+Replace:
+
+```ts
+const archivedTransactions = transferTransactions.map((transaction) =>
+  this.archiveTransactionModel(transaction),
+);
+```
+
+with:
+
+```ts
+const archivedTransactions = transferTransactions.map((transaction) =>
+  transaction.archive(),
+);
+```
+
+- [ ] **Step 5: Replace model calls in `updateTransfer`**
+
+Replace:
+
+```ts
+const updatedOutbound = this.updateTransactionModel(outboundTransaction, { ... });
+const updatedInbound = this.updateTransactionModel(inboundTransaction, { ... });
+```
+
+with:
+
+```ts
+const updatedOutbound = outboundTransaction.update({ ... });
+const updatedInbound = inboundTransaction.update({ ... });
+```
+
+- [ ] **Step 6: Remove model-function injections from `transfer-service.test.ts`** `[requires jest-tests skill]`
+
+Same pattern as Task 8 Step 6.
+
+- [ ] **Step 7: Run service test**
+
+Run: `npm --prefix backend test -- src/services/transfer-service.test.ts`
+Expected: all pass.
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 9: Stage changes**
+
+```bash
+git add backend/src/services/transfer-service.ts backend/src/services/transfer-service.test.ts
+```
+
+---
+
+## Task 10: Migrate `getSignedAmount` call sites
+
+**Files:**
+- Modify: `backend/src/services/account-service.ts`
+- Modify: `backend/src/services/by-category-report-service.ts`
+- Modify: `backend/src/langchain/tools/aggregate-transactions.ts`
+
+- [ ] **Step 1: `account-service.ts`**
+
+Remove the import of `getSignedAmount` from `../models/transaction`. Replace `(sum, transaction) => sum + getSignedAmount(transaction)` with `(sum, transaction) => sum + transaction.signedAmount`.
+
+- [ ] **Step 2: `by-category-report-service.ts`**
+
+Remove the `getSignedAmount` import. Open the file and locate the two call sites (from grep): around line 89 (`-getSignedAmount(transaction)`) and line 100 (`amountGetter = getSignedAmount`). The local `amountGetter: typeof getSignedAmount` typing becomes `amountGetter: (transaction: Transaction) => number`. The two branches:
+
+```ts
+// before
+let amountGetter: typeof getSignedAmount;
+if (invertAmounts) {
+  amountGetter = (transaction) => -getSignedAmount(transaction);
+} else {
+  amountGetter = getSignedAmount;
+}
+```
+
+```ts
+// after
+let amountGetter: (transaction: Transaction) => number;
+if (invertAmounts) {
+  amountGetter = (transaction) => -transaction.signedAmount;
+} else {
+  amountGetter = (transaction) => transaction.signedAmount;
+}
+```
+
+Adjust imports so `Transaction` is in scope if not already.
+
+- [ ] **Step 3: `aggregate-transactions.ts`**
+
+Remove `getSignedAmount` from the import `{ TransactionType, getSignedAmount }`. Replace `const signedAmount = getSignedAmount(transaction);` with `const signedAmount = transaction.signedAmount;`.
+
+- [ ] **Step 4: Run tests for the affected areas**
+
+Run: `npm --prefix backend test -- src/services/account-service.test.ts src/services/by-category-report-service.test.ts src/langchain/tools/aggregate-transactions.test.ts`
+Expected: all pass.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 6: Stage changes**
+
+```bash
+git add backend/src/services/account-service.ts backend/src/services/by-category-report-service.ts backend/src/langchain/tools/aggregate-transactions.ts
+```
+
+---
+
+## Task 11: Delete free functions, delete old test file, tighten `Transaction` interface
+
+**Files:**
+- Modify: `backend/src/models/transaction.ts`
+- Delete: `backend/src/models/transaction.test.ts`
+
+- [ ] **Step 1: Delete free functions from `transaction.ts`**
+
+Remove the four exports:
+
+- `export function createTransactionModel(...)` block.
+- `export function updateTransactionModel(...)` block.
+- `export function archiveTransactionModel(...)` block.
+- `export function getSignedAmount(...)` block.
+
+The private helper `assertTransactionInvariants` (old free-function version) is now unreferenced — delete it. The `normalizeDescription` helper is still referenced by `TransactionEntity.create` and `TransactionEntity.update` — keep it.
+
+- [ ] **Step 2: Tighten `Transaction` interface**
+
+Replace:
+
+```ts
+export interface Transaction {
+  userId: string;
+  id: string;
+  // ... all fields ...
+}
+```
+
+with:
+
+```ts
+export interface Transaction extends TransactionData {
+  readonly signedAmount: number;
+  update(
+    input: UpdateTransactionInput,
+    deps?: { clock?: () => Date },
+  ): Transaction;
+  archive(deps?: { clock?: () => Date }): Transaction;
+  toData(): TransactionData;
+}
+```
+
+Move `TransactionData` above `Transaction` in the file (if not already) so the `extends` resolves.
+
+- [ ] **Step 3: Declare that `TransactionEntity implements Transaction`**
+
+Change the class declaration from `export class TransactionEntity {` to `export class TransactionEntity implements Transaction {`. TypeScript will verify every member of `Transaction` is present on the class. The return types of `create`, `fromPersistence`, `update`, `archive` can tighten from `TransactionEntity` to `Transaction` (optional — leaving them as `TransactionEntity` is still valid since `TransactionEntity implements Transaction`). Prefer to return `Transaction` from public statics and instance methods so callers code against the interface:
+
+```ts
+static create(...): Transaction { ... }
+static fromPersistence(...): Transaction { ... }
+update(...): Transaction { ... }
+archive(...): Transaction { ... }
+```
+
+- [ ] **Step 4: Delete the old test file**
+
+```bash
+git rm backend/src/models/transaction.test.ts
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `npm --prefix backend run typecheck`
+Expected: clean. Any error here is a consumer that still imports one of the deleted free functions — fix by migrating the consumer (should not happen if Tasks 8–10 covered everything; grep to confirm: `rg 'createTransactionModel|updateTransactionModel|archiveTransactionModel|getSignedAmount' backend/src` — only the `transaction.ts` file should remain, and only via the class's private helper references if any, which there shouldn't be).
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 7: Stage changes**
+
+```bash
+git add backend/src/models/transaction.ts
+```
+
+---
+
+## Task 12: Final validation pipeline
+
+- [ ] **Step 1: Run full test suite from backend root**
+
+Run: `npm --prefix backend test`
+Expected: all pass.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm --prefix backend run typecheck`
+Expected: clean.
+
+- [ ] **Step 3: Run formatter / linter**
+
+Run: `npm --prefix backend run format`
+Expected: clean; no files reformatted unexpectedly. If any files are touched, stage them.
+
+- [ ] **Step 4: Grep for leftover references to the removed free functions**
+
+Run: `grep -rn "createTransactionModel\|updateTransactionModel\|archiveTransactionModel\|getSignedAmount" backend/src`
+Expected: no results.
+
+- [ ] **Step 5: Grep for direct `getSignedAmount` imports in any overlooked file**
+
+Run: `grep -rn "from .*models/transaction" backend/src | grep -v test`
+Expected: imports use `Transaction`, `TransactionData`, `TransactionEntity`, `TransactionType`, `NonTransferTransactionType`, `TransactionPattern`, `TransactionPatternType`, `CreateTransactionInput`, `UpdateTransactionInput` — nothing else.
+
+- [ ] **Step 6: Stop and hand off for user review**
+
+All staged. Working tree is ready for the user to inspect with `git diff --cached` and commit when they choose.
+
+---
+
+## Acceptance
+
+All checked from Task 12:
+
+- Full backend test suite passes.
+- `npm --prefix backend run typecheck` clean.
+- `npm --prefix backend run format` clean.
+- No remaining references to `createTransactionModel`, `updateTransactionModel`, `archiveTransactionModel`, or `getSignedAmount` in `backend/src`.
+- `Transaction`, `TransactionData`, `TransactionEntity` exported from `backend/src/models/transaction.ts`.
+- `DynTransactionRepository` read methods return `TransactionEntity` instances typed as `Transaction`.
+- `DynTransactionRepository.update` and `updateMany` return `TransactionEntity` instances with bumped version.
+- `TransactionServiceImpl` and `TransferService` no longer accept injected model functions.

--- a/docs/superpowers/specs/2026-04-24-transaction-entity-design.md
+++ b/docs/superpowers/specs/2026-04-24-transaction-entity-design.md
@@ -1,0 +1,351 @@
+# Transaction Domain Entity Design
+
+## Goal
+
+Replace the current `Transaction` interface + free functions (`createTransactionModel`, `updateTransactionModel`, `archiveTransactionModel`, `getSignedAmount`) with a DDD-style domain entity: a class that encapsulates transaction state, enforces invariants, and exposes a stable domain contract via an interface.
+
+## Motivation
+
+- Today a `Transaction` is a plain interface. Any caller can build a value of that shape without running invariants. Invariants exist only inside the free factory/updater functions.
+- Free functions are imported and injected into services (`createTransactionModel as defaultCreateTransactionModel` etc.) for testability. No test actually exercises the injection — it is dead flexibility.
+- Domain logic (`getSignedAmount`) lives as a free function while the data it operates on is a plain record. Splitting state and behavior is the classical anaemic-domain-model smell.
+- A class lets us attach state transitions, invariant checks, and derived values to a single addressable domain concept. New fields added to the interface are picked up by the class automatically; new behavior lives next to the data it operates on.
+
+Scope is **`Transaction` only**. `Account`, `Category`, `User` stay as plain interfaces. If this pilot lands cleanly, rollout to other entities is separate work.
+
+## Design Decisions (from brainstorming)
+
+1. **Immutable entity.** Instance fields are `readonly`. Methods like `update()` and `archive()` return a new instance rather than mutating `this`. Chosen after explicit comparison with mutable: pre-image access, predictable serialization, and temporal reasoning during debugging matter more in this codebase than the minor ergonomic wins of mutable DDD.
+2. **Two-layer type split.**
+   - `TransactionData` — pure data shape. The storage / serialization contract. Used by Zod schemas, DynamoDB marshalling, and the persistence boundary.
+   - `Transaction` — extends `TransactionData` with domain methods and computed getters. The contract services consume.
+3. **Class implements the interface.** Class name: `TransactionEntity`. Consumers type against `Transaction`, not `TransactionEntity`.
+4. **Public `readonly` fields, not private `#fields` + getters.** For immutable state without storage-vs-API divergence, getters add ceremony without a practical guarantee beyond `readonly`. Derived values (`signedAmount`) use `get`.
+5. **Named static factories.**
+   - `TransactionEntity.create(input, deps)` — build a new transaction. Generates id, timestamps, sets `version = 0`, `isArchived = false`. Runs full invariants.
+   - `TransactionEntity.fromPersistence(data)` — rehydrate from a validated `TransactionData` (Zod-validated at repo boundary). Runs full invariants to catch DB drift. Trusts `id`, `createdAt`, `updatedAt`, `version` as provided.
+   - Private constructor — called by both factories; assigns fields; runs invariants.
+6. **Invariants re-run on rehydration.** Catches records written before an invariant was added. Cost is a handful of synchronous checks on a flat object; benefit is that every in-memory `Transaction` is guaranteed valid by current rules regardless of origin.
+7. **Version (OCC token) stays owned by the repository.** Entity methods (`update`, `archive`) do not touch `version`. Repo reads the incoming entity's version for its DynamoDB conditional check, writes `version + 1`, and returns a new entity reflecting the persisted version (via `TransactionEntity.fromPersistence`). Rationale:
+   - The version represents "how many times this has been persisted", not "how many in-memory transformations have been applied". Chained `tx.update(a).update(b)` must bump once per persist, not twice.
+   - Putting the bump in the entity is speculative — the increment reflects a write that may not land.
+   - OCC is one concern; splitting it across entity and repo multiplies reasoning surface.
+8. **Repository speaks in instances both ways.** Reads return `Transaction` (really `TransactionEntity` instances, typed as `Transaction`). Writes accept `Transaction` and call `.toData()` internally for serialization. Service layer never sees raw `TransactionData`.
+9. **Big-bang migration.** Single coordinated change: introduce class, migrate every consumer, delete free functions. Scope is bounded to `Transaction`, so blast radius fits one reviewable PR. Avoids a temporary dual-API state.
+10. **Drop dependency-injected model functions from services.** Current `TransactionServiceImpl` and `TransferService` inject `createTransactionModel` / `updateTransactionModel` / `archiveTransactionModel` via constructor. No test uses the injection. Services call `TransactionEntity` static methods directly.
+11. **Existing test fakes evolve.** `fakeTransaction()` continues to return a value typed as `Transaction`. Concrete value becomes a `TransactionEntity` instance (built via `fromPersistence`), transparently to call sites. No explicit `fakeTransactionData` needed; rare cases call `.toData()`.
+
+## Types
+
+```ts
+// Pure data shape — storage, serialization, Zod.
+export interface TransactionData {
+  userId: string;
+  id: string;
+  accountId: string;
+  categoryId?: string;
+  type: TransactionType;
+  amount: number;
+  currency: string;
+  date: DateString;
+  description?: string;
+  transferId?: string;
+  isArchived: boolean;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Domain contract — what services consume.
+export interface Transaction extends TransactionData {
+  readonly signedAmount: number;
+  update(input: UpdateTransactionInput, deps?: { clock?: () => Date }): Transaction;
+  archive(deps?: { clock?: () => Date }): Transaction;
+  toData(): TransactionData;
+}
+
+// Implementation.
+export class TransactionEntity implements Transaction {
+  readonly userId: string;
+  readonly id: string;
+  readonly accountId: string;
+  readonly categoryId?: string;
+  readonly type: TransactionType;
+  readonly amount: number;
+  readonly currency: string;
+  readonly date: DateString;
+  readonly description?: string;
+  readonly transferId?: string;
+  readonly isArchived: boolean;
+  readonly version: number;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+
+  static create(
+    input: CreateTransactionInput,
+    deps?: { clock?: () => Date; idGenerator?: () => string },
+  ): Transaction;
+
+  static fromPersistence(data: TransactionData): Transaction;
+
+  private constructor(data: TransactionData);
+
+  get signedAmount(): number;
+
+  update(
+    input: UpdateTransactionInput,
+    deps?: { clock?: () => Date },
+  ): Transaction;
+
+  archive(deps?: { clock?: () => Date }): Transaction;
+
+  toData(): TransactionData;
+}
+```
+
+`CreateTransactionInput`, `UpdateTransactionInput`, `TransactionType`, `NonTransferTransactionType`, `TransactionPattern`, `TransactionPatternType` keep their current shapes and exports.
+
+## Behavior
+
+### `TransactionEntity.create(input, deps?)`
+
+Replaces `createTransactionModel`.
+
+1. `now = (deps.clock ?? () => new Date())().toISOString()`
+2. `id = (deps.idGenerator ?? randomUUID)()`
+3. Build `TransactionData`:
+   - `userId`, `type`, `amount`, `date`, `transferId` from `input`
+   - `accountId = input.account.id`
+   - `categoryId = input.category?.id`
+   - `currency = input.account.currency`
+   - `description = normalizeDescription(input.description)`
+   - `isArchived = false`
+   - `version = 0`
+   - `createdAt = updatedAt = now`
+4. Call private constructor with this `TransactionData` plus a reference to `input.account` and `input.category` so the constructor can run ownership/archive invariants against them. (Rationale: account/category ownership and archive checks require the full entities, not just ids. Keep the signature of the private constructor flexible enough to support this — see below.)
+5. Return instance typed as `Transaction`.
+
+Note on the construction path: the current code runs `assertTransactionInvariants({ transaction, newAccount, newCategory })`. The private constructor must accept either just `TransactionData` (for `fromPersistence`, where account/category are not in scope) or `TransactionData + { newAccount?, newCategory? }` (for `create` / `update`, which have the related entities on hand). Simplest shape:
+
+```ts
+private constructor(
+  data: TransactionData,
+  relations?: { newAccount?: Account; newCategory?: Category },
+);
+```
+
+`fromPersistence` passes `data` only. `create` and `update` pass the related entities in `relations` so ownership + archive checks run against them. The same `#assertInvariants` method covers both cases — only the invariants that depend on `relations` run when relations are present (mirrors current `assertTransactionInvariants` behavior: `if (newAccount) { ... }`).
+
+### `TransactionEntity.fromPersistence(data)`
+
+Replaces the repository's current behavior of returning Zod-parsed plain objects.
+
+1. Receives `TransactionData` (already Zod-validated at the repo boundary).
+2. Calls private constructor with `data` only (no relations — account/category are not loaded by the repo on transaction reads).
+3. Constructor runs invariants. Relation-dependent invariants (`newAccount`, `newCategory` archive/ownership checks) skip because relations are absent — matches current behavior where reads do not re-check account/category validity.
+4. Returns instance typed as `Transaction`.
+
+### `entity.update(input, deps?)`
+
+Replaces `updateTransactionModel`.
+
+1. If `this.isArchived` → throw `ModelError("Cannot update archived transaction")`.
+2. Resolve new values with current `undefined` vs `null` semantics:
+   - `accountId`, `currency` — from `input.account` if provided, else preserve current.
+   - `categoryId` — `undefined` = no change, `null` = clear, else use `input.category.id`.
+   - `description` — `undefined` = no change, `null` = clear, else `normalizeDescription(input.description)`.
+   - `type`, `amount`, `date` — `??` fallback to current.
+3. Build next `TransactionData`: all existing fields, overrides applied, `updatedAt = now`, `version` unchanged, `isArchived = false` (unchanged), `createdAt` unchanged, `id`/`userId`/`transferId` unchanged.
+4. Pass to private constructor with `relations = { newAccount: input.account, newCategory: input.category ?? undefined }`. Invariants run.
+5. Return new instance.
+
+### `entity.archive(deps?)`
+
+Replaces `archiveTransactionModel`.
+
+1. If `this.isArchived` → throw `ModelError("Cannot archive archived transaction")`.
+2. Build next `TransactionData`: all fields preserved, `isArchived = true`, `updatedAt = now`, `version` unchanged.
+3. Pass to private constructor (no relations).
+4. Return new instance.
+
+### `get signedAmount()`
+
+Replaces `getSignedAmount`.
+
+Returns positive `amount` for `INCOME`, `REFUND`, `TRANSFER_IN`; negative for `EXPENSE`, `TRANSFER_OUT`; throws `Error("Unknown transaction type: ...")` for unknown types. Logic is identical to the current free function.
+
+### `entity.toData()`
+
+Returns a plain object conforming to `TransactionData` — the class fields pulled into a fresh object, no methods. Used by the repository for persistence writes.
+
+## Invariants
+
+Unchanged from current `assertTransactionInvariants`. Moved to private method `#assertInvariants` on the class and invoked from the private constructor. Invariants:
+
+- If `relations.newAccount` present:
+  - `newAccount.userId === data.userId` else `ModelError("Account does not belong to user")`.
+  - `!newAccount.isArchived` else `ModelError("Account must not be archived")`.
+- `data.amount > 0` else `ModelError("Amount must be positive")`.
+- Transfer / transferId linkage:
+  - If `type ∈ { TRANSFER_IN, TRANSFER_OUT }`: must have `transferId` else `ModelError("Transfer transactions must include transferId")`.
+  - Transfer with `relations.newCategory` present → `ModelError("Transfer transactions cannot have a category")`.
+  - Non-transfer with `transferId` → `ModelError("Only transfer transactions can include transferId")`.
+- If `relations.newCategory` present:
+  - `newCategory.userId === data.userId` else `ModelError("Category does not belong to user")`.
+  - `!newCategory.isArchived` else `ModelError("Category must not be archived")`.
+  - Type match: INCOME category requires INCOME transaction; EXPENSE category requires EXPENSE or REFUND transaction. Else `ModelError("Category type does not match transaction type")`.
+- `description?.length <= DESCRIPTION_MAX_LENGTH` else `ModelError("Description cannot exceed N characters")`.
+
+## Persistence Boundary
+
+### Zod schema
+
+`backend/src/repositories/schemas/transaction.ts` currently declares `transactionSchema satisfies z.ZodType<Transaction>`. After the change, `Transaction` has methods, which Zod cannot produce. Re-point:
+
+```ts
+transactionSchema satisfies z.ZodType<TransactionData>
+```
+
+No behavioral change to the schema itself — it continues to describe the flat record.
+
+### Repository reads
+
+`DynTransactionRepository` currently does:
+
+```ts
+const transaction = hydrate(transactionSchema, result.Item);
+```
+
+After the change:
+
+```ts
+const data = hydrate(transactionSchema, result.Item);
+const transaction = TransactionEntity.fromPersistence(data);
+```
+
+Every read path that returns `Transaction` (or `Transaction[]`, or `TransactionConnection`) wraps Zod-validated data in `fromPersistence`. This includes `findOneById`, `findManyByUserId`, `findManyByUserIdPaginated`, `findManyByAccountId`, `findManyByTransferId`, `findManyByDescription`.
+
+`transactionDbItemSchema` (extends `transactionSchema` with `createdAtSortable`) returns `TransactionDbItem` — that type stays internal to the repo for pagination cursor computations; instances returned to callers strip `createdAtSortable` and wrap via `fromPersistence`.
+
+### Repository writes
+
+Current:
+
+```ts
+async create(transaction: Readonly<Transaction>): Promise<void> {
+  const dbItem: TransactionDbItem = { ...transaction, createdAtSortable: ... };
+  // PutCommand
+}
+```
+
+After the change, `transaction` is a class instance. Spread (`{ ...transaction }`) on a class instance does not enumerate getters or methods — only own enumerable properties. Readonly fields assigned via `Object.defineProperty` in the constructor may not be enumerable by default; fields assigned with `this.foo = ...` are enumerable. To be safe and explicit, use `toData()`:
+
+```ts
+async create(transaction: Readonly<Transaction>): Promise<void> {
+  const data = transaction.toData();
+  const dbItem: TransactionDbItem = { ...data, createdAtSortable: ... };
+  // PutCommand
+}
+```
+
+Same pattern in `createMany`, `update`, `updateMany`.
+
+### Return shape on `update` / `updateMany`
+
+Currently `update` returns `{ ...transaction, version: transaction.version + 1 }` — a plain object. After the change, the repo must return a `Transaction` instance so the service layer stays in class terms:
+
+```ts
+async update(transaction: Readonly<Transaction>): Promise<Transaction> {
+  // ... DynamoDB write with condition on transaction.version ...
+  return TransactionEntity.fromPersistence({
+    ...transaction.toData(),
+    version: transaction.version + 1,
+  });
+}
+```
+
+`updateMany` returns `Transaction[]` built the same way. No change to OCC semantics or the `ConditionExpression` / `VersionConflictError` machinery from PR #422.
+
+## Service Layer
+
+### `TransactionServiceImpl`
+
+Changes:
+
+- Drop constructor-injected model functions (`createTransactionModel`, `updateTransactionModel`, `archiveTransactionModel`) and their private fields.
+- `createTransaction`: replace `this.createTransactionModel(...)` with `TransactionEntity.create(...)`.
+- `updateTransaction`: replace `this.updateTransactionModel(existingTransaction, { ... })` with `existingTransaction.update({ ... })`.
+- `deleteTransaction`: replace `this.archiveTransactionModel(existingTransaction)` with `existingTransaction.archive()`.
+
+All other logic (pagination validation, filter validation, category type validation, pattern enrichment, description suggestions) unchanged.
+
+### `TransferService`
+
+Same shape of change:
+
+- Drop constructor-injected model functions.
+- `createTransfer`: replace the two `this.createTransactionModel(...)` calls with `TransactionEntity.create(...)`.
+- `deleteTransfer`: replace `this.archiveTransactionModel(transaction)` with `transaction.archive()`.
+- `updateTransfer`: replace `this.updateTransactionModel(...)` calls with `transaction.update(...)`.
+
+### `getSignedAmount` consumers
+
+Three call sites use the free function today. Each migrates to the instance getter:
+
+- `backend/src/services/account-service.ts` — `(sum, transaction) => sum + getSignedAmount(transaction)` → `(sum, transaction) => sum + transaction.signedAmount`.
+- `backend/src/langchain/tools/aggregate-transactions.ts` — `const signedAmount = getSignedAmount(transaction)` → `const signedAmount = transaction.signedAmount`.
+- `backend/src/services/by-category-report-service.ts` — two call sites of the same form. Both migrate to `.signedAmount`. The local variable `amountGetter: typeof getSignedAmount` (currently a function binding) becomes a callback `(t: Transaction) => number` that returns either `t.signedAmount` or `-t.signedAmount` depending on inversion; the `-getSignedAmount(transaction)` branch becomes `-transaction.signedAmount`.
+
+## Test Strategy
+
+### New test file — class behavior
+
+Rewrite `backend/src/models/transaction.test.ts` as tests for `TransactionEntity`. Structure: one top-level `describe("TransactionEntity")` with nested `describe` blocks mirroring the declaration order of the class (static factories first, then instance methods/getters — tests cannot exercise instance methods before construction works):
+
+- `describe("create")` — all cases currently under `describe("createTransactionModel")`.
+- `describe("fromPersistence")` — new cases: builds an instance from `TransactionData`, re-runs invariants (e.g., rejects amount ≤ 0, rejects transfer without transferId), does not re-check relation-dependent invariants (no account argument).
+- `describe("signedAmount")` — all cases currently under `describe("getSignedAmount")`.
+- `describe("update")` — all cases currently under `describe("updateTransactionModel")`.
+- `describe("archive")` — all cases currently under `describe("archiveTransactionModel")`.
+- `describe("toData")` — returns a plain object with the expected keys and values; the class' instance methods are not enumerable on the result; `result.toData` and `result.update` are `undefined` on the returned data.
+
+Test names stay without the "should" prefix (per recent commit #421).
+
+All assertions against a value of type `Transaction` (readable fields on the instance). `expect(result).toEqual({ ... })` assertions still work: Jest's `toEqual` treats class instances with matching fields as equal to plain objects.
+
+### Fakes
+
+`backend/src/utils/test-utils/models/transaction-fakes.ts`:
+
+- `fakeTransaction(overrides?: Partial<TransactionData>): Transaction` — builds `TransactionData` with faker-generated fields (matching current), then returns `TransactionEntity.fromPersistence(data)`. Return type stays `Transaction` — call sites unaffected.
+- `fakeCreateTransactionInput` unchanged.
+- `fakeTransactionPattern` unchanged.
+
+Signature note: the `overrides` parameter type changes from `Partial<Transaction>` to `Partial<TransactionData>` because callers pass raw field overrides, not method overrides. No call site passes methods.
+
+### Service / repository tests
+
+Existing tests in `transaction-service.test.ts`, `transfer-service.test.ts`, `account-service.test.ts`, `create-transaction-from-text-service.test.ts`, `dyn-transaction-repository.test.ts`, and the langchain tool tests all consume `fakeTransaction` or `TransactionType` enums. They compile unchanged as long as `fakeTransaction` keeps its return type. The parts that will change:
+
+- Any test that imports `createTransactionModel` / `updateTransactionModel` / `archiveTransactionModel` / `getSignedAmount` directly — rewritten to use class instead.
+- Any test that asserts `expect(x).toEqual(plainObject)` against a transaction instance — keeps working due to Jest field-equality semantics.
+- Service tests that injected fake model functions (`deps.createTransactionModel = jest.fn(...)`) — rewritten to let the service use `TransactionEntity` directly, asserting on persisted state via repo mocks instead.
+
+## Out of Scope
+
+- Changes to `Account`, `Category`, `User` models.
+- Changes to GraphQL schema or generated resolver types. `resolvers-types.ts` imports `TransactionType` and `TransactionPatternType` enums only — unaffected.
+- Changes to the migration file `20260423093628-add-transaction-version.ts`.
+- Changes to DynamoDB table shape or GSIs.
+- Performance tuning on `fromPersistence` (the invariant checks are cheap; no need to skip them for hot paths).
+- Any behavioral change to OCC beyond moving the version bump return path through `fromPersistence`.
+
+## Acceptance
+
+- `npm --prefix backend run typecheck` clean.
+- `npm --prefix backend test` clean.
+- `npm --prefix backend run format` clean.
+- Free functions `createTransactionModel`, `updateTransactionModel`, `archiveTransactionModel`, `getSignedAmount` no longer exported from `backend/src/models/transaction.ts`.
+- `TransactionEntity` exported from `backend/src/models/transaction.ts`. `Transaction` and `TransactionData` interfaces exported.
+- `DynTransactionRepository` returns `TransactionEntity` instances (typed as `Transaction`) from all read methods and from `update` / `updateMany`.
+- Services `TransactionServiceImpl` and `TransferService` no longer accept or use injected model functions.


### PR DESCRIPTION
## context

`Transaction` is a plain interface; any caller can construct a literal that skips `assertTransactionInvariants`.
Services inject `createTransactionModel` / `updateTransactionModel` / `archiveTransactionModel` solely so tests can mock them — boilerplate in every service constructor and test setup.

## before

- Invariants enforced only when callers go through `createTransactionModel` / `updateTransactionModel` / `archiveTransactionModel`
- `TransactionService` and `TransferService` carry the three model-function deps just for test mocking

## after

- `Transaction` is a class with private constructor; instances reachable only via `Transaction.create` / `Transaction.fromPersistence`, both run invariants
- Services drop the model-function deps and call `Transaction.create` / `instance.update` / `instance.archive` directly