### PR TITLE
test(math): align math.test.ts with testing skill rules

### DIFF
--- a/backend/src/langchain/tools/math.test.ts
+++ b/backend/src/langchain/tools/math.test.ts
@@ -30,9 +30,7 @@ describe("sumTool", () => {
     const result = await sumTool.invoke({ numbers: [10.5, 20.3, 15.0] });
 
     // Assert
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data).toBeCloseTo(45.8);
+    expect(result).toEqual({ success: true, data: 45.8 });
   });
 });
 
@@ -81,9 +79,7 @@ describe("calculateTool", () => {
     });
 
     // Assert
-    expect(result.success).toBe(true);
-    if (!result.success) return;
-    expect(result.data).toBeCloseTo(22.9);
+    expect(result).toEqual({ success: true, data: 22.9 });
   });
 
   // Validation failures

--- a/backend/src/langchain/tools/math.test.ts
+++ b/backend/src/langchain/tools/math.test.ts
@@ -2,43 +2,63 @@ import { describe, expect, it } from "vitest";
 import { avgTool, calculateTool, sumTool } from "./math";
 
 describe("sumTool", () => {
+  // Happy path
+
   it("has correct name", () => {
+    // Act & Assert
     expect(sumTool.name).toBe("sum");
   });
 
-  it("sums an array of numbers", async () => {
+  it("sums array of numbers", async () => {
+    // Act
     const result = await sumTool.invoke({ numbers: [1, 2, 3, 4, 5] });
 
+    // Assert
     expect(result).toEqual({ success: true, data: 15 });
   });
 
-  it("returns 0 for an empty array", async () => {
+  it("returns 0 for empty array", async () => {
+    // Act
     const result = await sumTool.invoke({ numbers: [] });
 
+    // Assert
     expect(result).toEqual({ success: true, data: 0 });
   });
 
   it("handles decimal numbers", async () => {
+    // Act
     const result = await sumTool.invoke({ numbers: [10.5, 20.3, 15.0] });
 
-    expect((result as { success: true; data: number }).data).toBeCloseTo(45.8);
+    // Assert
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toBeCloseTo(45.8);
   });
 });
 
 describe("avgTool", () => {
+  // Happy path
+
   it("has correct name", () => {
+    // Act & Assert
     expect(avgTool.name).toBe("avg");
   });
 
-  it("calculates the average of an array of numbers", async () => {
+  it("calculates average of array of numbers", async () => {
+    // Act
     const result = await avgTool.invoke({ numbers: [10, 20, 30] });
 
+    // Assert
     expect(result).toEqual({ success: true, data: 20 });
   });
 
-  it("returns failure for an empty array", async () => {
+  // Validation failures
+
+  it("returns failure for empty array", async () => {
+    // Act
     const result = await avgTool.invoke({ numbers: [] });
 
+    // Assert
     expect(result).toEqual({
       success: false,
       error: "Cannot calculate average of an empty array",
@@ -47,21 +67,32 @@ describe("avgTool", () => {
 });
 
 describe("calculateTool", () => {
+  // Happy path
+
   it("has correct name", () => {
+    // Act & Assert
     expect(calculateTool.name).toBe("calculate");
   });
 
-  it("evaluates a mathematical expression", async () => {
+  it("evaluates mathematical expression", async () => {
+    // Act
     const result = await calculateTool.invoke({
       expression: "(45.8 / 200) * 100",
     });
 
-    expect((result as { success: true; data: number }).data).toBeCloseTo(22.9);
+    // Assert
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toBeCloseTo(22.9);
   });
 
+  // Validation failures
+
   it("returns failure for non-numeric results", async () => {
+    // Act
     const result = await calculateTool.invoke({ expression: "sqrt(-1)" });
 
-    expect((result as { success: false; error: string }).success).toBe(false);
+    // Assert
+    expect(result.success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Reviewed all backend test files against the project testing skill rules. `backend/src/langchain/tools/math.test.ts` had the highest density of concrete violations, so this PR cleans it up.

### Concerns fixed

- **Articles in test names** (rule: present tense, no `a`/`an`/`the`)
  - `sums an array of numbers` → `sums array of numbers`
  - `returns 0 for an empty array` → `returns 0 for empty array`
  - `calculates the average of an array of numbers` → `calculates average of array of numbers`
  - `returns failure for an empty array` → `returns failure for empty array`
  - `evaluates a mathematical expression` → `evaluates mathematical expression`
- **Missing group comments** — added `// Happy path` and `// Validation failures` to `sumTool`, `avgTool`, and `calculateTool` describes.
- **Missing AAA comments** — added `// Arrange / Act / Assert` (or `// Act & Assert` for single-statement tests) to all 10 tests.
- **Awkward type casts** — replaced `as { success: true; data: number }` with discriminated-union narrowing (`if (!result.success) return;`) before asserting on `result.data`.

### Other files reviewed

Top concern counts after verification (concerns vary in severity):

- `dyn-transaction-repository.test.ts` — multiple level-3 describes ("without filters", "with account filters", etc.) with fewer than 3 tests each, violating the "when ..." scenario rule. Not fixed here — the file is 2544 lines and the cleanup would sprawl across many tests. Worth a follow-up PR.
- `dyn-base-repository.test.ts`, `dyn-category-repository.test.ts`, `dyn-user-repository.test.ts`, `get-categories.test.ts` — minor article/grouping issues. Most agent-reported "missing inline mock-setup comments" turned out to already be present.
- The remaining ~45 files had 0–2 minor concerns each.

## Test plan

- [x] `npm test -- src/langchain/tools/math.test.ts` — 10 tests pass
- [x] `npm run typecheck` — no errors
- [x] `npm run format` — no lint errors

https://claude.ai/code/session_01N63PYTEAHYwFAewo8dhas1

---
_Generated by [Claude Code](https://claude.ai/code/session_01N63PYTEAHYwFAewo8dhas1)_