### PR TITLE
tune agent prompts and tooling for amounts and aggregations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -72,5 +72,7 @@ Uses DynamoDB Local running in Docker with a named volume for data persistence.
 
 - `npm run format` - Run Prettier and ESLint to check and fix code style
 - `npm run test:integration` - Run agent integration tests (don't run in CI, only for local development)
-- `npm run test` - Run tests with Jest
+- `npm run test:repositories` - Run database-related tests only
+- `npm run test:unit` - Run unit tests only (excluding integration and repository tests)
+- `npm run test` - Run unit and repository tests (excludes integration tests)
 - `npm run typecheck` - Run TypeScript type checker

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,8 @@
     "test:db:setup": "npm run db:start && sleep 1 && npm run test:db:create",
     "test:integration": "dotenvx run -f .env.test -- jest --config jest.config.integration.ts",
     "test:repositories": "dotenvx run -f .env.test -- jest --config jest.config.repositories.ts",
-    "test": "dotenvx run -f .env.test -- jest && npm run test:repositories",
+    "test:unit": "dotenvx run -f .env.test -- jest",
+    "test": "npm run test:unit && npm run test:repositories",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/backend/src/langchain/agents/assistant-agent.ts
+++ b/backend/src/langchain/agents/assistant-agent.ts
@@ -61,20 +61,23 @@ A transaction can optionally:
 
 ## Rules for Analysis and Calculations
 
-Use these rules when the user asks to make calculations, analysis, or forecasts based on their financial data.
+Use these rules when the user asks to make calculations, analysis, or forecasts.
 
-- First, break down the request into steps if necessary
-- For each step, identify what calculations are needed
+- Break down the request into smaller steps
+- For each step, identify what calculations and aggregations are needed
 - For each calculation, identify what data is needed: accounts, categories, transactions
-- For each calculation, identify which transactions are included and why
+- For each aggregation, identify what filters are needed
+- For each step, retrieve the necessary data
+- Finalize the answer based on the retrieved data, calculations, and aggregations
+
+### Constraints
+
+- Exclude report-excluded categories from spending and income totals; when omitting them, mention the omission
+- Do not perform calculations yourself; instead, use the available tools; fall back to your own calculation only if no tool suits the need
+- Do not aggregate data yourself; instead, use the available tools; fall back to your own aggregation only if no tool suits the need
 - When a calculation requires a time period and the user did not specify one:
   - If the period is clear from prior conversation, use it
   - Otherwise, ask the user to clarify
-- Retrieve the necessary data in small, focused chunks
-- Apply filtering consistently
-- Do calculations based on the retrieved data
-- Exclude report-excluded categories from spending and income totals; when omitting them, mention the omission
-- Answer the user's request based on the calculations and data
 
 ## Rules for Logging Transactions
 
@@ -87,6 +90,8 @@ treat it as a request to log a transaction.
 - Keep the answer concise and focused on the user's request
 - Answer in the user's language
 - Respond in plain text
+- Use lists instead of tables
+- Do not use markdown
 `.trim();
 
 export function createAssistantAgent({

--- a/backend/src/langchain/agents/create-transaction-agent.ts
+++ b/backend/src/langchain/agents/create-transaction-agent.ts
@@ -1,4 +1,5 @@
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { PromptTemplate } from "@langchain/core/prompts";
 import {
   createAgent,
   dynamicSystemPromptMiddleware,
@@ -51,17 +52,8 @@ You MUST infer all mandatory and optional transaction fields and then MUST persi
 - Mandatory field
 - Numeric or written value representing a money quantity (e.g., 25, 20.5, "twenty five euros")
 - If multiple amounts are present, MUST stop and report an error — only one transaction at a time
-- If voice input is indicated, apply additional rules:
-  - Speech-to-text often transcribes a spoken price as a single number — "two thirty four" becomes "234"
-    - The integer "234" may represent 2.34, 23.4, or 234
-    - Look up similar past transactions (same or related category, similar description) to assess which interpretation is most realistic
-    - If no similar history exists, use the amount as transcribed
-  - Speech-to-text often transcribes a spoken price as a clock time — "eleven twenty three" becomes "11:23"
-    - The "11:23" string may represent a price of 11.23 or a clock time of 11:23
-    - If no time preposition ("at", "around", "by") is present and no other numeric amount is present, treat it as a price
-    - Example: "11:23" → amount 11.23
-    - Example: "lunch 11:23 at cafe" → amount 11.23 ("at cafe" identifies a place)
-    - Example: "coffee at 12:34" → 12:34 is a time
+
+{VOICE_INPUT_INDICATOR}
 
 ### Account
 
@@ -120,11 +112,30 @@ Amount: <amount>
 Date: <YYYY-MM-DD>
 Description: <description or N/A>
 </successful-response>
+
+## Current Date
+
+Today is {TODAY}.
 `.trim();
 
-export const VOICE_INPUT_INDICATOR = `## Voice Input Indicator
+const promptTemplate = PromptTemplate.fromTemplate(SYSTEM_PROMPT);
 
-The user's input was captured via voice recognition.
+export const VOICE_INPUT_INDICATOR = `
+The user's input was captured via voice recognition. Follow these additional rules.
+
+Speech-to-text often transcribes a spoken price as a single number — "two thirty four" becomes "234".
+
+- The integer "234" may represent 2.34, 23.4, or 234
+- MUST look up similar past transactions (same or related category, similar description) to assess which interpretation is most realistic
+- Only after lookup, if no similar history exists, use the amount as transcribed
+
+Speech-to-text often transcribes a spoken price as a clock time — "eleven twenty three" becomes "11:23".
+
+- The "11:23" string may represent a price of 11.23 or a clock time of 11:23
+- If no time preposition ("at", "around", "by") is present and no other numeric amount is present, treat it as a price
+- Example: "11:23" → amount 11.23
+- Example: "lunch 11:23 at cafe" → amount 11.23 ("at cafe" identifies a place)
+- Example: "coffee at 12:34" → 12:34 is a time
 `.trim();
 
 export function createCreateTransactionAgent({
@@ -152,14 +163,13 @@ export function createCreateTransactionAgent({
     tools,
     contextSchema: agentContextSchema,
     middleware: [
-      dynamicSystemPromptMiddleware<AgentContext>((_state, runtime) => {
+      dynamicSystemPromptMiddleware<AgentContext>(async (_state, runtime) => {
         const { today, isVoiceInput } = runtime.context;
-        const parts = [
-          SYSTEM_PROMPT,
-          `## Current Date\n\nToday is ${today}.`,
-          ...(isVoiceInput ? [VOICE_INPUT_INDICATOR] : []),
-        ];
-        return parts.join("\n\n");
+        const prompt = await promptTemplate.format({
+          TODAY: today,
+          VOICE_INPUT_INDICATOR: isVoiceInput ? VOICE_INPUT_INDICATOR : "",
+        });
+        return prompt;
       }),
       // Prevent creating more than one transaction per invocation
       toolCallLimitMiddleware({

--- a/backend/src/langchain/tools/get-categories.test.ts
+++ b/backend/src/langchain/tools/get-categories.test.ts
@@ -12,7 +12,7 @@ import { createMockTransactionRepository } from "../../utils/test-utils/reposito
 import { EntityScope } from "./get-accounts";
 import {
   CATEGORY_HISTORY_LOOKBACK_DAYS,
-  CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY,
+  CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY,
   createGetCategoriesTool,
 } from "./get-categories";
 
@@ -182,7 +182,7 @@ describe("createGetCategoriesTool", () => {
           name: "Groceries",
           type: CategoryType.EXPENSE,
           isArchived: false,
-          recentDescriptions: [],
+          keywords: [],
         },
         {
           excludeFromReports: mockCategories[1].excludeFromReports,
@@ -190,7 +190,7 @@ describe("createGetCategoriesTool", () => {
           name: "Salary",
           type: CategoryType.INCOME,
           isArchived: true,
-          recentDescriptions: [],
+          keywords: [],
         },
       ],
     });
@@ -212,7 +212,7 @@ describe("createGetCategoriesTool", () => {
     expect(result).toEqual({ success: true, data: [] });
   });
 
-  describe("recentDescriptions", () => {
+  describe("keywords", () => {
     it("returns empty array when no transactions exist", async () => {
       const category = fakeCategory({ isArchived: false });
       mockCategoryRepository.findManyWithArchivedByUserId.mockResolvedValue([
@@ -234,7 +234,7 @@ describe("createGetCategoriesTool", () => {
         data: [
           expect.objectContaining({
             id: category.id,
-            recentDescriptions: [],
+            keywords: [],
           }),
         ],
       });
@@ -267,7 +267,7 @@ describe("createGetCategoriesTool", () => {
         data: [
           expect.objectContaining({
             id: category.id,
-            recentDescriptions: [],
+            keywords: [],
           }),
         ],
       });
@@ -297,7 +297,7 @@ describe("createGetCategoriesTool", () => {
         data: [
           expect.objectContaining({
             id: category.id,
-            recentDescriptions: [],
+            keywords: [],
           }),
         ],
       });
@@ -336,20 +336,20 @@ describe("createGetCategoriesTool", () => {
         data: [
           expect.objectContaining({
             id: activeCategory.id,
-            recentDescriptions: ["milk and eggs"],
+            keywords: ["milk and eggs"],
           }),
         ],
       });
     });
 
-    it("caps recentDescriptions", async () => {
+    it("caps keywords", async () => {
       const category = fakeCategory({ isArchived: false });
       mockCategoryRepository.findManyWithArchivedByUserId.mockResolvedValue([
         category,
       ]);
 
       const transactions = Array.from(
-        { length: CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY + 5 },
+        { length: CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY + 5 },
         (_, index) =>
           fakeTransaction({
             categoryId: category.id,
@@ -371,20 +371,18 @@ describe("createGetCategoriesTool", () => {
 
       if (!result.success) throw new Error("Expected success"); // Type guard
 
-      expect(result.data[0].recentDescriptions).toHaveLength(
-        CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY,
+      expect(result.data[0].keywords).toHaveLength(
+        CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY,
       );
-      expect(result.data[0].recentDescriptions[0]).toEqual("description 0");
+      expect(result.data[0].keywords[0]).toEqual("description 0");
       expect(
-        result.data[0].recentDescriptions[
-          CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY - 1
-        ],
+        result.data[0].keywords[CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY - 1],
       ).toEqual(
-        `description ${CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY - 1}`,
+        `description ${CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY - 1}`,
       );
     });
 
-    it("groups multiple descriptions by categoryId", async () => {
+    it("groups multiple keywords by categoryId", async () => {
       const groceryCategory = fakeCategory({ isArchived: false });
       const eatingOutCategory = fakeCategory({ isArchived: false });
 
@@ -429,17 +427,17 @@ describe("createGetCategoriesTool", () => {
         data: expect.arrayContaining([
           expect.objectContaining({
             id: groceryCategory.id,
-            recentDescriptions: ["whole foods", "costco"],
+            keywords: ["whole foods", "costco"],
           }),
           expect.objectContaining({
             id: eatingOutCategory.id,
-            recentDescriptions: ["pizza place", "sushi restaurant"],
+            keywords: ["pizza place", "sushi restaurant"],
           }),
         ]),
       });
     });
 
-    it("deduplicates repeated descriptions", async () => {
+    it("deduplicates repeated keywords", async () => {
       const category = fakeCategory({ isArchived: false });
       mockCategoryRepository.findManyWithArchivedByUserId.mockResolvedValue([
         category,
@@ -469,7 +467,7 @@ describe("createGetCategoriesTool", () => {
         data: [
           expect.objectContaining({
             id: category.id,
-            recentDescriptions: ["ice cream", "milk"],
+            keywords: ["ice cream", "milk"],
           }),
         ],
       });

--- a/backend/src/langchain/tools/get-categories.ts
+++ b/backend/src/langchain/tools/get-categories.ts
@@ -9,10 +9,10 @@ import { agentContextSchema } from "../agents/agent-context";
 import { CategoryDto, toCategoryDto } from "./category-dto";
 import { EntityScope } from "./get-accounts";
 
-type CategoryData = CategoryDto & { recentDescriptions: string[] };
+type CategoryData = CategoryDto & { keywords: string[] };
 
 export const CATEGORY_HISTORY_LOOKBACK_DAYS = 90;
-export const CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY = 10;
+export const CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY = 10;
 
 const schema = z.object({
   scope: z
@@ -50,7 +50,7 @@ export const createGetCategoriesTool = ({
       const categoryDataList: CategoryData[] = filteredCategories.map(
         (category) => ({
           ...toCategoryDto(category),
-          recentDescriptions: [],
+          keywords: [],
         }),
       );
 
@@ -73,7 +73,7 @@ export const createGetCategoriesTool = ({
       const categoryIdSet = new Set(
         categoryDataList.map((category) => category.id),
       );
-      const descriptionsByCategory = new Map<string, Set<string>>();
+      const keywordsByCategory = new Map<string, Set<string>>();
 
       for (const transaction of transactions) {
         const { categoryId, description } = transaction;
@@ -82,25 +82,21 @@ export const createGetCategoriesTool = ({
           continue;
         }
 
-        if (!descriptionsByCategory.has(categoryId)) {
-          descriptionsByCategory.set(categoryId, new Set());
+        if (!keywordsByCategory.has(categoryId)) {
+          keywordsByCategory.set(categoryId, new Set());
         }
 
-        const descriptions = descriptionsByCategory.get(categoryId);
-        if (descriptions) {
-          if (
-            descriptions.size < CATEGORY_HISTORY_MAX_DESCRIPTIONS_PER_CATEGORY
-          ) {
-            descriptions.add(description);
+        const keywords = keywordsByCategory.get(categoryId);
+        if (keywords) {
+          if (keywords.size < CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY) {
+            keywords.add(description);
           }
         }
       }
 
       const enrichedCategoryDataList = categoryDataList.map((category) => ({
         ...category,
-        recentDescriptions: Array.from(
-          descriptionsByCategory.get(category.id) || [],
-        ),
+        keywords: Array.from(keywordsByCategory.get(category.id) || []),
       }));
 
       return Success(enrichedCategoryDataList);
@@ -108,7 +104,7 @@ export const createGetCategoriesTool = ({
     {
       name: "get_categories",
       description:
-        "Get user categories filtered by scope. Each category includes recent usage examples showing how similar transactions were previously categorised.",
+        "Get user categories filtered by scope. Each category includes keywords showing how similar transactions were previously categorised.",
       schema,
     },
   );

--- a/backend/src/utils/test-utils/models/transaction-fakes.ts
+++ b/backend/src/utils/test-utils/models/transaction-fakes.ts
@@ -27,7 +27,7 @@ export const fakeTransaction = (
     type,
     currency: faker.helpers.arrayElement(["EUR", "USD"]),
     date: toDateString(faker.date.recent().toISOString().split("T")[0]),
-    description: faker.finance.transactionDescription(),
+    description: faker.commerce.product(),
     transferId: isTransfer ? faker.string.uuid() : undefined,
     isArchived: false,
     // Randomized to surface tests that wrongly assume a specific version.
@@ -50,7 +50,7 @@ export const fakeCreateTransactionInput = (
     type: TransactionType.EXPENSE,
     amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
     date: toDateString(faker.date.recent().toISOString().split("T")[0]),
-    description: faker.finance.transactionDescription(),
+    description: faker.commerce.product(),
     ...overrides,
   };
 };

--- a/backend/src/utils/test-utils/services/transaction-service-fakes.ts
+++ b/backend/src/utils/test-utils/services/transaction-service-fakes.ts
@@ -12,7 +12,7 @@ export const fakeCreateTransactionServiceInput = (
     type: TransactionType.EXPENSE,
     amount: faker.number.float({ min: 1, max: 1000, fractionDigits: 2 }),
     date: toDateString(faker.date.recent().toISOString().split("T")[0]),
-    description: faker.finance.transactionDescription(),
+    description: faker.commerce.product(),
     ...overrides,
   };
 };


### PR DESCRIPTION
## context

The assistant agent and the create-transaction agent were not following amount-handling rules consistently.
Spending answers were computed in the model's reasoning rather than via tools.
Voice input with collapsed amounts (e.g. "sandwich 987") was committed verbatim because the model skipped the history lookup.
Misleading field naming and test fixtures contributed to the confusion.

## before

- The assistant aggregated transactions in its own reasoning instead of calling a tool
- create-transaction-agent skipped the history lookup when resolving an ambiguous amount from HH:MM-shaped voice input
- The `get_categories` field `recentDescriptions` was treated as a substitute for transaction history
- Transaction fake descriptions sometimes embedded prices, confusing amount inference
- Only one `test` script combined unit and repository tests

## after

- The assistant calls the aggregation tool for totals
- create-transaction-agent enforces a history lookup before resolving ambiguous voice amounts
- `get_categories` field renamed `keywords` to signal usage hints rather than history
- Transaction fakes use simple product names, no prices
- Separate `test:unit` script for convenience