### PR TITLE
convert backend lambda bundles to esm

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build:bundle:background-job": "esbuild src/lambdas/background-job.ts --bundle --platform=node --external:@aws-sdk/* --outfile=dist/background-job-lambda.js",
-    "build:bundle:migrate": "esbuild src/lambdas/migrate.ts --bundle --platform=node --external:@aws-sdk/* --outfile=dist/migrate-lambda.js",
-    "build:bundle:web": "esbuild src/lambdas/web.ts --bundle --platform=node --external:@aws-sdk/* --outfile=dist/web-lambda.js",
+    "build:bundle:background-job": "esbuild src/lambdas/background-job.ts --bundle --platform=node --format=esm --external:@aws-sdk/* --outfile=dist/background-job-lambda.mjs --banner:js=\"$(cat src/lambdas/esm-banner.ts)\"",
+    "build:bundle:migrate": "esbuild src/lambdas/migrate.ts --bundle --platform=node --format=esm --external:@aws-sdk/* --outfile=dist/migrate-lambda.mjs --banner:js=\"$(cat src/lambdas/esm-banner.ts)\"",
+    "build:bundle:web": "esbuild src/lambdas/web.ts --bundle --platform=node --format=esm --external:@aws-sdk/* --outfile=dist/web-lambda.mjs --banner:js=\"$(cat src/lambdas/esm-banner.ts)\"",
     "build:bundle": "npm run build:bundle:web && npm run build:bundle:background-job && npm run build:bundle:migrate",
     "build:clean": "rm -rf dist",
     "build:schema": "mkdir -p dist/graphql && cp src/graphql/schema.graphql dist/graphql/",

--- a/backend/src/lambdas/esm-banner.ts
+++ b/backend/src/lambdas/esm-banner.ts
@@ -1,0 +1,9 @@
+// Banner injected verbatim at the top of every ESM lambda bundle by esbuild
+// (see build:bundle:* scripts in package.json).
+// Restores `require` so bundled CJS deps that perform dynamic require()
+// (e.g. aws-xray-sdk-core loading node:diagnostics_channel) keep working.
+// esbuild's __require helper reads `require` from this scope at bundle init.
+
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+export { require };

--- a/backend/src/lambdas/esm-banner.ts
+++ b/backend/src/lambdas/esm-banner.ts
@@ -5,5 +5,5 @@
 // esbuild's __require helper reads `require` from this scope at bundle init.
 
 import { createRequire } from "module";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const require = createRequire(import.meta.url);
-export { require };

--- a/backend/src/server.test.ts
+++ b/backend/src/server.test.ts
@@ -1,0 +1,12 @@
+import { ApolloServer } from "@apollo/server";
+import { describe, expect, it } from "vitest";
+import { server } from "./server";
+
+describe("server", () => {
+  // Happy path
+
+  it("exports ApolloServer instance", () => {
+    // Act & Assert
+    expect(server).toBeInstanceOf(ApolloServer);
+  });
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,10 +24,7 @@ import { createCategoryLoader } from "./graphql/dataloaders/category-loader";
 import { resolvers } from "./graphql/resolvers";
 import { getAuthenticatedUser } from "./graphql/resolvers/shared";
 
-const currentDir =
-  typeof __dirname !== "undefined"
-    ? __dirname
-    : dirname(fileURLToPath(import.meta.url));
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 const typeDefs = readFileSync(join(currentDir, "graphql/schema.graphql"), {
   encoding: "utf-8",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14104,7 +14104,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
- Switch `esbuild build:bundle:*` scripts to `--format=esm` with .mjs output
- Add `lambdas/esm-banner.ts` injected via `--banner:js` to restore require for bundled CJS deps that perform dynamic `require()`
- Drop CJS `__dirname` fallback in server.ts
- Add `server.test.ts` asserting the exported server is an ApolloServer