### PR TITLE
fix schema path resolution in CJS lambda bundle

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,7 +24,10 @@ import { createCategoryLoader } from "./graphql/dataloaders/category-loader";
 import { resolvers } from "./graphql/resolvers";
 import { getAuthenticatedUser } from "./graphql/resolvers/shared";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
+const currentDir =
+  typeof __dirname !== "undefined"
+    ? __dirname
+    : dirname(fileURLToPath(import.meta.url));
 
 const typeDefs = readFileSync(join(currentDir, "graphql/schema.graphql"), {
   encoding: "utf-8",


### PR DESCRIPTION
- Commit 46c943e used import.meta.url, which works under ESM dev (tsx) but is rewritten to undefined after esbuild bundles to CJS for Lambda, crashing web lambda cold starts with fileURLToPath(undefined)
- Prefer __dirname when defined (CJS bundle); fall back to import.meta.url for ESM