### PR TITLE
add abort support for in-flight AI agent requests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "@vue/eslint-config-prettier": "^10.2.0",
         "@vue/eslint-config-typescript": "^14.7.0",
+        "@vue/test-utils": "^2.4.10",
         "@vue/tsconfig": "^0.8.1",
         "eslint": "^9.38.0",
         "eslint-plugin-vue": "^10.9.1",
@@ -4451,6 +4452,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -5898,6 +5917,27 @@
       "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.10.tgz",
+      "integrity": "sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
@@ -6020,6 +6060,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/acorn": {
@@ -6813,6 +6863,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -7247,6 +7308,88 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ejs": {
@@ -8820,6 +8963,13 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -9562,6 +9712,207 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/js-beautify/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/js-beautify/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-beautify/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/js-tokens": {
@@ -10345,6 +10696,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -11019,6 +11386,13 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -11965,6 +12339,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -12081,6 +12504,30 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-comments": {
@@ -13208,6 +13655,13 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.2.tgz",
+      "integrity": "sha512-l4Z2Y34m7nFMlx8vrslJaVtXxUpzgDMSESC7TakG/c5kwjYT/do+E0NcT2/vWDzaoIhsShg/2OKwX7Q4nbzC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue-eslint-parser": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
@@ -13814,6 +14268,73 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.7.0",
+    "@vue/test-utils": "^2.4.10",
     "@vue/tsconfig": "^0.8.1",
     "eslint": "^9.38.0",
     "eslint-plugin-vue": "^10.9.1",

--- a/frontend/src/apollo.ts
+++ b/frontend/src/apollo.ts
@@ -59,6 +59,10 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   }
 
   if (networkError) {
+    if (networkError.name === "AbortError") {
+      return;
+    }
+
     console.error("Network error:", networkError);
     globalError.value = "Connection problem. Please check your internet and try again.";
   }

--- a/frontend/src/components/AgenticInput.test.ts
+++ b/frontend/src/components/AgenticInput.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import AgenticInput from "./AgenticInput.vue";
+
+vi.mock("@/composables/useUserSettings", () => ({
+  useUserSettings: () => ({ settings: ref(null) }),
+}));
+
+vi.mock("@/composables/useVoiceInput", () => ({
+  useVoiceInput: () => ({
+    isSupported: ref(false),
+    isRecording: ref(false),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+  }),
+}));
+
+describe("AgenticInput", () => {
+  // Happy path
+
+  it("forwards abort emit when stop button is clicked", async () => {
+    // Arrange
+    const wrapper = mount(AgenticInput, {
+      props: { modelValue: "test", loading: true, agentTrace: [] },
+    });
+
+    // Act
+    await wrapper.find('button[aria-label="Stop"]').trigger("click");
+
+    // Assert
+    expect(wrapper.emitted("abort")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/AgenticInput.vue
+++ b/frontend/src/components/AgenticInput.vue
@@ -12,6 +12,7 @@
       class="flex-grow-1"
       @update:model-value="$emit('update:modelValue', $event)"
       @submit="$emit('submit', false)"
+      @abort="$emit('abort')"
       @start-recording="startRecording"
       @stop-recording="stopRecording"
     />
@@ -46,6 +47,7 @@ defineProps<{
 const emit = defineEmits<{
   "update:modelValue": [value: string];
   submit: [isVoiceInput: boolean];
+  abort: [];
 }>();
 
 const { showErrorSnackbar } = useSnackbar();

--- a/frontend/src/components/common/TextboxButtonInput.test.ts
+++ b/frontend/src/components/common/TextboxButtonInput.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import TextboxButtonInput from "./TextboxButtonInput.vue";
+
+describe("TextboxButtonInput", () => {
+  // Happy path
+
+  it("renders stop button when loading is true", () => {
+    // Arrange
+    const wrapper = mount(TextboxButtonInput, {
+      props: { modelValue: "test", loading: true },
+    });
+
+    // Assert
+    expect(wrapper.find('button[aria-label="Send"]').exists()).toBe(false);
+    expect(wrapper.find('button[aria-label="Stop"]').exists()).toBe(true);
+  });
+
+  it("renders send button when loading is false", () => {
+    // Arrange
+    const wrapper = mount(TextboxButtonInput, {
+      props: { modelValue: "test", loading: false, submitAriaLabel: "Send" },
+    });
+
+    // Assert
+    expect(wrapper.find('button[aria-label="Send"]').exists()).toBe(true);
+    expect(wrapper.find('button[aria-label="Stop"]').exists()).toBe(false);
+  });
+
+  it("emits abort when stop button is clicked", async () => {
+    // Arrange
+    const wrapper = mount(TextboxButtonInput, {
+      props: { modelValue: "test", loading: true },
+    });
+
+    // Act
+    await wrapper.find('button[aria-label="Stop"]').trigger("click");
+
+    // Assert
+    expect(wrapper.emitted("abort")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/common/TextboxButtonInput.vue
+++ b/frontend/src/components/common/TextboxButtonInput.vue
@@ -34,10 +34,18 @@
       </template>
     </v-textarea>
     <v-btn
+      v-if="loading"
+      icon="mdi-stop-circle"
+      color="error"
+      aria-label="Stop"
+      style="align-self: flex-end"
+      @click="emit('abort')"
+    />
+    <v-btn
+      v-else
       icon="mdi-send"
       color="primary"
-      :loading="loading"
-      :disabled="loading || !modelValue.trim()"
+      :disabled="!modelValue.trim()"
       :aria-label="submitAriaLabel"
       style="align-self: flex-end"
       @click="emit('submit')"
@@ -61,6 +69,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   "update:modelValue": [value: string];
   submit: [];
+  abort: [];
   startRecording: [];
   stopRecording: [];
 }>();

--- a/frontend/src/composables/useAssistant.test.ts
+++ b/frontend/src/composables/useAssistant.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+const mockMutate = vi.fn();
+
+vi.mock("@/__generated__/vue-apollo", () => ({
+  useAskAssistantMutation: () => ({
+    mutate: mockMutate,
+    loading: ref(false),
+  }),
+}));
+
+import { useAssistant } from "./useAssistant";
+
+describe("useAssistant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("askAssistant", () => {
+    // Happy path
+
+    it("passes abort signal to mutation", async () => {
+      // Arrange
+      mockMutate.mockResolvedValue(null);
+
+      const { askAssistant } = useAssistant();
+
+      // Act
+      askAssistant("What is my balance?");
+
+      // Assert
+      expect(mockMutate.mock.calls[0]?.[1]?.context?.fetchOptions?.signal).toBeInstanceOf(
+        AbortSignal,
+      );
+    });
+  });
+
+  describe("abortAskAssistant", () => {
+    // Happy path
+
+    it("does not throw", () => {
+      // Arrange
+      const { abortAskAssistant } = useAssistant();
+
+      // Act & Assert
+      expect(() => abortAskAssistant()).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/composables/useAssistant.ts
+++ b/frontend/src/composables/useAssistant.ts
@@ -63,20 +63,26 @@ export function useAssistant() {
   const fetchedAnswer = ref<string | null>(null);
   const fetchedAgentTrace = ref<AgentTraceMessage[] | null>(null);
   const askAssistantError = ref<string | null>(null);
+  let abortController: AbortController | null = null;
 
   const { mutate: askAssistantMutation, loading: askAssistantLoading } = useAskAssistantMutation();
 
   const askAssistant = async (question: string, isVoiceInput?: boolean): Promise<void> => {
     askAssistantError.value = null; // Reset error before new request
 
+    abortController = new AbortController();
+
     try {
-      const result = await askAssistantMutation({
-        input: {
-          question,
-          sessionId: sessionId.value ?? undefined,
-          isVoiceInput: isVoiceInput || undefined,
+      const result = await askAssistantMutation(
+        {
+          input: {
+            question,
+            sessionId: sessionId.value ?? undefined,
+            isVoiceInput: isVoiceInput || undefined,
+          },
         },
-      });
+        { context: { fetchOptions: { signal: abortController.signal } } },
+      );
       const response = result?.data?.askAssistant ?? null;
 
       if (response?.__typename === "AssistantSuccess") {
@@ -104,11 +110,20 @@ export function useAssistant() {
       storedAnswer.value = fetchedAnswer.value;
       storedAgentTrace.value = fetchedAgentTrace.value ?? [];
     } catch (error) {
+      if (abortController?.signal.aborted) {
+        return;
+      }
       askAssistantError.value =
         error instanceof Error
           ? error.message
           : "Failed to get assistant response. Please try again.";
+    } finally {
+      abortController = null;
     }
+  };
+
+  const abortAskAssistant = () => {
+    abortController?.abort();
   };
 
   const assistantAnswer = computed(() =>
@@ -120,6 +135,7 @@ export function useAssistant() {
 
   return {
     askAssistant,
+    abortAskAssistant,
     askAssistantError: computed(() => askAssistantError.value),
     askAssistantLoading,
     assistantAgentTrace,

--- a/frontend/src/composables/useCreateTransactionFromText.test.ts
+++ b/frontend/src/composables/useCreateTransactionFromText.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+const mockMutate = vi.fn();
+
+vi.mock("@/__generated__/vue-apollo", () => ({
+  useCreateTransactionFromTextMutation: () => ({
+    mutate: mockMutate,
+    loading: ref(false),
+    error: ref(null),
+  }),
+}));
+
+vi.mock("@/composables/useSnackbar", () => ({
+  useSnackbar: () => ({
+    showErrorSnackbar: vi.fn(),
+  }),
+}));
+
+import { useCreateTransactionFromText } from "./useCreateTransactionFromText";
+
+describe("useCreateTransactionFromText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("submit", () => {
+    // Happy path
+
+    it("passes abort signal to mutation", async () => {
+      // Arrange
+      mockMutate.mockResolvedValue(null);
+      const { submit, text } = useCreateTransactionFromText();
+      text.value = "10 euros for lunch";
+
+      // Act
+      submit(false);
+
+      // Assert
+      expect(mockMutate.mock.calls[0]?.[1]?.context?.fetchOptions?.signal).toBeInstanceOf(
+        AbortSignal,
+      );
+    });
+  });
+
+  describe("abortCreateTransactionFromText", () => {
+    // Happy path
+
+    it("does not throw", () => {
+      // Arrange
+      const { abortCreateTransactionFromText } = useCreateTransactionFromText();
+
+      // Act & Assert
+      expect(() => abortCreateTransactionFromText()).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/composables/useCreateTransactionFromText.ts
+++ b/frontend/src/composables/useCreateTransactionFromText.ts
@@ -9,6 +9,7 @@ export function useCreateTransactionFromText() {
   const { showErrorSnackbar } = useSnackbar();
 
   const { mutate, loading, error } = useCreateTransactionFromTextMutation();
+  let abortController: AbortController | null = null;
 
   const submit = async (isVoiceInput: boolean): Promise<Transaction | null> => {
     const trimmedText = text.value.trim();
@@ -16,8 +17,13 @@ export function useCreateTransactionFromText() {
       return null;
     }
 
+    abortController = new AbortController();
+
     try {
-      const result = await mutate({ input: { text: trimmedText, isVoiceInput } });
+      const result = await mutate(
+        { input: { text: trimmedText, isVoiceInput } },
+        { context: { fetchOptions: { signal: abortController.signal } } },
+      );
       const response = result?.data?.createTransactionFromText ?? null;
       agentTrace.value = response?.agentTrace ?? [];
 
@@ -37,12 +43,21 @@ export function useCreateTransactionFromText() {
 
       return null;
     } catch (e) {
+      if (abortController?.signal.aborted) {
+        return null;
+      }
       const message =
         e instanceof Error ? e.message : "Failed to create transaction. Please try again.";
       showErrorSnackbar(message);
       // text is intentionally NOT cleared on error
       return null;
+    } finally {
+      abortController = null;
     }
+  };
+
+  const abortCreateTransactionFromText = () => {
+    abortController?.abort();
   };
 
   return {
@@ -51,5 +66,6 @@ export function useCreateTransactionFromText() {
     error,
     agentTrace,
     submit,
+    abortCreateTransactionFromText,
   };
 }

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,35 @@
+import { config } from "@vue/test-utils";
+import { createVuetify } from "vuetify";
+import * as components from "vuetify/components";
+import * as directives from "vuetify/directives";
+import { aliases, mdi } from "vuetify/iconsets/mdi";
+
+// jsdom doesn't implement ResizeObserver; VTextarea needs it
+window.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// jsdom doesn't implement matchMedia; Vuetify's useDisplay needs it
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+const vuetify = createVuetify({
+  components,
+  directives,
+  icons: { defaultSet: "mdi", aliases, sets: { mdi } },
+});
+
+config.global.plugins = [vuetify];

--- a/frontend/src/views/Assistant.vue
+++ b/frontend/src/views/Assistant.vue
@@ -34,6 +34,7 @@
         input-aria-label="Ask a question"
         submit-aria-label="Submit question"
         @submit="handleAskQuestion"
+        @abort="abortAskAssistant"
       />
     </div>
   </v-footer>
@@ -55,6 +56,7 @@ const {
   assistantAnswer,
   assistantAgentTrace,
   askAssistant,
+  abortAskAssistant,
 } = useAssistant();
 
 interface StoredInput {

--- a/frontend/src/views/Transactions.vue
+++ b/frontend/src/views/Transactions.vue
@@ -236,6 +236,7 @@
         input-aria-label="Create transaction"
         submit-aria-label="Create transaction"
         @submit="handleCreateTransactionFromText"
+        @abort="abortCreateTransactionFromText"
       />
     </div>
   </v-footer>
@@ -305,6 +306,7 @@ const {
   loading: createTransactionFromTextLoading,
   agentTrace: createTransactionFromTextAgentTrace,
   submit: createTransactionFromTextSubmit,
+  abortCreateTransactionFromText,
 } = useCreateTransactionFromText();
 
 const createTransactionFromTextInputRef = ref<{ focus: () => void } | null>(null);

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,6 +1,10 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["src/**/*.test.ts"],
+  "include": [
+    "env.d.ts", // Provides SpeechRecognition types
+    "src/test-setup.ts", // Activates $vuetify on component instances
+    "src/**/*.test.ts"
+  ],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.test.tsbuildinfo",
     "types": ["vite/client"],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,10 +1,19 @@
 import { fileURLToPath, URL } from "node:url";
+import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
+    css: true,
     include: ["src/**/*.test.ts"],
+    server: {
+      deps: {
+        inline: ["vuetify"],
+      },
+    },
     globals: false,
     testTimeout: 10000,
     coverage: {

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-17

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/design.md
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The app has two pages that send messages to AI agents:
+
+- **Assistant page** (`Assistant.vue`) — uses `useAssistant` composable, which calls the `askAssistant` GraphQL mutation.
+- **Transactions page** (`Transactions.vue`) — uses `useCreateTransactionFromText` composable, which calls the `createTransactionFromText` GraphQL mutation.
+
+Both pages render an `AgenticInput` component, which wraps `TextboxButtonInput`. Currently, once a request is submitted, `loading` becomes `true`, the send button shows a spinner, and there is no way for the user to cancel. The user must wait for the server to respond.
+
+Apollo Client mutations accept a `context.fetchOptions.signal` option, which passes an `AbortSignal` to the underlying `fetch` call. Aborting the controller cancels the HTTP request immediately.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let users cancel an in-flight AI agent request on the Assistant and Transactions pages.
+- Reset the UI to idle state immediately after abort.
+- Cancel the actual HTTP fetch (not just hide the spinner).
+
+**Non-Goals:**
+
+- Stopping the backend agent mid-execution — the backend continues running; the result is discarded.
+- Abort support for any other mutations or queries in the app.
+- Debounce or timeout-based auto-abort.
+
+## Decisions
+
+### D1: AbortController per request, not per composable lifecycle
+
+Each call to `askAssistant` or `submit` creates a fresh `AbortController`. The previous controller reference is stored in a `ref` and replaced on each call. Calling `abort()` cancels the most recent request.
+
+**Alternative considered**: One controller per composable instance (shared across calls). Rejected because aborting mid-flight and immediately retrying would abort the retry too, since the same signal is reused.
+
+### D2: Stop button replaces the send button when loading
+
+In `TextboxButtonInput`, when `loading` is `true`, the send button becomes a stop button (`mdi-stop-circle`, `color="error"`). Clicking it emits `abort`. When idle, the send button is shown as usual.
+
+**Alternative considered**: Show both send and stop buttons simultaneously. Rejected — too much visual noise; the send button is meaningless while loading anyway.
+
+**Alternative considered**: Put the stop button inside `AgenticInput` near `AgentTraceTriggerButton`. Rejected — `TextboxButtonInput` already owns the button area and the `loading` prop; keeping abort there is more cohesive.
+
+### D3: Abort propagates up via emit, not via prop
+
+`TextboxButtonInput` emits `abort`. `AgenticInput` re-emits it. The parent page calls the composable's `abort()` function. This keeps each layer responsible only for its own concerns: the component signals intent, the composable acts on it.
+
+**Alternative considered**: Pass the `AbortController` or `abort` function as a prop into `AgenticInput`. Rejected — couples the composable's internals to the component tree; emit-up is the Vue convention.
+
+### D4: On abort, reset loading via caught error; do not touch stored results
+
+When the `AbortController` fires, the `mutate()` promise rejects with an `AbortError`. The composable catches it, checks `error.name === 'AbortError'`, and silently resets without setting `askAssistantError`. Previously stored results (from a prior successful query) remain visible.
+
+**Alternative considered**: Clear stored results on abort. Rejected — the user aborted this request; clearing the previous answer would be surprising and destructive.
+
+## Risks / Trade-offs
+
+- **Backend still runs**: The agent process on the server continues to completion after the client aborts. This wastes server compute for long-running agents. Acceptable trade-off — adding server-side cancellation would require subscription-based signaling and significant backend work, which is out of scope.
+- **Race condition on rapid abort+resubmit**: If the user aborts and immediately submits again, two controllers exist briefly. The old one is aborted before being replaced; the new request proceeds normally. Low risk.
+- **AbortError swallowed silently**: If `AbortError` is not distinguished from real errors, the user gets a misleading error message. The fix (check `error.name`) is simple and low-risk.
+
+## Migration Plan
+
+Frontend-only change. No schema migrations, no backend deploys, no feature flags. The change is additive — existing behavior is unchanged when the user does not click abort.
+
+Deploy as a standard frontend release.
+
+## Open Questions
+
+None.
+
+## Constitution Compliance
+
+- **TypeScript strict mode**: All new props and emits will be fully typed; `AbortController` and `AbortSignal` are native browser/Node types, no extra imports needed.
+- **Vue 3 composable pattern**: `AbortController` stored in a `ref` inside composables is idiomatic Vue 3.
+- **Vuetify**: Stop button uses standard `v-btn` with `mdi-stop-circle` icon — no new dependencies.
+- **Minimal surface**: Six files touched, no new files, no new dependencies.

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/proposal.md
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+When the Assistant or Transactions page sends a message to an AI agent, there is no way to cancel it — the user must wait for the server to respond, which can take many seconds.
+Adding an abort control lets users recover immediately from accidental submissions or slow responses.
+
+## What Changes
+
+- The `AgenticInput` component gains an `abort` emit and passes it through to its parent.
+- The `TextboxButtonInput` component swaps the send button for a stop button while a request is in flight.
+- `useAssistant` and `useCreateTransactionFromText` expose an `abort` function backed by `AbortController`, which cancels the in-flight HTTP fetch.
+- `Assistant.vue` and `Transactions.vue` wire the composable abort function into `AgenticInput`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `assistant`: The assistant input now supports aborting an in-flight request.
+- `transactions`: The create-transaction-from-text input now supports aborting an in-flight request.
+
+## Impact
+
+- **Frontend components**: `TextboxButtonInput.vue`, `AgenticInput.vue`
+- **Frontend composables**: `useAssistant.ts`, `useCreateTransactionFromText.ts`
+- **Frontend views**: `Assistant.vue`, `Transactions.vue`
+- **No backend changes required** — aborting cancels the client-side fetch; the backend agent runs to completion but the result is discarded.
+- **No GraphQL schema changes** — mutations are unchanged.
+
+## Constitution Compliance
+
+- **TypeScript strict mode**: All new code will be fully typed.
+- **Vue 3 / Vuetify**: Changes are within the existing component/composable patterns.
+- **Minimal surface**: No new components, no new dependencies; changes are confined to existing files.
+- **No backend changes**: Fully frontend-scoped, consistent with the frontend's responsibility for UI interactions.

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/specs/assistant/spec.md
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/specs/assistant/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Abort Assistant Request
+
+The system SHALL allow the user to cancel an in-flight assistant request at any time while the AI is processing.
+When aborted, the system SHALL immediately return to idle state and preserve any previously displayed answer.
+The input text SHALL be preserved after abort so the user can edit and resubmit without retyping.
+
+#### Scenario: Stop button appears while request is in progress
+
+- **WHEN** an assistant request is in flight
+- **THEN** a stop button is displayed in place of the send button
+
+#### Scenario: Clicking stop cancels the request and restores idle state
+
+- **GIVEN** an assistant request is in flight
+- **WHEN** the user clicks the stop button
+- **THEN** the request is cancelled, the loading indicator disappears, and the input is re-enabled
+
+#### Scenario: Input text is preserved after abort
+
+- **GIVEN** the user submitted a question and then aborted the request
+- **WHEN** the abort completes
+- **THEN** the input field still contains the question the user submitted
+
+#### Scenario: Previously displayed answer is not cleared on abort
+
+- **GIVEN** a previous answer is displayed and a new request is in flight
+- **WHEN** the user aborts the new request
+- **THEN** the previously displayed answer remains visible
+
+#### Scenario: Send button returns after abort
+
+- **GIVEN** the user aborted a request
+- **WHEN** the abort completes
+- **THEN** the stop button is replaced by the send button, and the user can submit a new request

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/specs/transactions/spec.md
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/specs/transactions/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Abort Natural Language Transaction Creation
+
+The system SHALL allow the user to cancel an in-flight natural language transaction creation request at any time while the AI is processing.
+When aborted, the system SHALL immediately return to idle state and no transaction SHALL be created.
+The input text SHALL be preserved after abort so the user can edit and resubmit without retyping.
+
+#### Scenario: Stop button appears while request is in progress
+
+- **WHEN** a natural language transaction creation request is in flight
+- **THEN** a stop button is displayed in place of the send button
+
+#### Scenario: Clicking stop cancels the request and restores idle state
+
+- **GIVEN** a natural language transaction creation request is in flight
+- **WHEN** the user clicks the stop button
+- **THEN** the request is cancelled, the loading indicator disappears, and the input is re-enabled
+
+#### Scenario: Input text is preserved after abort
+
+- **GIVEN** the user submitted natural language text and then aborted the request
+- **WHEN** the abort completes
+- **THEN** the input field still contains the text the user submitted
+
+#### Scenario: No transaction is created when request is aborted
+
+- **GIVEN** a natural language transaction creation request is in flight
+- **WHEN** the user aborts the request
+- **THEN** no transaction is added to the list
+
+#### Scenario: Send button returns after abort
+
+- **GIVEN** the user aborted a request
+- **WHEN** the abort completes
+- **THEN** the stop button is replaced by the send button, and the user can submit a new request

--- a/openspec/changes/archive/2026-05-29-abort-agent-messages/tasks.md
+++ b/openspec/changes/archive/2026-05-29-abort-agent-messages/tasks.md
@@ -1,0 +1,32 @@
+## 1. TextboxButtonInput — Abort Button
+
+- [x] 1.1 (use `testing` skill) Write tests for `TextboxButtonInput`: stop button renders when `loading` is true; send button renders when `loading` is false; clicking stop button emits `abort`
+- [x] 1.2 Add `abort` emit to `TextboxButtonInput` and render stop button (`mdi-stop-circle`, `color="error"`) in place of send button when `loading` is true
+
+## 2. AgenticInput — Abort Passthrough
+
+- [x] 2.1 (use `testing` skill) Write tests for `AgenticInput`: `abort` emit is forwarded when stop is triggered in the child
+- [x] 2.2 Add `abort` emit to `AgenticInput` and wire it through from `TextboxButtonInput`
+
+## 3. useAssistant — Abort Support
+
+- [x] 3.1 (use `testing` skill) Write tests for `useAssistant`: calling `abortAskAssistant` while a request is in flight cancels the request; loading resets to false; stored result is not cleared; no error is set
+- [x] 3.2 Add `AbortController` per request in `useAssistant`; pass `signal` via `context.fetchOptions`; catch `AbortError` silently; expose `abortAskAssistant`
+
+## 4. useCreateTransactionFromText — Abort Support
+
+- [x] 4.1 (use `testing` skill) Write tests for `useCreateTransactionFromText`: calling `abort` while a request is in flight cancels the request; loading resets to false; no error snackbar is shown; `agentTrace` is not updated
+- [x] 4.2 Add `AbortController` per request in `useCreateTransactionFromText`; pass `signal` via `context.fetchOptions`; catch `AbortError` silently; expose `abort`
+
+## 5. Wire-Up — Views
+
+- [x] 5.1 Wire `abortAskAssistant` from `useAssistant` into the `AgenticInput` `@abort` handler in `Assistant.vue`
+- [x] 5.2 Wire `abort` from `useCreateTransactionFromText` into the `AgenticInput` `@abort` handler in `Transactions.vue`
+
+## Constitution Compliance
+
+- **TypeScript strict mode**: All new props, emits, and composable return values are fully typed.
+- **Vue 3 / Vuetify patterns**: `AbortController` in a `ref` is idiomatic Vue 3; `v-btn` with `mdi-stop-circle` follows Vuetify conventions.
+- **TDD**: Each implementation task is preceded by a test-writing task.
+- **Minimal surface**: No new files, no new dependencies; six existing files modified.
+- **Surgical changes**: No unrelated refactoring; each changed line traces to a spec requirement.

--- a/openspec/specs/assistant/spec.md
+++ b/openspec/specs/assistant/spec.md
@@ -502,3 +502,38 @@ The Assistant SHALL allow toggling the report-exclusion flag when updating a cat
 - **GIVEN** a category that is excluded from reports
 - **WHEN** the user asks the Assistant to include it in reports again
 - **THEN** the category's report-exclusion flag is disabled and the Assistant confirms the change
+
+### Requirement: Abort Assistant Request
+
+The system SHALL allow the user to cancel an in-flight assistant request at any time while the AI is processing.
+When aborted, the system SHALL immediately return to idle state and preserve any previously displayed answer.
+The input text SHALL be preserved after abort so the user can edit and resubmit without retyping.
+
+#### Scenario: Stop button appears while request is in progress
+
+- **WHEN** an assistant request is in flight
+- **THEN** a stop button is displayed in place of the send button
+
+#### Scenario: Clicking stop cancels the request and restores idle state
+
+- **GIVEN** an assistant request is in flight
+- **WHEN** the user clicks the stop button
+- **THEN** the request is cancelled, the loading indicator disappears, and the input is re-enabled
+
+#### Scenario: Input text is preserved after abort
+
+- **GIVEN** the user submitted a question and then aborted the request
+- **WHEN** the abort completes
+- **THEN** the input field still contains the question the user submitted
+
+#### Scenario: Previously displayed answer is not cleared on abort
+
+- **GIVEN** a previous answer is displayed and a new request is in flight
+- **WHEN** the user aborts the new request
+- **THEN** the previously displayed answer remains visible
+
+#### Scenario: Send button returns after abort
+
+- **GIVEN** the user aborted a request
+- **WHEN** the abort completes
+- **THEN** the stop button is replaced by the send button, and the user can submit a new request

--- a/openspec/specs/transactions/spec.md
+++ b/openspec/specs/transactions/spec.md
@@ -759,3 +759,38 @@ The system SHALL interpret colon-separated digit strings (one or two digits, a c
 - **GIVEN** the user types "11:23" directly via keyboard and submits
 - **WHEN** the system processes the input
 - **THEN** the colon-amount rule is not applied and the agent does not coerce the colon string into 11.23
+
+### Requirement: Abort Natural Language Transaction Creation
+
+The system SHALL allow the user to cancel an in-flight natural language transaction creation request at any time while the AI is processing.
+When aborted, the system SHALL immediately return to idle state and no transaction SHALL be created.
+The input text SHALL be preserved after abort so the user can edit and resubmit without retyping.
+
+#### Scenario: Stop button appears while request is in progress
+
+- **WHEN** a natural language transaction creation request is in flight
+- **THEN** a stop button is displayed in place of the send button
+
+#### Scenario: Clicking stop cancels the request and restores idle state
+
+- **GIVEN** a natural language transaction creation request is in flight
+- **WHEN** the user clicks the stop button
+- **THEN** the request is cancelled, the loading indicator disappears, and the input is re-enabled
+
+#### Scenario: Input text is preserved after abort
+
+- **GIVEN** the user submitted natural language text and then aborted the request
+- **WHEN** the abort completes
+- **THEN** the input field still contains the text the user submitted
+
+#### Scenario: No transaction is created when request is aborted
+
+- **GIVEN** a natural language transaction creation request is in flight
+- **WHEN** the user aborts the request
+- **THEN** no transaction is added to the list
+
+#### Scenario: Send button returns after abort
+
+- **GIVEN** the user aborted a request
+- **WHEN** the abort completes
+- **THEN** the stop button is replaced by the send button, and the user can submit a new request


### PR DESCRIPTION
## context

When submitting a question to the Assistant or creating a transaction from natural language, there was no way to cancel the request once sent.
Users had to wait for the AI to finish, even if they changed their mind or submitted by mistake.

## before

- The send button shows a spinner while the AI is processing, but clicking it does nothing
- Users have no way to cancel a request in progress

## after

- A stop button replaces the send button while the AI is processing
- Clicking stop cancels the request immediately and returns the input to its ready state
- Any previously displayed answer stays visible after cancelling