### PR TITLE
docs: document backend port interfaces pattern in constitution

### DIFF
--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -223,19 +223,6 @@ graph LR
 
 **Rationale**: Enables independent testing, maintainable code, and portable architecture.
 
-### Backend Port Interfaces
-
-**Non-negotiable rule**: Each repository and external integration MUST expose a port interface, and all consumers (services, resolvers) MUST depend on these interfaces — never on concrete implementations.
-
-**Implementation**:
-
-- Define port interfaces in `src/ports/` (one file per interface, e.g., `account-repository.ts`)
-- Name concrete implementations with an adapter prefix that reflects the underlying technology (e.g., `DynAccountRepository` for a DynamoDB-backed `AccountRepository`)
-- Services receive port interfaces as constructor parameters — never concrete classes
-- Wire concrete implementations together exclusively in `dependencies.ts`
-
-**Rationale**: Decouples business logic from infrastructure. Services coded to interfaces can be tested with mock repositories without touching a database, and the underlying storage technology can be swapped by substituting the concrete implementation without modifying any service or resolver.
-
 ### Backend GraphQL Layer
 
 **Non-negotiable rule**: GraphQL schema reflects user-facing functionality, not database implementation details. The schema serves as a Backend-For-Frontend (BFF) contract optimized for the frontend client.
@@ -291,6 +278,19 @@ graph LR
 - Prefer single-purpose services when orchestrating multiple repositories
 
 **Rationale**: Balances maintainability with flexibility for complex operations.
+
+### Backend Port Interfaces
+
+**Non-negotiable rule**: The service layer defines ports (interfaces) at its boundary with infrastructure and external systems. Repositories and external integrations are adapters that implement these ports. Services depend only on ports, never on adapters.
+
+**Implementation**:
+
+- Ports live in `src/ports/`, one per file (e.g., `account-repository.ts`); they are owned by the service layer
+- Adapters use a prefix naming the technology (e.g., `DynAccountRepository` implements the `AccountRepository` port for DynamoDB)
+- Services receive ports via constructor — never adapters
+- Adapters are wired to ports in `dependencies.ts`
+
+**Rationale**: Hexagonal architecture. Business logic owns its contracts; infrastructure conforms. Services are testable with fake adapters and infrastructure can be swapped without touching the domain.
 
 ### Result Pattern
 

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -223,6 +223,19 @@ graph LR
 
 **Rationale**: Enables independent testing, maintainable code, and portable architecture.
 
+### Backend Port Interfaces
+
+**Non-negotiable rule**: Each repository and external integration MUST expose a port interface, and all consumers (services, resolvers) MUST depend on these interfaces — never on concrete implementations.
+
+**Implementation**:
+
+- Define port interfaces in `src/ports/` (one file per interface, e.g., `account-repository.ts`)
+- Name concrete implementations with an adapter prefix that reflects the underlying technology (e.g., `DynAccountRepository` for a DynamoDB-backed `AccountRepository`)
+- Services receive port interfaces as constructor parameters — never concrete classes
+- Wire concrete implementations together exclusively in `dependencies.ts`
+
+**Rationale**: Decouples business logic from infrastructure. Services coded to interfaces can be tested with mock repositories without touching a database, and the underlying storage technology can be swapped by substituting the concrete implementation without modifying any service or resolver.
+
 ### Backend GraphQL Layer
 
 **Non-negotiable rule**: GraphQL schema reflects user-facing functionality, not database implementation details. The schema serves as a Backend-For-Frontend (BFF) contract optimized for the frontend client.


### PR DESCRIPTION
## Summary

- Adds a new **Backend Port Interfaces** section to `docs/constitution.md`
- Documents the non-negotiable rule that services must depend on port interfaces (in `src/ports/`), never on concrete implementations
- Captures the naming convention for concrete adapters (`Dyn*` prefix for DynamoDB) and the rule that wiring happens exclusively in `dependencies.ts`

## Why this matters

The codebase already applies this pattern consistently everywhere — every repository has a port interface, every service constructor takes those interfaces as parameters — but the rule was not written down. Without it, a new developer could wire a concrete `DynAccountRepository` directly into a service, bypassing the abstraction that makes test mocking and database portability possible.

This section bridges the gap between the existing **Vendor Independence** and **Test Strategy** principles (both of which depend on this pattern working) and the actual code that implements them.

## Test plan

- [x] Read the new section and verify it accurately reflects the code in `src/ports/`, `src/repositories/`, `src/services/`, and `src/dependencies.ts`
- [x] Confirm no other sections need updating as a result of this addition

https://claude.ai/code/session_01SpVfNcuU8NgjHW1cAiBM9t

---
_Generated by [Claude Code](https://claude.ai/code/session_01SpVfNcuU8NgjHW1cAiBM9t)_