### PR TITLE
align category-service.test.ts with testing skill standards

### DIFF
--- a/backend/src/services/category-service.test.ts
+++ b/backend/src/services/category-service.test.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type Mocked, beforeEach, describe, expect, it } from "vitest";
 import { CategoryType } from "../models/category";
+import { CategoryRepository } from "../ports/category-repository";
 import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { fakeCreateCategoryInput } from "../utils/test-utils/repositories/category-repository-fakes";
 import { createMockCategoryRepository } from "../utils/test-utils/repositories/category-repository-mocks";
@@ -12,63 +13,65 @@ import {
 } from "./category-service";
 
 describe("CategoryService", () => {
+  let mockCategoryRepository: Mocked<CategoryRepository>;
   let service: CategoryServiceImpl;
   let userId: string;
-  let mockCategoryRepository: ReturnType<typeof createMockCategoryRepository>;
 
   beforeEach(() => {
     mockCategoryRepository = createMockCategoryRepository();
     service = new CategoryServiceImpl(mockCategoryRepository);
     userId = faker.string.uuid();
 
-    // Default mocks for duplicate name checking (can be overridden in specific tests)
+    // Default: no existing categories for duplicate-name lookup
     mockCategoryRepository.findManyByUserId.mockResolvedValue([]);
-
-    // Reset all mocks
-    vi.clearAllMocks();
   });
 
   describe("getCategoriesByUser", () => {
-    it("calls findManyByUserId without type filter when no type provided", async () => {
+    // Happy path
+
+    it("returns categories when no type provided", async () => {
       // Arrange
-      const mockCategories = [fakeCategory(), fakeCategory()];
-      mockCategoryRepository.findManyByUserId.mockResolvedValue(mockCategories);
+      // Repository returns two categories
+      const categories = [fakeCategory(), fakeCategory()];
+      mockCategoryRepository.findManyByUserId.mockResolvedValue(categories);
 
       // Act
       const result = await service.getCategoriesByUser(userId);
 
       // Assert
+      expect(result).toEqual(categories);
       expect(mockCategoryRepository.findManyByUserId).toHaveBeenCalledWith(
         userId,
         { type: undefined },
       );
-      expect(mockCategoryRepository.findManyByUserId).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(mockCategories);
     });
 
-    it("calls findManyByUserId with type filter when type provided", async () => {
+    it("returns categories filtered by given type", async () => {
       // Arrange
       const type = CategoryType.INCOME;
-      const mockCategories = [fakeCategory(), fakeCategory()];
-      mockCategoryRepository.findManyByUserId.mockResolvedValue(mockCategories);
+      // Repository returns two income categories
+      const categories = [fakeCategory(), fakeCategory()];
+      mockCategoryRepository.findManyByUserId.mockResolvedValue(categories);
 
       // Act
       const result = await service.getCategoriesByUser(userId, type);
 
       // Assert
+      expect(result).toEqual(categories);
       expect(mockCategoryRepository.findManyByUserId).toHaveBeenCalledWith(
         userId,
         { type },
       );
-      expect(mockCategoryRepository.findManyByUserId).toHaveBeenCalledTimes(1);
-      expect(result).toEqual(mockCategories);
     });
   });
 
   describe("createCategory", () => {
+    // Happy path
+
     it("creates new category", async () => {
       // Arrange
       const input = fakeCreateCategoryInput();
+      // Persists and returns created category
       const createdCategory = fakeCategory();
       mockCategoryRepository.create.mockResolvedValue(createdCategory);
 
@@ -80,7 +83,7 @@ describe("CategoryService", () => {
       expect(mockCategoryRepository.create).toHaveBeenCalledWith(input);
     });
 
-    it("trims name", async () => {
+    it("trims name before persisting", async () => {
       // Arrange
       const input = fakeCreateCategoryInput({ name: "  Groceries  " });
 
@@ -89,19 +92,20 @@ describe("CategoryService", () => {
 
       // Assert
       expect(mockCategoryRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: "Groceries", // Trimmed
-        }),
+        expect.objectContaining({ name: "Groceries" }),
       );
     });
 
-    it("throws error when name is empty string", async () => {
+    // Validation failures
+
+    it("throws when name is empty", async () => {
       // Arrange
       const input = fakeCreateCategoryInput({ name: "" });
 
-      // Act & Assert
+      // Act
       const promise = service.createCategory(input);
 
+      // Assert
       await expect(promise).rejects.toThrow(BusinessError);
       await expect(promise).rejects.toMatchObject({
         message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
@@ -109,13 +113,14 @@ describe("CategoryService", () => {
       expect(mockCategoryRepository.create).not.toHaveBeenCalled();
     });
 
-    it("throws error when name is only whitespace", async () => {
+    it("throws when name is only whitespace", async () => {
       // Arrange
       const input = fakeCreateCategoryInput({ name: "   " });
 
-      // Act & Assert
+      // Act
       const promise = service.createCategory(input);
 
+      // Assert
       await expect(promise).rejects.toThrow(BusinessError);
       await expect(promise).rejects.toMatchObject({
         message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
@@ -123,15 +128,16 @@ describe("CategoryService", () => {
       expect(mockCategoryRepository.create).not.toHaveBeenCalled();
     });
 
-    it("throws error when name exceeds maximum length", async () => {
+    it("throws when name exceeds maximum length", async () => {
       // Arrange
       const input = fakeCreateCategoryInput({
         name: "a".repeat(NAME_MAX_LENGTH + 1),
       });
 
-      // Act & Assert
+      // Act
       const promise = service.createCategory(input);
 
+      // Assert
       await expect(promise).rejects.toThrow(BusinessError);
       await expect(promise).rejects.toMatchObject({
         message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
@@ -139,22 +145,18 @@ describe("CategoryService", () => {
       expect(mockCategoryRepository.create).not.toHaveBeenCalled();
     });
 
-    it("throws error when category name already exists", async () => {
+    it("throws when name matches existing category case-insensitively", async () => {
       // Arrange
+      // Existing category uses same name in different casing
       mockCategoryRepository.findManyByUserId.mockResolvedValue([
-        fakeCategory({
-          userId,
-          name: "GROCERIES",
-        }),
+        fakeCategory({ userId, name: "GROCERIES" }),
       ]);
-      const input = fakeCreateCategoryInput({
-        userId,
-        name: "groceries", // Different casing
-      });
+      const input = fakeCreateCategoryInput({ userId, name: "groceries" });
 
-      // Act & Assert
+      // Act
       const promise = service.createCategory(input);
 
+      // Assert
       await expect(promise).rejects.toThrow(BusinessError);
       await expect(promise).rejects.toMatchObject({
         message: 'Category "groceries" already exists',
@@ -164,10 +166,13 @@ describe("CategoryService", () => {
   });
 
   describe("updateCategory", () => {
+    // Happy path
+
     it("updates category", async () => {
       // Arrange
       const categoryId = faker.string.uuid();
       const input = { name: "Updated Category Name" };
+      // Persists and returns updated category
       const updatedCategory = fakeCategory();
       mockCategoryRepository.update.mockResolvedValue(updatedCategory);
 
@@ -182,10 +187,9 @@ describe("CategoryService", () => {
       );
     });
 
-    it("trims name", async () => {
+    it("trims name before persisting", async () => {
       // Arrange
       const categoryId = faker.string.uuid();
-
       const input = { name: "  Groceries  " };
 
       // Act
@@ -194,93 +198,20 @@ describe("CategoryService", () => {
       // Assert
       expect(mockCategoryRepository.update).toHaveBeenCalledWith(
         { id: categoryId, userId },
-        { name: "Groceries" }, // Trimmed
+        { name: "Groceries" },
       );
     });
 
-    it("throws error when name is empty string", async () => {
-      // Arrange
-      const categoryId = faker.string.uuid();
-      const input = { name: "" };
-
-      // Act & Assert
-      const promise = service.updateCategory(categoryId, userId, input);
-
-      await expect(promise).rejects.toThrow(BusinessError);
-      await expect(promise).rejects.toMatchObject({
-        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
-      });
-      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
-    });
-
-    it("throws error when name is only whitespace", async () => {
-      // Arrange
-      const categoryId = faker.string.uuid();
-      const input = { name: "   " };
-
-      // Act & Assert
-      const promise = service.updateCategory(categoryId, userId, input);
-
-      await expect(promise).rejects.toThrow(BusinessError);
-      await expect(promise).rejects.toMatchObject({
-        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
-      });
-      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
-    });
-
-    it("throws error when name exceeds maximum length", async () => {
-      // Arrange
-      const categoryId = faker.string.uuid();
-      const input = { name: "a".repeat(NAME_MAX_LENGTH + 1) };
-
-      // Act & Assert
-      const promise = service.updateCategory(categoryId, userId, input);
-
-      await expect(promise).rejects.toThrow(BusinessError);
-      await expect(promise).rejects.toMatchObject({
-        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
-      });
-      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
-    });
-
-    it("throws error when updated name already exists", async () => {
+    it("allows keeping same name", async () => {
       // Arrange
       const categoryId = faker.string.uuid();
       const currentCategory = fakeCategory({
         id: categoryId,
-        userId,
-      });
-      const anotherExistingCategory = fakeCategory({
         userId,
         name: "Groceries",
       });
       const input = { name: "Groceries" };
-
-      mockCategoryRepository.findManyByUserId.mockResolvedValue([
-        currentCategory,
-        anotherExistingCategory,
-      ]);
-
-      // Act & Assert
-      const promise = service.updateCategory(categoryId, userId, input);
-
-      await expect(promise).rejects.toThrow(BusinessError);
-      await expect(promise).rejects.toMatchObject({
-        message: 'Category "Groceries" already exists',
-      });
-      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
-    });
-
-    it("allows keeping same name when updating", async () => {
-      // Arrange
-      const categoryId = faker.string.uuid();
-      const currentCategory = fakeCategory({
-        id: categoryId,
-        userId,
-        name: "Groceries",
-      });
-      const input = { name: "Groceries" }; // Same name
-
+      // Existing categories include target itself and one unrelated
       mockCategoryRepository.findManyByUserId.mockResolvedValue([
         currentCategory,
         fakeCategory({ userId }),
@@ -295,12 +226,88 @@ describe("CategoryService", () => {
         input,
       );
     });
+
+    // Validation failures
+
+    it("throws when name is empty", async () => {
+      // Arrange
+      const categoryId = faker.string.uuid();
+      const input = { name: "" };
+
+      // Act
+      const promise = service.updateCategory(categoryId, userId, input);
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
+      });
+      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("throws when name is only whitespace", async () => {
+      // Arrange
+      const categoryId = faker.string.uuid();
+      const input = { name: "   " };
+
+      // Act
+      const promise = service.updateCategory(categoryId, userId, input);
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
+      });
+      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("throws when name exceeds maximum length", async () => {
+      // Arrange
+      const categoryId = faker.string.uuid();
+      const input = { name: "a".repeat(NAME_MAX_LENGTH + 1) };
+
+      // Act
+      const promise = service.updateCategory(categoryId, userId, input);
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: `Category name must be between ${NAME_MIN_LENGTH} and ${NAME_MAX_LENGTH} characters`,
+      });
+      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("throws when updated name already exists", async () => {
+      // Arrange
+      const categoryId = faker.string.uuid();
+      const currentCategory = fakeCategory({ id: categoryId, userId });
+      const otherCategory = fakeCategory({ userId, name: "Groceries" });
+      const input = { name: "Groceries" };
+      // Another category already uses target name
+      mockCategoryRepository.findManyByUserId.mockResolvedValue([
+        currentCategory,
+        otherCategory,
+      ]);
+
+      // Act
+      const promise = service.updateCategory(categoryId, userId, input);
+
+      // Assert
+      await expect(promise).rejects.toThrow(BusinessError);
+      await expect(promise).rejects.toMatchObject({
+        message: 'Category "Groceries" already exists',
+      });
+      expect(mockCategoryRepository.update).not.toHaveBeenCalled();
+    });
   });
 
   describe("deleteCategory", () => {
+    // Happy path
+
     it("archives category", async () => {
       // Arrange
       const categoryId = faker.string.uuid();
+      // Persists and returns archived category
       const archivedCategory = fakeCategory();
       mockCategoryRepository.archive.mockResolvedValue(archivedCategory);
 


### PR DESCRIPTION
## Summary

Reviewed all 57 backend test files against the testing skill standards. `category-service.test.ts` had the most concerns (17), so this PR aligns it with the standards while leaving all other test files untouched.

## Changes

- Type `mockCategoryRepository` as `Mocked<CategoryRepository>` instead of `ReturnType<typeof createMockCategoryRepository>` to match the standard mock-typing rule.
- Rename `getCategoriesByUser` tests so they describe behavior (`"returns categories when no type provided"`, `"returns categories filtered by given type"`) rather than the underlying repository call.
- Add `// Happy path` and `// Validation failures` section comments to every method describe.
- Assert return value before dependency calls (was reversed in `getCategoriesByUser`).
- Split `// Act & Assert` into separate `// Act` and `// Assert` sections for the multi-line validation tests.
- Reorder `updateCategory` tests so all happy-path cases (including "allows keeping same name") come before validation failures.
- Drop redundant `vi.clearAllMocks()` after fresh mock creation.
- Add short Arrange comments above mock setups explaining what each mock simulates.

## Test plan

- [x] `npm test -- src/services/category-service.test.ts` — 16 tests pass
- [x] `npm run typecheck` — no errors
- [x] `npm run format` — no lint errors
- [x] Full unit suite (`--project unit`) — 562 pass; pre-existing `migrations-table.test.ts` failure requires DynamoDB Local and is unrelated

https://claude.ai/code/session_01Hx32TuPQ4SdQQRhXqFADLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hx32TuPQ4SdQQRhXqFADLT)_