### PR TITLE
test: align dyn-category-repository tests with testing standard

### DIFF
--- a/backend/src/repositories/dyn-category-repository.test.ts
+++ b/backend/src/repositories/dyn-category-repository.test.ts
@@ -28,6 +28,8 @@ describe("DynCategoryRepository", () => {
   });
 
   describe("findManyByUserId", () => {
+    // Happy path
+
     it("returns categories sorted alphabetically", async () => {
       // Arrange - Create categories in mixed order with different types
       await repository.create(
@@ -215,7 +217,9 @@ describe("DynCategoryRepository", () => {
     });
   });
 
-  describe("findManyByUserId", () => {
+  describe("findManyWithArchivedByUserId", () => {
+    // Happy path
+
     it("returns all categories including archived", async () => {
       // Arrange
       const activeCategory = await repository.create(
@@ -272,6 +276,8 @@ describe("DynCategoryRepository", () => {
       expect(result[0]?.userId).toBe(userId);
     });
 
+    // Validation failures
+
     it("throws error when userId is missing", async () => {
       // Act & Assert
       await expect(repository.findManyWithArchivedByUserId("")).rejects.toThrow(
@@ -280,7 +286,9 @@ describe("DynCategoryRepository", () => {
     });
   });
 
-  describe("findManyByIds", () => {
+  describe("findManyWithArchivedByIds", () => {
+    // Happy path
+
     it("returns categories when IDs exist", async () => {
       // Arrange
       const category1 = await repository.create(
@@ -330,16 +338,6 @@ describe("DynCategoryRepository", () => {
       expect(result[0]).toEqual(category);
     });
 
-    it("throws error when userId is missing", async () => {
-      // Act & Assert
-      await expect(
-        repository.findManyWithArchivedByIds({
-          ids: ["category-1"],
-          userId: "",
-        }),
-      ).rejects.toThrow("User ID is required");
-    });
-
     it("returns archived categories (not filtered)", async () => {
       // Arrange
       const category = await repository.create(
@@ -357,9 +355,49 @@ describe("DynCategoryRepository", () => {
       expect(result).toHaveLength(1);
       expect(result[0]?.isArchived).toBe(true);
     });
+
+    // Validation failures
+
+    it("throws error when userId is missing", async () => {
+      // Act & Assert
+      await expect(
+        repository.findManyWithArchivedByIds({
+          ids: ["category-1"],
+          userId: "",
+        }),
+      ).rejects.toThrow("User ID is required");
+    });
+
+    // Dependency failures
+
+    it("throws error when required field type is missing from database record", async () => {
+      // Arrange
+      const category = await repository.create(
+        fakeCreateCategoryInput({ userId }),
+      );
+
+      // Manually corrupt database record by removing type (type is reserved keyword)
+      await client.send(
+        new UpdateCommand({
+          TableName: tableName,
+          Key: { userId, id: category.id },
+          UpdateExpression: "REMOVE #t",
+          ExpressionAttributeNames: {
+            "#t": "type",
+          },
+        }),
+      );
+
+      // Act & Assert
+      await expect(
+        repository.findManyWithArchivedByIds({ ids: [category.id], userId }),
+      ).rejects.toThrow();
+    });
   });
 
   describe("create", () => {
+    // Happy path
+
     it("creates category successfully", async () => {
       // Arrange
       const input = fakeCreateCategoryInput({ userId });
@@ -405,6 +443,8 @@ describe("DynCategoryRepository", () => {
   });
 
   describe("update", () => {
+    // Happy path
+
     it("updates category name successfully", async () => {
       // Arrange
       const category = await repository.create(
@@ -500,6 +540,8 @@ describe("DynCategoryRepository", () => {
       expect(result.updatedAt).not.toBe(category.updatedAt);
     });
 
+    // Validation failures
+
     it("throws error when category does not exist", async () => {
       // Act & Assert
       await expect(
@@ -536,6 +578,8 @@ describe("DynCategoryRepository", () => {
   });
 
   describe("archive", () => {
+    // Happy path
+
     it("archives category successfully", async () => {
       // Arrange
       const category = await repository.create(
@@ -550,6 +594,8 @@ describe("DynCategoryRepository", () => {
       expect(result.isArchived).toBe(true);
       expect(result.updatedAt).not.toBe(category.updatedAt);
     });
+
+    // Validation failures
 
     it("throws error when archiving non-existent category", async () => {
       // Act & Assert
@@ -580,33 +626,6 @@ describe("DynCategoryRepository", () => {
       await expect(
         repository.archive({ id: "some-id", userId: "" }),
       ).rejects.toThrow("User ID is required");
-    });
-  });
-
-  describe("hydration - data corruption detection", () => {
-    it("throws error when required field type is missing from database record", async () => {
-      // Arrange
-      const category = await repository.create(
-        fakeCreateCategoryInput({ userId }),
-      );
-      const client = createDynamoDBDocumentClient();
-
-      // Manually corrupt the database record by removing type (type is a reserved keyword)
-      await client.send(
-        new UpdateCommand({
-          TableName: tableName,
-          Key: { userId, id: category.id },
-          UpdateExpression: "REMOVE #t",
-          ExpressionAttributeNames: {
-            "#t": "type",
-          },
-        }),
-      );
-
-      // Act & Assert
-      await expect(
-        repository.findManyWithArchivedByIds({ ids: [category.id], userId }),
-      ).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Summary

Reviewed every test file under `backend/src/**/*.test.ts` against the project testing skill (`.claude/skills/testing/SKILL.md`). Concerns were collected per file across three parallel reviews. `backend/src/repositories/dyn-category-repository.test.ts` had the most issues, so this PR fixes only that file.

### Concerns fixed in `dyn-category-repository.test.ts`

- **Two mislabeled `describe` blocks**: the second `describe("findManyByUserId", ...)` was actually testing `findManyWithArchivedByUserId`, and `describe("findManyByIds", ...)` was actually testing `findManyWithArchivedByIds`. Renamed to match the methods under test.
- **Missing section structure**: added `// Happy path`, `// Validation failures`, and `// Dependency failures` comment labels per the skill on every method's `describe`.
- **Test ordering inside `findManyWithArchivedByIds`**: the validation-failure test was sandwiched between happy-path tests. Reordered so all happy paths come first, then validation failures, then dependency failures.
- **Orphan `describe("hydration - data corruption detection", ...)`** at the bottom: the skill requires `describe` blocks to mirror the source class's method order. The test exercises `findManyWithArchivedByIds`, so it was moved into that block as a `// Dependency failures` test (and the inline shadowed `client` was removed in favor of the outer one).

No production code changed. No new tests added or removed.

### Concerns left out of scope (per "limit each change to a single test file")

The wider review surfaced smaller concerns elsewhere — most often missing section comments and a few `ReturnType<typeof createMock...>` annotations that should be `jest.Mocked<Interface>` (notably `category-service.test.ts:17`, `create-transaction.test.ts`, `create-transaction-subagent.test.ts`). These are not addressed here.

## Test plan

- [x] `npm run test:repositories -- src/repositories/dyn-category-repository.test.ts` — 28/28 passing
- [x] `npm run typecheck` — no errors
- [x] `npm run format` — no lint errors (eslint --fix was a no-op on the diff)

https://claude.ai/code/session_01HrJFmV5iPACajxxTNar625

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrJFmV5iPACajxxTNar625)_