### PR TITLE
bump auth Lambda runtimes to Node.js 24

### DIFF
--- a/infra-cdk/lib/auth-callback-config-stack.ts
+++ b/infra-cdk/lib/auth-callback-config-stack.ts
@@ -88,7 +88,7 @@ export class AuthCallbackConfigStack extends Stack {
       this,
       "UpdateCallbackUrlsFunction",
       {
-        runtime: lambda.Runtime.NODEJS_20_X,
+        runtime: lambda.Runtime.NODEJS_24_X,
         entry: "lib/update-callback-urls-handler.ts",
         handler: "handler",
         logGroup: updateCallbackUrlsLogGroup,

--- a/infra-cdk/lib/auth-cdk-stack.ts
+++ b/infra-cdk/lib/auth-cdk-stack.ts
@@ -125,7 +125,7 @@ export class AuthCdkStack extends cdk.Stack {
       this,
       "PreTokenGeneration",
       {
-        runtime: lambda.Runtime.NODEJS_20_X,
+        runtime: lambda.Runtime.NODEJS_24_X,
         entry: "lib/pre-token-generation.ts",
         handler: "handler",
         logGroup: preTokenGenerationLogGroup,

--- a/infra-cdk/package-lock.json
+++ b/infra-cdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-cognito-identity-provider": "^3.990.0",
-        "aws-cdk-lib": "^2.246.0",
+        "aws-cdk-lib": "^2.252.0",
         "constructs": "^10.4.5"
       },
       "bin": {
@@ -21,7 +21,7 @@
         "@types/aws-lambda": "^8.10.160",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.2.3",
-        "aws-cdk": "^2.1118.4",
+        "aws-cdk": "^2.1120.0",
         "esbuild": "^0.27.3",
         "eslint": "^9.39.2",
         "eslint-plugin-import": "^2.32.0",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -46,9 +46,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.11.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.11.0.tgz",
-      "integrity": "sha512-sAkcWQz2hvblIDHe5pFXxyIPZuhDaYowGIpASK+LSDvknBpP7+y3fib/FMpSPQdyI6ZOmJPEQOnz553H7mPnBA==",
+      "version": "53.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.20.0.tgz",
+      "integrity": "sha512-4kLAUO+I8b4nlk1Z2P4n3Ye8UtqCiXk0kJMLUThBnyHLbdz06rwAb+qlb9WZOie7NtPluemVS243ifcBh/NVsQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -4201,9 +4201,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1118.4",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1118.4.tgz",
-      "integrity": "sha512-wJfRQdvb+FJ2cni059mYdmjhfwhMskP+PAB59BL9jhon+jYtjy8X3pbj3uzHgAOJwNhh6jGkP8xq36Cffccbbw==",
+      "version": "2.1120.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1120.0.tgz",
+      "integrity": "sha512-vDVa0IX0FhizARdY/GLSParFglKbdHCIhM8IDmynrAv9w8uLLljzWMeLUOhC1XpMErDZ/npYEihAOjfKxTaMIw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4214,9 +4214,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.246.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.246.0.tgz",
-      "integrity": "sha512-7OtF95mss9dWohopCNQKAlNFrMJwgOIvNTNgoOWWcKhULBf6UxKCaf6ATlnuysIWRGf2DHgcval/4+yySOKRBw==",
+      "version": "2.252.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.252.0.tgz",
+      "integrity": "sha512-bRLyTtJxhVgsx2JrL2B/KYYWf+Rg0s68UgQp+VRZK0h5fXeaPqDVEJGPMr7FiOgrmYwEadjfbxsTsZKNAloAvg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -4233,10 +4233,10 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -4257,7 +4257,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
+      "version": "2.2.2",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -4272,26 +4272,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -4353,7 +4334,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4495,11 +4476,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"

--- a/infra-cdk/package.json
+++ b/infra-cdk/package.json
@@ -26,7 +26,7 @@
     "@types/aws-lambda": "^8.10.160",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.2.3",
-    "aws-cdk": "^2.1118.4",
+    "aws-cdk": "^2.1120.0",
     "esbuild": "^0.27.3",
     "eslint": "^9.39.2",
     "eslint-plugin-import": "^2.32.0",
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3.990.0",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "^2.252.0",
     "constructs": "^10.4.5"
   }
 }

--- a/infra-cdk/test/auth-cdk.test.ts
+++ b/infra-cdk/test/auth-cdk.test.ts
@@ -63,7 +63,7 @@ describe("AuthCdkStack", () => {
       const lambda = lambdas[lambdaName || ""];
 
       // Verify Lambda function is created with Node.js runtime
-      expect(lambda.Properties.Runtime).toBe("nodejs20.x");
+      expect(lambda.Properties.Runtime).toBe("nodejs24.x");
       expect(lambda.Properties.Handler).toBe("index.handler");
 
       // Verify User Pool has Lambda trigger configured with V2_0 for access token customization


### PR DESCRIPTION
AWS ends Node.js 20.x support on 2026-04-30. Both auth stacks pinned NODEJS_20_X explicitly; bump to NODEJS_24_X to match backend stack.