### PR TITLE
clear assistant data on sign out

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { useUser } from "@/composables/useUser";
 import { useSnackbar } from "@/composables/useSnackbar";
 import { useDisplay } from "vuetify";
 import { setAuthTokenGetter, globalError, clearGlobalError } from "@/apollo";
+import { clearAssistantStorage } from "@/composables/useAssistant";
 
 const {
   user,
@@ -104,6 +105,7 @@ const handleSignOut = () => {
   if (mobile.value) {
     drawer.value = false;
   }
+  clearAssistantStorage();
   logout();
 };
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,13 +104,9 @@ const handleSignOut = () => {
   if (mobile.value) {
     drawer.value = false;
   }
-  // Remove all assistant-scoped data so it doesn't leak to the next user.
-  // Prefix sweep covers any future `assistant-*` key without further changes here.
-  for (const key of Object.keys(localStorage)) {
-    if (key.startsWith("assistant-")) {
-      localStorage.removeItem(key);
-    }
-  }
+  // Wipe localStorage so no per-user data leaks to the next user on this browser.
+  // OIDC tokens live here too — they get re-created on next sign-in.
+  localStorage.clear();
   logout();
 };
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -104,8 +104,6 @@ const handleSignOut = () => {
   if (mobile.value) {
     drawer.value = false;
   }
-  // Wipe localStorage so no per-user data leaks to the next user on this browser.
-  // OIDC tokens live here too — they get re-created on next sign-in.
   localStorage.clear();
   logout();
 };

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,6 +5,7 @@ import { useUser } from "@/composables/useUser";
 import { useSnackbar } from "@/composables/useSnackbar";
 import { useDisplay } from "vuetify";
 import { setAuthTokenGetter, globalError, clearGlobalError } from "@/apollo";
+import { appStorage } from "@/lib/appStorage";
 
 const {
   user,
@@ -65,27 +66,27 @@ onMounted(() => {
 });
 
 // Track if user has been ensured for this auth session
-const USER_ENSURED_KEY = "budget_user_ensured";
+const USER_ENSURED_KEY = "user_ensured";
 
 // Watch for authentication state changes - only ensure user on fresh login
 watch(
   [isAuthenticated, authLoading],
   async ([authenticated, loading]) => {
     if (authenticated && !loading) {
-      const userAlreadyEnsured = localStorage.getItem(USER_ENSURED_KEY) === "true";
+      const userAlreadyEnsured = appStorage.getItem(USER_ENSURED_KEY) === "true";
 
       if (!userAlreadyEnsured) {
         try {
           console.log("Fresh login detected, ensuring user exists");
           await ensureUser();
-          localStorage.setItem(USER_ENSURED_KEY, "true");
+          appStorage.setItem(USER_ENSURED_KEY, "true");
         } catch (error) {
           console.error("Failed to ensure user after login:", error);
         }
       }
     } else if (!authenticated && !loading) {
       // Clear the flag when user logs out
-      localStorage.removeItem(USER_ENSURED_KEY);
+      appStorage.removeItem(USER_ENSURED_KEY);
     }
   },
   { immediate: true },
@@ -104,7 +105,7 @@ const handleSignOut = () => {
   if (mobile.value) {
     drawer.value = false;
   }
-  localStorage.clear();
+  appStorage.clearAll();
   logout();
 };
 

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -5,7 +5,6 @@ import { useUser } from "@/composables/useUser";
 import { useSnackbar } from "@/composables/useSnackbar";
 import { useDisplay } from "vuetify";
 import { setAuthTokenGetter, globalError, clearGlobalError } from "@/apollo";
-import { clearAssistantStorage } from "@/composables/useAssistant";
 
 const {
   user,
@@ -105,7 +104,13 @@ const handleSignOut = () => {
   if (mobile.value) {
     drawer.value = false;
   }
-  clearAssistantStorage();
+  // Remove all assistant-scoped data so it doesn't leak to the next user.
+  // Prefix sweep covers any future `assistant-*` key without further changes here.
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith("assistant-")) {
+      localStorage.removeItem(key);
+    }
+  }
   logout();
 };
 

--- a/frontend/src/composables/useAssistant.ts
+++ b/frontend/src/composables/useAssistant.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from "vue";
 import { useAskAssistantMutation } from "@/__generated__/vue-apollo";
 import type { AgentTraceMessage } from "@/__generated__/vue-apollo";
+import { appStorage } from "@/lib/appStorage";
 
 const LAST_RESULT_STORAGE_KEY = "assistant-last-result";
 const SESSION_ID_STORAGE_KEY = "assistant-session-id";
@@ -12,7 +13,7 @@ interface StoredAssistantResult {
 
 const loadStoredResult = (): StoredAssistantResult | null => {
   try {
-    const stored = localStorage.getItem(LAST_RESULT_STORAGE_KEY);
+    const stored = appStorage.getItem(LAST_RESULT_STORAGE_KEY);
     return stored ? JSON.parse(stored) : null;
   } catch (error) {
     console.error("Failed to load stored result:", error);
@@ -22,11 +23,11 @@ const loadStoredResult = (): StoredAssistantResult | null => {
 
 const saveStoredResult = (result: StoredAssistantResult): void => {
   try {
-    localStorage.setItem(LAST_RESULT_STORAGE_KEY, JSON.stringify(result));
+    appStorage.setItem(LAST_RESULT_STORAGE_KEY, JSON.stringify(result));
   } catch {
     // Fallback: agentTrace can be large; try storing without it
     try {
-      localStorage.setItem(LAST_RESULT_STORAGE_KEY, JSON.stringify({ ...result, agentTrace: [] }));
+      appStorage.setItem(LAST_RESULT_STORAGE_KEY, JSON.stringify({ ...result, agentTrace: [] }));
     } catch (error) {
       console.error("Failed to persist assistant result:", error);
     }
@@ -35,7 +36,7 @@ const saveStoredResult = (result: StoredAssistantResult): void => {
 
 const loadStoredSessionId = (): string | null => {
   try {
-    return localStorage.getItem(SESSION_ID_STORAGE_KEY);
+    return appStorage.getItem(SESSION_ID_STORAGE_KEY);
   } catch (error) {
     // Non-critical — session will just restart next visit
     console.error("Failed to load session ID:", error);
@@ -45,7 +46,7 @@ const loadStoredSessionId = (): string | null => {
 
 const saveSessionId = (sessionId: string): void => {
   try {
-    localStorage.setItem(SESSION_ID_STORAGE_KEY, sessionId);
+    appStorage.setItem(SESSION_ID_STORAGE_KEY, sessionId);
   } catch (error) {
     // Non-critical — session will just restart next visit
     console.error("Failed to persist session ID:", error);

--- a/frontend/src/composables/useAssistant.ts
+++ b/frontend/src/composables/useAssistant.ts
@@ -52,6 +52,15 @@ const saveSessionId = (sessionId: string): void => {
   }
 };
 
+export const clearAssistantStorage = (): void => {
+  try {
+    localStorage.removeItem(LAST_RESULT_STORAGE_KEY);
+    localStorage.removeItem(SESSION_ID_STORAGE_KEY);
+  } catch (error) {
+    console.error("Failed to clear assistant storage:", error);
+  }
+};
+
 export function useAssistant() {
   const stored = loadStoredResult();
   const storedAnswer = ref<string | null>(stored?.answer ?? null);

--- a/frontend/src/composables/useAssistant.ts
+++ b/frontend/src/composables/useAssistant.ts
@@ -52,15 +52,6 @@ const saveSessionId = (sessionId: string): void => {
   }
 };
 
-export const clearAssistantStorage = (): void => {
-  try {
-    localStorage.removeItem(LAST_RESULT_STORAGE_KEY);
-    localStorage.removeItem(SESSION_ID_STORAGE_KEY);
-  } catch (error) {
-    console.error("Failed to clear assistant storage:", error);
-  }
-};
-
 export function useAssistant() {
   const stored = loadStoredResult();
   const storedAnswer = ref<string | null>(stored?.answer ?? null);

--- a/frontend/src/lib/appStorage.test.ts
+++ b/frontend/src/lib/appStorage.test.ts
@@ -1,0 +1,118 @@
+import { appStorage } from "./appStorage";
+
+describe("appStorage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("getItem", () => {
+    // Happy path
+
+    it("reads value stored under prefixed key", () => {
+      // Arrange
+      localStorage.setItem("budget:foo", "bar");
+
+      // Act
+      const result = appStorage.getItem("foo");
+
+      // Assert
+      expect(result).toBe("bar");
+    });
+
+    it("returns null when key is absent", () => {
+      // Act
+      const result = appStorage.getItem("missing");
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it("ignores unprefixed key with same name", () => {
+      // Arrange
+      // Simulates legacy data written before wrapper existed
+      localStorage.setItem("foo", "legacy");
+
+      // Act
+      const result = appStorage.getItem("foo");
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setItem", () => {
+    // Happy path
+
+    it("writes value under prefixed key", () => {
+      // Act
+      appStorage.setItem("foo", "bar");
+
+      // Assert
+      expect(localStorage.getItem("budget:foo")).toBe("bar");
+      expect(localStorage.getItem("foo")).toBeNull();
+    });
+
+    it("overwrites existing value under same key", () => {
+      // Arrange
+      appStorage.setItem("foo", "first");
+
+      // Act
+      appStorage.setItem("foo", "second");
+
+      // Assert
+      expect(appStorage.getItem("foo")).toBe("second");
+    });
+  });
+
+  describe("removeItem", () => {
+    // Happy path
+
+    it("deletes prefixed key", () => {
+      // Arrange
+      appStorage.setItem("foo", "bar");
+
+      // Act
+      appStorage.removeItem("foo");
+
+      // Assert
+      expect(appStorage.getItem("foo")).toBeNull();
+    });
+
+    it("does nothing when key is absent", () => {
+      // Act & Assert
+      expect(() => appStorage.removeItem("missing")).not.toThrow();
+    });
+  });
+
+  describe("clearAll", () => {
+    // Happy path
+
+    it("removes all prefixed keys", () => {
+      // Arrange
+      appStorage.setItem("one", "1");
+      appStorage.setItem("two", "2");
+      appStorage.setItem("three", "3");
+
+      // Act
+      appStorage.clearAll();
+
+      // Assert
+      expect(appStorage.getItem("one")).toBeNull();
+      expect(appStorage.getItem("two")).toBeNull();
+      expect(appStorage.getItem("three")).toBeNull();
+    });
+
+    it("preserves keys without prefix", () => {
+      // Arrange
+      localStorage.setItem("other", "keep-me");
+      appStorage.setItem("foo", "wipe-me");
+
+      // Act
+      appStorage.clearAll();
+
+      // Assert
+      expect(localStorage.getItem("other")).toBe("keep-me");
+      expect(appStorage.getItem("foo")).toBeNull();
+    });
+  });
+});

--- a/frontend/src/lib/appStorage.ts
+++ b/frontend/src/lib/appStorage.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrapper around localStorage for user-scoped data that must be wiped on sign out.
+ *
+ * Why: a previous bug allowed one user's assistant data
+ * to persist into the next user's session on a shared browser.
+ * Calling localStorage.clear() on sign out fixed the leak
+ * but also wiped oidc-client-ts state (id_token_hint),
+ * breaking signoutRedirect.
+ *
+ * This wrapper namespaces every user-scoped key with a `budget:` prefix
+ * so clearAll() can wipe exactly that data and nothing else.
+ */
+const PREFIX = "budget:";
+
+export const appStorage = {
+  getItem(key: string): string | null {
+    return localStorage.getItem(PREFIX + key);
+  },
+
+  setItem(key: string, value: string): void {
+    localStorage.setItem(PREFIX + key, value);
+  },
+
+  removeItem(key: string): void {
+    localStorage.removeItem(PREFIX + key);
+  },
+
+  clearAll(): void {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith(PREFIX)) {
+        localStorage.removeItem(key);
+      }
+    }
+  },
+};

--- a/frontend/src/views/Assistant.vue
+++ b/frontend/src/views/Assistant.vue
@@ -43,6 +43,7 @@
 import { ref, watch } from "vue";
 import { useAssistant } from "@/composables/useAssistant";
 import { useSnackbar } from "@/composables/useSnackbar";
+import { appStorage } from "@/lib/appStorage";
 import AgenticInput from "@/components/AgenticInput.vue";
 
 const STORAGE_KEY = "assistant-input";
@@ -62,7 +63,7 @@ interface StoredInput {
 
 const loadStoredInput = (): Partial<StoredInput> => {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = appStorage.getItem(STORAGE_KEY);
     return stored ? JSON.parse(stored) : {};
   } catch {
     return {};
@@ -73,7 +74,7 @@ const saveInput = () => {
   const data: StoredInput = {
     question: question.value,
   };
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  appStorage.setItem(STORAGE_KEY, JSON.stringify(data));
 };
 
 const storedInput = loadStoredInput();


### PR DESCRIPTION
## context

When multiple users share a browser, signing out and signing back in as a different user exposes the previous user's assistant conversation.
This is a privacy issue — assistant questions and answers can contain sensitive financial information.

## before

- The previous user's last assistant answer remains visible after a new user signs in
- The new user's first assistant request continues the previous user's session

## after

- Signing out clears the previous user's assistant answer
- Signing out starts a fresh assistant session for the next user

Close #336
