### PR TITLE
docs: add GraphQL DataLoaders section to constitution

### DIFF
--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -252,6 +252,25 @@ graph LR
 
 **Rationale**: Balances performance with simplicity. Load-more pattern provides better mobile UX and stable navigation.
 
+### GraphQL DataLoaders
+
+**Non-negotiable rule**: Any resolver that loads a related entity by ID MUST use a DataLoader. Direct repository calls for per-item lookups inside list resolvers are forbidden.
+
+**Problem**: Without batching, resolving a list of N transactions where each transaction has an `account` field triggers N separate database round-trips — the classic N+1 problem.
+
+**Implementation**:
+
+- DataLoaders live in `src/graphql/dataloaders/`, one file per entity type (e.g. `account-loader.ts`)
+- Each DataLoader is instantiated fresh per GraphQL request and attached to `GraphQLContext` — never shared across requests
+- Resolvers call `context.<entity>Loader.load(id)` rather than accessing repositories directly
+- Each loader's batch function fetches all IDs in a single repository call and maps results back in input order
+- When an entity is missing (e.g. soft-deleted or orphaned), return a stub value with an `"Unknown"` display name rather than `null` — this preserves data resilience for historical records
+- Batch functions and loader factories are kept in separate named exports to allow unit-testing the batch logic independently of the DataLoader wrapper
+
+**Embedded Types**: Loaders project entities to a minimal embedded shape (e.g. `TransactionEmbeddedAccount`) defined in `src/graphql/embedded-types.ts` — never return the full domain entity from a loader.
+
+**Rationale**: Batching collapses N database round-trips into one per entity type per request. Per-request scoping ensures isolation between concurrent operations. Stub data prevents null-propagation errors in historical records that reference since-archived entities.
+
 ### Backend Service Layer
 
 **Non-negotiable rule**: Service classes follow one of two patterns based on complexity and purpose.


### PR DESCRIPTION
## Summary

- Identified that the DataLoader pattern is used throughout the codebase (`src/graphql/dataloaders/`) but entirely absent from `docs/constitution.md`
- Added a new **GraphQL DataLoaders** section after the existing GraphQL Pagination Strategy section
- The section establishes a non-negotiable rule: any resolver loading related entities by ID must use a DataLoader

## Why DataLoaders

Among several undocumented patterns (optimistic locking, dependency injection wiring, error hierarchy), the DataLoader pattern was chosen as the most impactful addition because:

1. **Silent correctness risk** — a developer adding a new entity with nested references would naturally reach for `context.someService.findById()` inside a resolver, creating N+1 queries with no warning
2. **Specific and actionable** — the rule is clear: use `context.<entity>Loader.load(id)`, not a direct repository call
3. **Has structural rules** — per-request scoping, stub data for missing entities, embedded types, and testable batch function exports are all enforced conventions that need documentation

## What the section covers

- The N+1 problem statement
- File location (`src/graphql/dataloaders/`)
- Per-request scoping requirement
- Stub data rule for missing/orphaned entities
- Embedded types (projections, not full domain entities)
- Separate batch function export for testability

https://claude.ai/code/session_018RXaSqVo4AtXCVoQe77gf7

---
_Generated by [Claude Code](https://claude.ai/code/session_018RXaSqVo4AtXCVoQe77gf7)_