### PR TITLE
docs(constitution): add Backend Error Hierarchy section

### DIFF
--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -319,6 +319,30 @@ graph LR
 
 **Rationale**: Use Result when the caller must handle the failure and make a decision; use exceptions for infrastructure panics the caller cannot recover from.
 
+### Backend Error Hierarchy
+
+**Non-negotiable rule**: Each architectural layer owns one error type. The GraphQL layer translates all layer errors into client-safe `GraphQLError` instances through a shared error handler.
+
+**Error types by layer**:
+
+| Error Class | Owned By | When to Throw |
+|---|---|---|
+| `ModelError` | Domain Model | Invariant violated during construction or state transition |
+| `BusinessError` | Service | Business rule violated (not found, duplicate, constraint) |
+| `RepositoryError` | Repository | Data access operation failed |
+
+**GraphQL error translation**:
+
+The shared `handleResolverError` helper in the GraphQL layer translates layer errors into client responses:
+
+- `BusinessError` and `ModelError` → `GraphQLError` with the original message (user-facing; safe to expose)
+- `RepositoryError` → `GraphQLError` with a generic message; full details logged server-side
+- Unknown errors → `GraphQLError` with a generic message; full details logged server-side
+
+Call `handleResolverError` in every resolver catch block to ensure consistent error mapping.
+
+**Rationale**: Each layer signals failures in its own vocabulary. The GraphQL boundary is the only place that decides whether an error message is safe to expose — it must never pass raw infrastructure error details to clients.
+
 ### Database Record Hydration
 
 **Non-negotiable rule**: All data read from the database MUST be validated at the repository boundary before being returned to service or resolver layers.


### PR DESCRIPTION
## Summary

- Documents the three-tier error ownership pattern: `ModelError` (domain models), `BusinessError` (services), `RepositoryError` (repositories)
- Documents the `handleResolverError` convention that translates layer errors to client-safe `GraphQLError` at the GraphQL boundary
- Clarifies which errors are user-facing (business/model) vs. logged internally (repository/unknown)

## Background

The codebase implements a clear error hierarchy that determines what information is safe to expose to API clients. This pattern was referenced in fragments across the constitution (`ModelError` in the domain entities section, `BusinessError` in the result pattern section) but never described as a unified architectural rule. Without it, a developer adding a new resolver would not know to call `handleResolverError`, and might accidentally expose raw infrastructure error details to clients.

## Test plan

- [ ] Review the new section for accuracy against `backend/src/graphql/resolvers/shared.ts` (the `handleResolverError` implementation)
- [ ] Review the new section for accuracy against `backend/src/models/model-error.ts`, `backend/src/services/business-error.ts`, `backend/src/ports/repository-error.ts`
- [ ] Confirm placement (after Result Pattern, before Database Record Hydration) reads naturally

https://claude.ai/code/session_011mfMN7oSTSjh8ud9eBpSTK

---
_Generated by [Claude Code](https://claude.ai/code/session_011mfMN7oSTSjh8ud9eBpSTK)_