### PR TITLE
Revert "refactor langchain model initialization"

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,24 +128,29 @@ aws ssm put-parameter --overwrite --type String \
 #### Runtime
 
 ```bash
+# AI connection timeout (in milliseconds)
+aws ssm put-parameter --overwrite --type String \
+    --name "/manual/budget/production/bedrock/connection-timeout" \
+    --value "5000"
+
 # AI max response tokens
 aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/langchain/max-tokens" \
+    --name "/manual/budget/production/bedrock/max-tokens" \
     --value "2000"
 
 # AI model ID (e.g., openai.gpt-oss-120b-1:0)
 aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/langchain/model-id" \
+    --name "/manual/budget/production/bedrock/model-id" \
     --value "openai.gpt-oss-120b-1:0"
 
-# AI request timeout (in seconds)
+# AI request timeout (in milliseconds)
 aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/langchain/timeout" \
-    --value "30"
+    --name "/manual/budget/production/bedrock/request-timeout" \
+    --value "30000"
 
 # AI sampling temperature
 aws ssm put-parameter --overwrite --type String \
-    --name "/manual/budget/production/langchain/temperature" \
+    --name "/manual/budget/production/bedrock/temperature" \
     --value "0.2"
 
 # Chat history max messages

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,9 +1,6 @@
 NODE_ENV=development
 
 # AWS Configuration
-# AWS_DEFAULT_REGION is required by LangChain's Bedrock provider (langchain-aws)
-# which reads it directly and throws if unset.
-AWS_DEFAULT_REGION=us-east-1
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=dummy
 AWS_SECRET_ACCESS_KEY=dummy
@@ -30,14 +27,13 @@ TELEGRAM_BOTS_TABLE_NAME=TelegramBots
 TRANSACTIONS_TABLE_NAME=Transactions
 USERS_TABLE_NAME=Users
 
-# AI Configuration
-# AWS_BEARER_TOKEN_BEDROCK is read internally by LangChain's Bedrock provider
-# for API-key authentication in local/dev environments.
+# AWS Bedrock AI Configuration
 AWS_BEARER_TOKEN_BEDROCK=<your_bedrock_api_key> # Long-term API key
-# LANGCHAIN_MAX_TOKENS=2000
-# LANGCHAIN_MODEL_ID=bedrock:openai.gpt-oss-120b-1:0
-# LANGCHAIN_TEMPERATURE=0.2
-# LANGCHAIN_TIMEOUT=30
+# AWS_BEDROCK_CONNECTION_TIMEOUT=5000
+# AWS_BEDROCK_MAX_TOKENS=2000
+# AWS_BEDROCK_MODEL_ID=openai.gpt-oss-120b-1:0
+# AWS_BEDROCK_REQUEST_TIMEOUT=30000
+# AWS_BEDROCK_TEMPERATURE=0.2
 
 # Application Configuration
 # CHAT_HISTORY_MAX_MESSAGES=20

--- a/backend/.env.test.example
+++ b/backend/.env.test.example
@@ -9,9 +9,6 @@ NODE_OPTIONS=--experimental-vm-modules
 NODE_ENV=test
 
 # AWS Configuration
-# AWS_DEFAULT_REGION is required by LangChain's Bedrock provider (langchain-aws)
-# which reads it directly and throws if unset.
-AWS_DEFAULT_REGION=us-east-1
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=dummy
 AWS_SECRET_ACCESS_KEY=dummy
@@ -33,14 +30,13 @@ TELEGRAM_BOTS_TABLE_NAME=_test_TelegramBots
 TRANSACTIONS_TABLE_NAME=_test_Transactions
 USERS_TABLE_NAME=_test_Users
 
-# AI Configuration
-# AWS_BEARER_TOKEN_BEDROCK is read internally by LangChain's Bedrock provider
-# for API-key authentication in local/dev environments.
+# AWS Bedrock AI Configuration
 AWS_BEARER_TOKEN_BEDROCK=bedrock-1234567890 # Long-term API key
-# LANGCHAIN_MAX_TOKENS=2000
-# LANGCHAIN_MODEL_ID=bedrock:openai.gpt-oss-120b-1:0
-# LANGCHAIN_TEMPERATURE=0.2
-# LANGCHAIN_TIMEOUT=30
+# AWS_BEDROCK_CONNECTION_TIMEOUT=5000
+# AWS_BEDROCK_MAX_TOKENS=2000
+# AWS_BEDROCK_MODEL_ID=openai.gpt-oss-120b-1:0
+# AWS_BEDROCK_REQUEST_TIMEOUT=30000
+# AWS_BEDROCK_TEMPERATURE=0.2
 
 # Application Configuration
 # CHAT_HISTORY_MAX_MESSAGES=20

--- a/backend/src/dependencies.ts
+++ b/backend/src/dependencies.ts
@@ -1,15 +1,8 @@
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import { initChatModel } from "langchain";
 import { JwtAuthService } from "./auth/jwt-auth";
 import { createAssistantAgent } from "./langchain/agents/assistant-agent";
 import { createCreateTransactionAgent } from "./langchain/agents/create-transaction-agent";
 import { LangChainAgent } from "./langchain/langchain-agent";
-import {
-  DEFAULT_LANGCHAIN_MAX_TOKENS,
-  DEFAULT_LANGCHAIN_MODEL_ID,
-  DEFAULT_LANGCHAIN_TEMPERATURE,
-  DEFAULT_LANGCHAIN_TIMEOUT,
-} from "./langchain/settings";
 import {
   DEFAULT_CHAT_HISTORY_MAX_MESSAGES,
   DEFAULT_CHAT_MESSAGE_TTL_SECONDS,
@@ -35,16 +28,10 @@ import { TelegramBotService } from "./services/telegram-bot-service";
 import { TransactionServiceImpl } from "./services/transaction-service";
 import { TransferService } from "./services/transfer-service";
 import { UserService } from "./services/user-service";
-import {
-  createAsyncSingleton,
-  createSingleton,
-} from "./utils/dependency-injection";
+import { createBedrockChatModel } from "./utils/bedrock";
+import { createSingleton } from "./utils/dependency-injection";
 import { createDynamoDBClient } from "./utils/dynamo-client";
-import {
-  requireEnv,
-  requireFloatEnv,
-  requireIntEnv,
-} from "./utils/require-env";
+import { requireEnv, requireIntEnv } from "./utils/require-env";
 
 // Auth
 export const resolveJwtAuthService = createSingleton(
@@ -169,30 +156,14 @@ const resolveTelegramApiClient = createSingleton(
 );
 
 // AI infrastructure
-export const createChatModel = async () =>
-  await initChatModel(
-    requireEnv("LANGCHAIN_MODEL_ID", DEFAULT_LANGCHAIN_MODEL_ID),
-    {
-      maxTokens: requireIntEnv(
-        "LANGCHAIN_MAX_TOKENS",
-        DEFAULT_LANGCHAIN_MAX_TOKENS,
-      ),
-      temperature: requireFloatEnv(
-        "LANGCHAIN_TEMPERATURE",
-        DEFAULT_LANGCHAIN_TEMPERATURE,
-      ),
-      timeout: requireIntEnv("LANGCHAIN_TIMEOUT", DEFAULT_LANGCHAIN_TIMEOUT),
-    },
-  );
-
-const resolveChatModel = createAsyncSingleton(() => createChatModel());
+const resolveBedrockChatModel = createSingleton(() => createBedrockChatModel());
 
 // AI agents
-export const resolveAssistantAgent = createAsyncSingleton(
-  async () =>
+export const resolveAssistantAgent = createSingleton(
+  () =>
     new LangChainAgent(
       createAssistantAgent({
-        model: await resolveChatModel(),
+        model: resolveBedrockChatModel(),
         accountRepository: resolveAccountRepository(),
         accountService: resolveAccountService(),
         categoryRepository: resolveCategoryRepository(),
@@ -203,11 +174,11 @@ export const resolveAssistantAgent = createAsyncSingleton(
       "assistant-agent",
     ),
 );
-export const resolveCreateTransactionAgent = createAsyncSingleton(
-  async () =>
+export const resolveCreateTransactionAgent = createSingleton(
+  () =>
     new LangChainAgent(
       createCreateTransactionAgent({
-        model: await resolveChatModel(),
+        model: resolveBedrockChatModel(),
         accountRepository: resolveAccountRepository(),
         categoryRepository: resolveCategoryRepository(),
         transactionRepository: resolveTransactionRepository(),
@@ -218,21 +189,21 @@ export const resolveCreateTransactionAgent = createAsyncSingleton(
 );
 
 // AI services
-export const resolveCreateTransactionFromTextService = createAsyncSingleton(
-  async () =>
+export const resolveCreateTransactionFromTextService = createSingleton(
+  () =>
     new CreateTransactionFromTextService({
-      createTransactionAgent: await resolveCreateTransactionAgent(),
+      createTransactionAgent: resolveCreateTransactionAgent(),
       transactionService: resolveTransactionService(),
     }),
 );
-export const resolveAssistantService = createAsyncSingleton(
-  async () => new AssistantServiceImpl(await resolveAssistantAgent()),
+export const resolveAssistantService = createSingleton(
+  () => new AssistantServiceImpl(resolveAssistantAgent()),
 );
-export const resolveAssistantChatService = createAsyncSingleton(
-  async () =>
+export const resolveAssistantChatService = createSingleton(
+  () =>
     new AssistantChatServiceImpl({
       chatMessageRepository: resolveChatMessageRepository(),
-      assistantService: await resolveAssistantService(),
+      assistantService: resolveAssistantService(),
       maxMessages: requireIntEnv(
         "CHAT_HISTORY_MAX_MESSAGES",
         DEFAULT_CHAT_HISTORY_MAX_MESSAGES,
@@ -241,10 +212,10 @@ export const resolveAssistantChatService = createAsyncSingleton(
 );
 
 // Telegram
-export const resolveProcessTelegramMessageService = createAsyncSingleton(
-  async () =>
+export const resolveProcessTelegramMessageService = createSingleton(
+  () =>
     new ProcessTelegramMessageService({
-      assistantChatService: await resolveAssistantChatService(),
+      assistantChatService: resolveAssistantChatService(),
       telegramApiClient: resolveTelegramApiClient(),
       telegramBotRepository: resolveTelegramBotRepository(),
     }),

--- a/backend/src/lambdas/background-job.ts
+++ b/backend/src/lambdas/background-job.ts
@@ -35,8 +35,7 @@ export const handler = async (rawEvent: unknown): Promise<void> => {
 
   switch (event.type) {
     case "telegram-message": {
-      const service = await resolveProcessTelegramMessageService();
-      const result = await service.call({
+      const result = await resolveProcessTelegramMessageService().call({
         botId: event.payload.botId,
         chatId: event.payload.chatId,
         text: event.payload.text,

--- a/backend/src/lambdas/bootstrap.ts
+++ b/backend/src/lambdas/bootstrap.ts
@@ -12,20 +12,24 @@ type SsmEnvBindingsFactory = (nodeEnv: string) => ParamBinding[];
 
 const defaultSsmEnvBindings: SsmEnvBindingsFactory = (nodeEnv) => [
   {
-    ssmPath: `/manual/budget/${nodeEnv}/langchain/max-tokens`,
-    envVar: "LANGCHAIN_MAX_TOKENS",
+    ssmPath: `/manual/budget/${nodeEnv}/bedrock/connection-timeout`,
+    envVar: "AWS_BEDROCK_CONNECTION_TIMEOUT",
   },
   {
-    ssmPath: `/manual/budget/${nodeEnv}/langchain/model-id`,
-    envVar: "LANGCHAIN_MODEL_ID",
+    ssmPath: `/manual/budget/${nodeEnv}/bedrock/max-tokens`,
+    envVar: "AWS_BEDROCK_MAX_TOKENS",
   },
   {
-    ssmPath: `/manual/budget/${nodeEnv}/langchain/temperature`,
-    envVar: "LANGCHAIN_TEMPERATURE",
+    ssmPath: `/manual/budget/${nodeEnv}/bedrock/model-id`,
+    envVar: "AWS_BEDROCK_MODEL_ID",
   },
   {
-    ssmPath: `/manual/budget/${nodeEnv}/langchain/timeout`,
-    envVar: "LANGCHAIN_TIMEOUT",
+    ssmPath: `/manual/budget/${nodeEnv}/bedrock/request-timeout`,
+    envVar: "AWS_BEDROCK_REQUEST_TIMEOUT",
+  },
+  {
+    ssmPath: `/manual/budget/${nodeEnv}/bedrock/temperature`,
+    envVar: "AWS_BEDROCK_TEMPERATURE",
   },
   {
     ssmPath: `/manual/budget/${nodeEnv}/app/chat-history-max-messages`,

--- a/backend/src/langchain/agents/assistant-agent.int.test.ts
+++ b/backend/src/langchain/agents/assistant-agent.int.test.ts
@@ -1,7 +1,6 @@
-import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import { AIMessage, HumanMessage } from "langchain";
 import {
-  createChatModel,
   resolveAccountRepository,
   resolveAccountService,
   resolveCategoryRepository,
@@ -13,6 +12,7 @@ import {
 import { CategoryType } from "../../models/category";
 import { TransactionType } from "../../models/transaction";
 import { toDateString } from "../../types/date";
+import { createBedrockChatModel } from "../../utils/bedrock";
 import { formatDateAsYYYYMMDD } from "../../utils/date";
 import { createDynamoDBDocumentClient } from "../../utils/dynamo-client";
 import { truncateAllTables } from "../../utils/test-utils/dynamodb-helpers";
@@ -30,23 +30,20 @@ const transactionRepository = resolveTransactionRepository();
 const transactionService = resolveTransactionService();
 const userRepository = resolveUserRepository();
 
+const agent = createAssistantAgent({
+  model: createBedrockChatModel(),
+  accountRepository,
+  accountService,
+  categoryRepository,
+  categoryService,
+  transactionRepository,
+  transactionService,
+});
+
 describe("AssistantAgent (integration)", () => {
   let context: { userId: string; today: string };
   let today: string;
   let userId: string;
-  let agent: ReturnType<typeof createAssistantAgent>;
-
-  beforeAll(async () => {
-    agent = createAssistantAgent({
-      model: await createChatModel(),
-      accountRepository,
-      accountService,
-      categoryRepository,
-      categoryService,
-      transactionRepository,
-      transactionService,
-    });
-  });
 
   beforeEach(async () => {
     await truncateAllTables(createDynamoDBDocumentClient());

--- a/backend/src/langchain/agents/create-transaction-agent.int.test.ts
+++ b/backend/src/langchain/agents/create-transaction-agent.int.test.ts
@@ -1,7 +1,6 @@
-import { beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import { beforeEach, describe, expect, it } from "@jest/globals";
 import { AIMessage, HumanMessage } from "langchain";
 import {
-  createChatModel,
   resolveAccountRepository,
   resolveCategoryRepository,
   resolveTransactionRepository,
@@ -10,6 +9,7 @@ import {
 } from "../../dependencies";
 import { CategoryType } from "../../models/category";
 import { TransactionType } from "../../models/transaction";
+import { createBedrockChatModel } from "../../utils/bedrock";
 import { formatDateAsYYYYMMDD } from "../../utils/date";
 import { createDynamoDBDocumentClient } from "../../utils/dynamo-client";
 import { truncateAllTables } from "../../utils/test-utils/dynamodb-helpers";
@@ -26,21 +26,18 @@ const transactionRepository = resolveTransactionRepository();
 const transactionService = resolveTransactionService();
 const userRepository = resolveUserRepository();
 
+const agent = createCreateTransactionAgent({
+  model: createBedrockChatModel(),
+  accountRepository,
+  categoryRepository,
+  transactionRepository,
+  transactionService,
+});
+
 describe("CreateTransactionAgent (integration)", () => {
   let context: { userId: string; today: string; isVoiceInput?: boolean };
   let today: string;
   let userId: string;
-  let agent: ReturnType<typeof createCreateTransactionAgent>;
-
-  beforeAll(async () => {
-    agent = createCreateTransactionAgent({
-      model: await createChatModel(),
-      accountRepository,
-      categoryRepository,
-      transactionRepository,
-      transactionService,
-    });
-  });
 
   beforeEach(async () => {
     await truncateAllTables(createDynamoDBDocumentClient());

--- a/backend/src/langchain/settings.ts
+++ b/backend/src/langchain/settings.ts
@@ -1,4 +1,0 @@
-export const DEFAULT_LANGCHAIN_MAX_TOKENS = 2000;
-export const DEFAULT_LANGCHAIN_MODEL_ID = "bedrock:openai.gpt-oss-120b-1:0";
-export const DEFAULT_LANGCHAIN_TEMPERATURE = 0.2;
-export const DEFAULT_LANGCHAIN_TIMEOUT = 30;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -77,9 +77,8 @@ export async function createContext(req: {
     byCategoryReportService: resolveByCategoryReportService(),
 
     // AI services
-    createTransactionFromTextService:
-      await resolveCreateTransactionFromTextService(),
-    assistantChatService: await resolveAssistantChatService(),
+    createTransactionFromTextService: resolveCreateTransactionFromTextService(),
+    assistantChatService: resolveAssistantChatService(),
 
     // Telegram services
     telegramBotService: resolveTelegramBotService(),

--- a/backend/src/utils/bedrock.ts
+++ b/backend/src/utils/bedrock.ts
@@ -1,0 +1,60 @@
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
+import { ChatBedrockConverse } from "@langchain/aws";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { requireEnv, requireFloatEnv, requireIntEnv } from "./require-env";
+
+const DEFAULT_AWS_BEDROCK_CONNECTION_TIMEOUT = 5000;
+const DEFAULT_AWS_BEDROCK_MAX_TOKENS = 2000;
+const DEFAULT_AWS_BEDROCK_MODEL_ID = "openai.gpt-oss-120b-1:0";
+const DEFAULT_AWS_BEDROCK_REQUEST_TIMEOUT = 30000;
+const DEFAULT_AWS_BEDROCK_TEMPERATURE = 0.2;
+
+const isLocalEnvironment =
+  process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+
+/**
+ * Creates a Bedrock runtime client.
+ * - Local: authenticates via a long-term Bedrock API key (AWS_BEARER_TOKEN_BEDROCK).
+ * - Production: authenticates via the Lambda execution role (IAM/SigV4).
+ */
+export function createBedrockRuntimeClient(): BedrockRuntimeClient {
+  const config = isLocalEnvironment
+    ? { token: { token: requireEnv("AWS_BEARER_TOKEN_BEDROCK") } }
+    : {};
+
+  // Time to establish the TCP connection before giving up
+  const connectionTimeout = requireIntEnv(
+    "AWS_BEDROCK_CONNECTION_TIMEOUT",
+    DEFAULT_AWS_BEDROCK_CONNECTION_TIMEOUT,
+  );
+  // Total time cap for the full request/response cycle (non-streaming)
+  const requestTimeout = requireIntEnv(
+    "AWS_BEDROCK_REQUEST_TIMEOUT",
+    DEFAULT_AWS_BEDROCK_REQUEST_TIMEOUT,
+  );
+
+  return new BedrockRuntimeClient({
+    ...config,
+    requestHandler: new NodeHttpHandler({
+      connectionTimeout,
+      requestTimeout,
+    }),
+  });
+}
+
+/** Creates a LangChain Bedrock chat model configured from environment variables. */
+export function createBedrockChatModel(): ChatBedrockConverse {
+  return new ChatBedrockConverse({
+    model: requireEnv("AWS_BEDROCK_MODEL_ID", DEFAULT_AWS_BEDROCK_MODEL_ID),
+    region: requireEnv("AWS_REGION"),
+    maxTokens: requireIntEnv(
+      "AWS_BEDROCK_MAX_TOKENS",
+      DEFAULT_AWS_BEDROCK_MAX_TOKENS,
+    ),
+    temperature: requireFloatEnv(
+      "AWS_BEDROCK_TEMPERATURE",
+      DEFAULT_AWS_BEDROCK_TEMPERATURE,
+    ),
+    client: createBedrockRuntimeClient(),
+  });
+}

--- a/backend/src/utils/dependency-injection.test.ts
+++ b/backend/src/utils/dependency-injection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
-import { createAsyncSingleton, createSingleton } from "./dependency-injection";
+import { createSingleton } from "./dependency-injection";
 
 describe("createSingleton", () => {
   it("calls the factory only once", () => {
@@ -27,47 +27,5 @@ describe("createSingleton", () => {
     resolve();
 
     expect(factory).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("createAsyncSingleton", () => {
-  it("calls the factory only once across sequential awaits", async () => {
-    const factory = jest.fn(async () => ({ value: 42 }));
-    const resolve = createAsyncSingleton(factory);
-
-    await resolve();
-    await resolve();
-    await resolve();
-
-    expect(factory).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls the factory only once for concurrent callers", async () => {
-    const factory = jest.fn(
-      () => new Promise((resolve) => setTimeout(() => resolve({}), 10)),
-    );
-    const resolve = createAsyncSingleton(factory);
-
-    await Promise.all([resolve(), resolve(), resolve()]);
-
-    expect(factory).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns the same instance on every call", async () => {
-    const resolve = createAsyncSingleton(async () => ({ value: 42 }));
-
-    expect(await resolve()).toBe(await resolve());
-  });
-
-  it("retries the factory after a rejection", async () => {
-    const factory = jest
-      .fn<() => Promise<{ value: number }>>()
-      .mockRejectedValueOnce(new Error("boom"))
-      .mockResolvedValueOnce({ value: 42 });
-    const resolve = createAsyncSingleton(factory);
-
-    await expect(resolve()).rejects.toThrow("boom");
-    await expect(resolve()).resolves.toEqual({ value: 42 });
-    expect(factory).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/src/utils/dependency-injection.ts
+++ b/backend/src/utils/dependency-injection.ts
@@ -8,19 +8,3 @@ export function createSingleton<T>(factory: () => T): () => T {
     return instance;
   };
 }
-
-export function createAsyncSingleton<T>(
-  factory: () => Promise<T>,
-): () => Promise<T> {
-  let promise: Promise<T> | undefined;
-
-  return () => {
-    if (!promise) {
-      promise = factory().catch((error) => {
-        promise = undefined;
-        throw error;
-      });
-    }
-    return promise;
-  };
-}


### PR DESCRIPTION
Reverts alexei-lexx/budget#433.

`initChatModel` resolves the provider package via a runtime dynamic import with a variable argument: `await import(config.package)`. esbuild only follows `import()` when the argument is a string literal — variable arguments are left as-is and resolved by Node against the filesystem `node_modules` at runtime.

The Lambda artifact is a single bundled file with no `node_modules` shipped, so the runtime import always fails. Every GraphQL request crashed in `createContext`, taking production down.