### PR TITLE
test: remove articles from comments in create-transaction-from-text-service test

### DIFF
--- a/backend/src/services/create-transaction-from-text-service.test.ts
+++ b/backend/src/services/create-transaction-from-text-service.test.ts
@@ -47,7 +47,7 @@ describe("CreateTransactionFromTextService", () => {
       const transactionId = faker.string.uuid();
       const createdTransaction = fakeTransaction();
 
-      // Agent successfully creates a transaction
+      // Agent successfully creates transaction
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: "OK",
         agentTrace: [],
@@ -63,7 +63,7 @@ describe("CreateTransactionFromTextService", () => {
         ],
       });
 
-      // Fetching the created transaction succeeds
+      // Fetching created transaction succeeds
       mockTransactionService.getTransactionById.mockResolvedValue(
         createdTransaction,
       );
@@ -89,7 +89,7 @@ describe("CreateTransactionFromTextService", () => {
         { type: AgentTraceMessageType.TEXT, content: "Thinking..." },
       ];
 
-      // Agent returns a thinking trace alongside the tool execution
+      // Agent returns thinking trace alongside tool execution
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: "OK",
         agentTrace,
@@ -105,7 +105,7 @@ describe("CreateTransactionFromTextService", () => {
         ],
       });
 
-      // Fetching the created transaction succeeds
+      // Fetching created transaction succeeds
       mockTransactionService.getTransactionById.mockResolvedValue(
         fakeTransaction(),
       );
@@ -130,7 +130,7 @@ describe("CreateTransactionFromTextService", () => {
       const lastTransactionId = faker.string.uuid();
       const createdTransaction = fakeTransaction();
 
-      // Agent calls createTransaction twice — only the last result should be used
+      // Agent calls createTransaction twice — only last result is used
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: "OK",
         agentTrace: [],
@@ -154,7 +154,7 @@ describe("CreateTransactionFromTextService", () => {
         ],
       });
 
-      // Fetching the created transaction succeeds
+      // Fetching created transaction succeeds
       mockTransactionService.getTransactionById.mockResolvedValue(
         createdTransaction,
       );
@@ -175,7 +175,7 @@ describe("CreateTransactionFromTextService", () => {
 
     describe("agent call parameters", () => {
       beforeEach(() => {
-        // Agent successfully creates a transaction
+        // Agent successfully creates transaction
         mockCreateTransactionAgent.invoke.mockResolvedValue({
           answer: "OK",
           agentTrace: [],
@@ -191,7 +191,7 @@ describe("CreateTransactionFromTextService", () => {
           ],
         });
 
-        // Fetching the created transaction succeeds
+        // Fetching created transaction succeeds
         mockTransactionService.getTransactionById.mockResolvedValue(
           fakeTransaction(),
         );
@@ -317,7 +317,7 @@ describe("CreateTransactionFromTextService", () => {
     it("returns failure when agent does not attempt to create transaction", async () => {
       // Arrange
 
-      // Agent responds without invoking the createTransaction tool
+      // Agent responds without invoking createTransaction tool
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: "I need more information.",
         agentTrace: [],
@@ -341,7 +341,7 @@ describe("CreateTransactionFromTextService", () => {
     it("returns failure when tool output is not valid JSON", async () => {
       // Arrange
 
-      // Agent invokes the tool but the output is malformed
+      // Agent invokes tool but output is malformed
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: undefined,
         agentTrace: [],
@@ -368,7 +368,7 @@ describe("CreateTransactionFromTextService", () => {
     it("returns failure when tool output does not match expected schema", async () => {
       // Arrange
 
-      // Agent invokes the tool but returns an unexpected JSON shape
+      // Agent invokes tool but returns unexpected JSON shape
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: undefined,
         agentTrace: [],
@@ -400,7 +400,7 @@ describe("CreateTransactionFromTextService", () => {
     it("returns failure when tool reports transaction creation failed", async () => {
       // Arrange
 
-      // Agent invokes the tool but the tool itself reports a business failure
+      // Agent invokes tool but tool itself reports business failure
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: undefined,
         agentTrace: [],
@@ -430,7 +430,7 @@ describe("CreateTransactionFromTextService", () => {
     it("includes agentTrace in failure response", async () => {
       // Arrange
 
-      // Agent responds with a thinking trace but no tool call
+      // Agent responds with thinking trace but no tool call
       mockCreateTransactionAgent.invoke.mockResolvedValue({
         answer: undefined,
         agentTrace: [


### PR DESCRIPTION
## Summary

Per the testing skill, comments in test files (mock setup notes and section labels) MUST omit articles (`a`, `an`, `the`).

I surveyed all `*.test.ts` files in `backend/src/` against the testing skill standards. `create-transaction-from-text-service.test.ts` had the most concerns — 13 comment lines using articles. This PR fixes all of them.

Examples of the change:
- `// Agent successfully creates a transaction` → `// Agent successfully creates transaction`
- `// Fetching the created transaction succeeds` → `// Fetching created transaction succeeds`
- `// Agent invokes the tool but the output is malformed` → `// Agent invokes tool but output is malformed`

## Scope

Single test file. No production code touched. No test logic changed — comments only.

## Survey context (top offenders)

| File | Concerns |
| --- | --- |
| `services/create-transaction-from-text-service.test.ts` | **13** ← this PR |
| `repositories/dyn-transaction-repository.test.ts` | 11 |
| `services/assistant-service.test.ts` | 9 |
| `repositories/dyn-user-repository.test.ts` | 4 |
| `langchain/tools/update-account.test.ts` | 4 |

Other files have ≤ 3 concerns each. Mock-typing concerns (using `ReturnType<typeof createMock...>` instead of `jest.Mocked<Interface>`) appear in a handful of langchain agent tests and `category-service.test.ts` — out of scope for this PR.

## Test plan

- [x] `npx jest src/services/create-transaction-from-text-service.test.ts` — 17/17 pass
- [x] `npm run test:unit` — same pass/fail counts as baseline (14 pre-existing failures in `migrations-table.test.ts` require DynamoDB Local, unrelated)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run prettier` — clean

https://claude.ai/code/session_01QuyPYvWKQiHJNwVWu6WFm2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QuyPYvWKQiHJNwVWu6WFm2)_