### PR TITLE
align user-service.test.ts with testing skill standards

### DIFF
--- a/backend/src/services/user-service.test.ts
+++ b/backend/src/services/user-service.test.ts
@@ -20,6 +20,8 @@ describe("UserService", () => {
   });
 
   describe("getSettings", () => {
+    // Happy path
+
     it("returns settings for existing user", async () => {
       // Arrange
       const userId = faker.string.uuid();
@@ -28,6 +30,7 @@ describe("UserService", () => {
         transactionPatternsLimit: 5,
         voiceInputLanguage: "pl-PL",
       });
+      // Returns user with saved settings
       mockUserRepository.findOneById.mockResolvedValue(user);
 
       // Act
@@ -47,6 +50,7 @@ describe("UserService", () => {
       // Arrange
       const userId = faker.string.uuid();
       const user = fakeUser({ id: userId });
+      // Returns user without saved settings
       mockUserRepository.findOneById.mockResolvedValue(user);
 
       // Act
@@ -62,8 +66,20 @@ describe("UserService", () => {
       });
     });
 
-    it("fails when user is not found", async () => {
+    // Validation failures
+
+    it("returns failure when userId is empty", async () => {
+      // Act
+      const result = await service.getSettings("");
+
+      // Assert
+      expect(result).toEqual({ success: false, error: "User ID is required" });
+      expect(mockUserRepository.findOneById).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when user is not found", async () => {
       // Arrange
+      // Returns no user for given id
       mockUserRepository.findOneById.mockResolvedValue(null);
 
       // Act
@@ -72,19 +88,16 @@ describe("UserService", () => {
       // Assert
       expect(result).toEqual({ success: false, error: "User not found" });
     });
-
-    it("fails when userId is empty", async () => {
-      const result = await service.getSettings("");
-
-      expect(result).toEqual({ success: false, error: "User ID is required" });
-    });
   });
 
   describe("updateSettings", () => {
+    // Happy path
+
     it("updates voiceInputLanguage", async () => {
       // Arrange
       const userId = faker.string.uuid();
       const updated = fakeUser({ id: userId, voiceInputLanguage: "de-DE" });
+      // Persists and returns updated user
       mockUserRepository.update.mockResolvedValue(updated);
 
       // Act
@@ -110,6 +123,7 @@ describe("UserService", () => {
       // Arrange
       const userId = faker.string.uuid();
       const updated = fakeUser({ id: userId, transactionPatternsLimit: 7 });
+      // Persists and returns updated user
       mockUserRepository.update.mockResolvedValue(updated);
 
       // Act
@@ -125,42 +139,6 @@ describe("UserService", () => {
       });
     });
 
-    it("fails when transactionPatternsLimit is below minimum", async () => {
-      const result = await service.updateSettings({
-        userId: faker.string.uuid(),
-        transactionPatternsLimit: MIN_TRANSACTION_PATTERNS_LIMIT - 1,
-      });
-
-      expect(result).toEqual({
-        success: false,
-        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
-      });
-    });
-
-    it("fails when transactionPatternsLimit is above maximum", async () => {
-      const result = await service.updateSettings({
-        userId: faker.string.uuid(),
-        transactionPatternsLimit: MAX_TRANSACTION_PATTERNS_LIMIT + 1,
-      });
-
-      expect(result).toEqual({
-        success: false,
-        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
-      });
-    });
-
-    it("fails when transactionPatternsLimit is not an integer", async () => {
-      const result = await service.updateSettings({
-        userId: faker.string.uuid(),
-        transactionPatternsLimit: 2.5,
-      });
-
-      expect(result).toEqual({
-        success: false,
-        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
-      });
-    });
-
     it("updates both fields at once", async () => {
       // Arrange
       const userId = faker.string.uuid();
@@ -169,6 +147,7 @@ describe("UserService", () => {
         transactionPatternsLimit: 5,
         voiceInputLanguage: "en-US",
       });
+      // Persists and returns updated user
       mockUserRepository.update.mockResolvedValue(updated);
 
       // Act
@@ -188,13 +167,63 @@ describe("UserService", () => {
       });
     });
 
-    it("fails when userId is empty", async () => {
+    // Validation failures
+
+    it("returns failure when userId is empty", async () => {
+      // Act
       const result = await service.updateSettings({
         userId: "",
         voiceInputLanguage: "en-US",
       });
 
+      // Assert
       expect(result).toEqual({ success: false, error: "User ID is required" });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when transactionPatternsLimit is below minimum", async () => {
+      // Act
+      const result = await service.updateSettings({
+        userId: faker.string.uuid(),
+        transactionPatternsLimit: MIN_TRANSACTION_PATTERNS_LIMIT - 1,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when transactionPatternsLimit is above maximum", async () => {
+      // Act
+      const result = await service.updateSettings({
+        userId: faker.string.uuid(),
+        transactionPatternsLimit: MAX_TRANSACTION_PATTERNS_LIMIT + 1,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("returns failure when transactionPatternsLimit is not an integer", async () => {
+      // Act
+      const result = await service.updateSettings({
+        userId: faker.string.uuid(),
+        transactionPatternsLimit: 2.5,
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: `Transaction patterns limit must be an integer between ${MIN_TRANSACTION_PATTERNS_LIMIT} and ${MAX_TRANSACTION_PATTERNS_LIMIT}`,
+      });
+      expect(mockUserRepository.update).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/services/user-service.test.ts
+++ b/backend/src/services/user-service.test.ts
@@ -44,6 +44,7 @@ describe("UserService", () => {
           voiceInputLanguage: "pl-PL",
         },
       });
+      expect(mockUserRepository.findOneById).toHaveBeenCalledWith(userId);
     });
 
     it("returns defaults when no settings are saved", async () => {
@@ -64,6 +65,7 @@ describe("UserService", () => {
           voiceInputLanguage: undefined,
         },
       });
+      expect(mockUserRepository.findOneById).toHaveBeenCalledWith(userId);
     });
 
     // Validation failures
@@ -79,14 +81,16 @@ describe("UserService", () => {
 
     it("returns failure when user is not found", async () => {
       // Arrange
+      const userId = faker.string.uuid();
       // Returns no user for given id
       mockUserRepository.findOneById.mockResolvedValue(null);
 
       // Act
-      const result = await service.getSettings(faker.string.uuid());
+      const result = await service.getSettings(userId);
 
       // Assert
       expect(result).toEqual({ success: false, error: "User not found" });
+      expect(mockUserRepository.findOneById).toHaveBeenCalledWith(userId);
     });
   });
 
@@ -137,6 +141,9 @@ describe("UserService", () => {
         success: true,
         data: { transactionPatternsLimit: 7, voiceInputLanguage: undefined },
       });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(userId, {
+        transactionPatternsLimit: 7,
+      });
     });
 
     it("updates both fields at once", async () => {
@@ -164,6 +171,10 @@ describe("UserService", () => {
           transactionPatternsLimit: 5,
           voiceInputLanguage: "en-US",
         },
+      });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(userId, {
+        transactionPatternsLimit: 5,
+        voiceInputLanguage: "en-US",
       });
     });
 


### PR DESCRIPTION
## Summary

Reviewed every backend test file against the testing skill rules and selected `services/user-service.test.ts` as the file with the most concerns. Fixes are scoped to that single file.

### Concerns addressed in `backend/src/services/user-service.test.ts`

1. **Missing section markers in `getSettings`** — added `// Happy path` and `// Validation failures` comments.
2. **Missing section markers in `updateSettings`** — added `// Happy path` and `// Validation failures` comments.
3. **Tests interleaved by category in `updateSettings`** — reordered so all happy-path tests precede all validation-failure tests; matches the source method's validation order (empty userId first, then `transactionPatternsLimit` checks).
4. **Missing `// Arrange / // Act / // Assert` markers** on five tests — added explicit sections (using `// Act` only when there is no setup).
5. **Missing one-line mock-setup comments** above every `mockResolvedValue` call — added short, article-free explanations of what each mock simulates.
6. **Test names used `"fails when ..."`** — renamed to `"returns failure when ..."` to match the skill's good example, since the service uses the Result pattern.

Also added `expect(mockUserRepository.update).not.toHaveBeenCalled()` / `findOneById.not.toHaveBeenCalled()` in validation-failure tests to verify dependencies are not invoked when validation rejects input.

### Other concerns surveyed (not fixed; out of scope per task)

- `langchain/tools/create-transaction-subagent.test.ts`, `langchain/agents/assistant-agent.test.ts`, `langchain/agents/create-transaction-agent.test.ts`: use `ReturnType<typeof fakeModel>` instead of an explicit `Mocked<...>` type.
- `migrations/operations/migrations-table.test.ts`: uses `beforeAll` for the DynamoDB client and lacks section markers; describe nesting goes 4 levels deep.
- `repositories/dyn-account-repository.test.ts`: trailing `describe("hydration - data corruption detection")` block does not mirror a source method.
- Several files (`account-loader`, `category-loader`, `graphql/resolvers/shared`, `providers/http-telegram-api-client`, `providers/lambda-background-job-dispatcher`, `langchain/utils`) are missing the three-group section comments.
- `types/date.test.ts` and `utils/email.test.ts`: have level-3 describe blocks holding fewer than 3 tests.

## Test plan

- [x] `npm test -- src/services/user-service.test.ts` — 11 passed
- [x] `npm run test:unit` — 562 passed; only `migrations-table.test.ts` fails because DynamoDB Local (Docker) is not available in this environment, unrelated to this change
- [x] `npm run typecheck` — clean
- [x] `npm run format` — clean

https://claude.ai/code/session_01S86szeSDze8VPnkZ2ubo7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01S86szeSDze8VPnkZ2ubo7K)_