### PR TITLE
preserve voice context when resubmitting after failure

### DIFF
--- a/frontend/src/components/AgenticInput.test.ts
+++ b/frontend/src/components/AgenticInput.test.ts
@@ -1,19 +1,24 @@
-import { describe, it, expect, vi } from "vitest";
-import { ref } from "vue";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { ref, nextTick } from "vue";
 import { mount } from "@vue/test-utils";
 import AgenticInput from "./AgenticInput.vue";
+
+let capturedOnTranscript: ((transcript: string) => void) | undefined;
 
 vi.mock("@/composables/useUserSettings", () => ({
   useUserSettings: () => ({ settings: ref(null) }),
 }));
 
 vi.mock("@/composables/useVoiceInput", () => ({
-  useVoiceInput: () => ({
-    isSupported: ref(false),
-    isRecording: ref(false),
-    startRecording: vi.fn(),
-    stopRecording: vi.fn(),
-  }),
+  useVoiceInput: (options: { onTranscript: (transcript: string) => void }) => {
+    capturedOnTranscript = options.onTranscript;
+    return {
+      isSupported: ref(false),
+      isRecording: ref(false),
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+    };
+  },
 }));
 
 describe("AgenticInput", () => {
@@ -30,5 +35,84 @@ describe("AgenticInput", () => {
 
     // Assert
     expect(wrapper.emitted("abort")).toBeTruthy();
+  });
+
+  describe("submit event", () => {
+    let wrapper: ReturnType<typeof mount>;
+    let submitButton: ReturnType<typeof wrapper.find>;
+
+    beforeEach(() => {
+      capturedOnTranscript = undefined;
+
+      wrapper = mount(AgenticInput, {
+        props: {
+          modelValue: "hello",
+          loading: false,
+          agentTrace: [],
+          submitAriaLabel: "Submit",
+        },
+      });
+
+      submitButton = wrapper.find('button[aria-label="Submit"]');
+    });
+
+    // Happy path
+
+    it("emits submit(false) without prior voice input", async () => {
+      // Act & Assert
+      await submitButton.trigger("click");
+      expect(wrapper.emitted("submit")).toEqual([[false]]);
+    });
+
+    describe("when voice transcript was received", () => {
+      beforeEach(async () => {
+        // Voice transcript populates input
+        capturedOnTranscript!("hello");
+
+        await nextTick();
+      });
+
+      it("emits submit(true) when text not edited", async () => {
+        const countBefore = wrapper.emitted("submit")?.length ?? 0;
+
+        // Act
+        await submitButton.trigger("click");
+
+        // Assert
+        const submits = wrapper.emitted("submit");
+        expect(submits).toHaveLength(countBefore + 1);
+        expect(submits?.[submits.length - 1]).toEqual([true]);
+      });
+
+      it("emits submit(false) when text edited after voice input", async () => {
+        // Arrange
+        // User edits after voice input
+        await wrapper.find("textarea").setValue("hello edited");
+        const countBefore = wrapper.emitted("submit")?.length ?? 0;
+
+        // Act
+        await submitButton.trigger("click");
+
+        // Assert
+        const submits = wrapper.emitted("submit");
+        expect(submits).toHaveLength(countBefore + 1);
+        expect(submits?.[submits.length - 1]).toEqual([false]);
+      });
+
+      it("emits submit(false) after previous submission", async () => {
+        // Arrange
+        // First submit clears voice flag
+        await submitButton.trigger("click");
+        const countBefore = wrapper.emitted("submit")?.length ?? 0;
+
+        // Act
+        await submitButton.trigger("click");
+
+        // Assert
+        const submits = wrapper.emitted("submit");
+        expect(submits).toHaveLength(countBefore + 1);
+        expect(submits?.[submits.length - 1]).toEqual([false]);
+      });
+    });
   });
 });

--- a/frontend/src/components/AgenticInput.vue
+++ b/frontend/src/components/AgenticInput.vue
@@ -10,8 +10,8 @@
       :is-voice-supported="isVoiceSupported"
       :is-recording="isRecording"
       class="flex-grow-1"
-      @update:model-value="$emit('update:modelValue', $event)"
-      @submit="$emit('submit', false)"
+      @update:model-value="onModelValueUpdate"
+      @submit="onSubmit"
       @abort="$emit('abort')"
       @start-recording="startRecording"
       @stop-recording="stopRecording"
@@ -53,6 +53,8 @@ const emit = defineEmits<{
 const { showErrorSnackbar } = useSnackbar();
 const { settings } = useUserSettings();
 
+const isVoiceSet = ref(false);
+
 const {
   isSupported: isVoiceSupported,
   isRecording,
@@ -60,12 +62,23 @@ const {
   stopRecording,
 } = useVoiceInput({
   onTranscript: (transcript: string) => {
+    isVoiceSet.value = true;
     emit("update:modelValue", transcript);
-    emit("submit", true);
+    emit("submit", isVoiceSet.value);
   },
   onError: showErrorSnackbar,
   language: () => settings.value?.voiceInputLanguage ?? undefined,
 });
+
+function onModelValueUpdate(value: string) {
+  isVoiceSet.value = false;
+  emit("update:modelValue", value);
+}
+
+function onSubmit() {
+  emit("submit", isVoiceSet.value);
+  isVoiceSet.value = false;
+}
 
 const showAgentTrace = ref(false);
 const inputRef = ref<{ focus: () => void } | null>(null);

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/design.md
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`AgenticInput.vue` is the shared component used on both the Transactions page and the Assistant page for natural-language input with voice support. When a voice transcript is received it immediately emits `submit(true)`. The submit button, however, is wired as `@submit="$emit('submit', false)"` — a hard-coded `false` that is never changed regardless of how the input was populated.
+
+The `isVoiceInput` flag travels from the frontend submit event → GraphQL mutation argument → service layer → LangChain agent context, and is consumed only in `create-transaction-agent.ts` to inject the `VOICE_INPUT_SUBPROMPT` that guides amount disambiguation. On the Assistant page, the flag is propagated into the create-transaction subagent tool via `config.context`, so it reaches the same prompt.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the voice origin flag when text was set by voice and has not been manually edited since.
+- Cover both Transactions and Assistant pages through the single shared component.
+
+**Non-Goals:**
+
+- No change to the backend, GraphQL schema, or any service.
+- No change to `useVoiceInput.ts` — the composable is correct; only the consumer is wrong.
+- Not persisting voice origin across page reloads or across separate voice sessions.
+
+## Decisions
+
+### Track `isVoiceSet` as reactive state in `AgenticInput.vue`
+
+**Decision**: Add `const isVoiceSet = ref(false)` to `AgenticInput`. Set it `true` inside `onTranscript`. Clear it when `TextboxButtonInput` emits `update:modelValue` (user typed). Pass it — and then clear it — when the button submit event fires.
+
+**Alternative considered**: Track the flag in each parent view (`Transactions.vue`, `Assistant.vue`). Rejected — duplicates logic in two places and the component already has all the information needed.
+
+**Alternative considered**: Persist the flag through a `v-model` prop from the parent. Rejected — the parents have no business reason to know about voice state; it is an `AgenticInput` concern.
+
+**Why clear on user edit**: Any manual keystroke after a voice transcript changes the text; the voice inference rules are designed for unmodified STT output. Clearing on edit is the correct boundary.
+
+**Why clear after submit**: Prevents stale `true` from surviving into the next input cycle if the parent does not reset the `modelValue` (e.g. after a failed submission).
+
+### No change to the `update:modelValue` event emitted to the parent
+
+The parent continues to receive the pass-through unchanged. Only the `submit` payload changes from always-`false` to `isVoiceSet.value`.
+
+## Risks / Trade-offs
+
+- **Risk**: A future refactor moves the submit button out of `AgenticInput` and the `isVoiceSet` ref is no longer accessible. → Mitigation: The flag is an internal implementation detail; the emitted API (`submit: [isVoiceInput: boolean]`) stays identical, so consumers are unaffected.
+
+- **Trade-off**: Clearing `isVoiceSet` on any manual edit means a user who speaks, then corrects a single typo, loses the voice flag. This matches the agreed requirement (any edit = not voice) and is explicit user intent.
+
+## Constitution Compliance
+
+- **Minimum code**: One `ref`, one guard on the pass-through, one change to the submit emit. No new abstractions, no new files.
+- **Surgical changes**: Only `AgenticInput.vue` is modified; no adjacent code, comments, or formatting is touched.
+- **No backwards-compatibility hacks**: The external emit signature (`submit: [isVoiceInput: boolean]`) is unchanged; parents require no update.

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/proposal.md
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+When a voice-originated submission fails (e.g. network error), pressing the submit button again always sends `isVoiceInput: false`, silently dropping the voice origin flag and bypassing the amount-inference rules that prevent misinterpretation of transcribed numbers like "234" (spoken "two thirty four") or "11:23" (spoken price). The user submitted via voice; the system should honour that when they submit again.
+
+## What Changes
+
+- `AgenticInput.vue` gains a `isVoiceSet` reactive flag that is set `true` when a voice transcript populates the input and cleared when the user manually edits the text or after any submission.
+- The submit button, when clicked, forwards `isVoiceSet` instead of the hard-coded `false` it currently emits.
+- No backend, GraphQL schema, or service changes — the `isVoiceInput` field already exists end-to-end.
+
+## Capabilities
+
+### New Capabilities
+
+- None
+
+### Modified Capabilities
+
+- `transactions`: Add requirement — when the text was set by voice and not subsequently edited, pressing submit again SHALL carry the voice origin flag.
+- `assistant`: Same requirement for the Assistant page (which also routes transactions through the create-transaction agent via the subagent tool).
+
+## Impact
+
+- **Frontend**: `AgenticInput.vue` only — one reactive ref, one guard on the text-change pass-through, one change to the submit emit.
+- **Backend / API**: None — `isVoiceInput` is already plumbed through GraphQL, services, and the agent context.
+- **Both pages**: Transactions page and Assistant page share `AgenticInput`, so both are fixed by the single component change.
+
+## Constitution Compliance
+
+- **Minimum code that solves the problem** — change confined to one component, no new abstractions.
+- **Surgical changes** — only the submit emit and the `update:modelValue` pass-through are touched; nothing else in `AgenticInput` changes.
+- **No speculative features** — flag reset on edit and on submit covers exactly the described scenarios, nothing more.

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/specs/assistant/spec.md
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/specs/assistant/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Voice Origin Preserved on Re-submission
+
+The system SHALL retain the voice origin flag for a submission when the text was populated by voice and has not been subsequently modified by the user. When the initial voice-originated submission fails (e.g. due to a network error) and the user presses the submit button again without editing the text, the re-submission SHALL be treated as voice input and the AI agent SHALL apply the same voice amount-inference rules as for the original submission. If the user edits the text after the voice transcript was inserted — including correcting a single character — the voice origin flag SHALL be cleared and the re-submission SHALL be treated as keyboard input.
+
+#### Scenario: Unedited voice input re-submitted with voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Assistant page and the submission failed
+- **AND** the user has not edited the text since the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent with the voice origin flag set
+- **AND** when the message describes a transaction, the AI agent applies voice amount-inference rules
+
+#### Scenario: Editing after voice input clears voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Assistant page and the submission failed
+- **AND** the user has edited the text after the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent without the voice origin flag
+- **AND** when the message describes a transaction, the amount is treated as literal keyboard input
+
+#### Scenario: Voice origin flag is cleared after a successful submission
+
+- **GIVEN** the user submitted a voice transcript and the submission succeeded
+- **WHEN** the user types new text and submits again
+- **THEN** the new submission is treated as keyboard input, not voice input

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/specs/transactions/spec.md
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/specs/transactions/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Voice Origin Preserved on Re-submission
+
+The system SHALL retain the voice origin flag for a submission when the text was populated by voice and has not been subsequently modified by the user. When the initial voice-originated submission fails (e.g. due to a network error) and the user presses the submit button again without editing the text, the re-submission SHALL be treated as voice input and the AI agent SHALL apply the same voice amount-inference rules as for the original submission. If the user edits the text after the voice transcript was inserted — including correcting a single character — the voice origin flag SHALL be cleared and the re-submission SHALL be treated as keyboard input.
+
+#### Scenario: Unedited voice input re-submitted with voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Transactions page and the submission failed
+- **AND** the user has not edited the text since the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent with the voice origin flag set
+- **AND** the AI agent applies voice amount-inference rules
+
+#### Scenario: Editing after voice input clears voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Transactions page and the submission failed
+- **AND** the user has edited the text after the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent without the voice origin flag
+- **AND** the AI agent treats the amount as literal keyboard input
+
+#### Scenario: Voice origin flag is cleared after a successful submission
+
+- **GIVEN** the user submitted a voice transcript and the submission succeeded
+- **WHEN** the user types new text and submits again
+- **THEN** the new submission is treated as keyboard input, not voice input

--- a/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/tasks.md
+++ b/openspec/changes/archive/2026-06-09-persist-voice-flag-on-retry/tasks.md
@@ -1,0 +1,21 @@
+## 1. Tests for `AgenticInput` voice-flag retention
+
+- [x] 1.1 (use `testing` skill) Add test: pressing submit again without editing after voice transcript emits `submit(true)`
+- [x] 1.2 (use `testing` skill) Add test: pressing submit again after manually editing voice transcript emits `submit(false)`
+- [x] 1.3 (use `testing` skill) Add test: button submit without any prior voice input emits `submit(false)`
+- [x] 1.4 (use `testing` skill) Add test: after a successful voice submission, subsequent button submit emits `submit(false)`
+
+## 2. Implementation in `AgenticInput.vue`
+
+- [x] 2.1 Add `isVoiceSet = ref(false)` reactive flag
+- [x] 2.2 Set `isVoiceSet = true` inside `onTranscript` (before emitting `update:modelValue` and `submit`)
+- [x] 2.3 Replace `@update:model-value="$emit('update:modelValue', $event)"` pass-through with a handler that clears `isVoiceSet` then re-emits
+- [x] 2.4 Replace `@submit="$emit('submit', false)"` with a handler that emits `submit(isVoiceSet.value)` then clears `isVoiceSet`
+- [x] 2.5 Run `npm --prefix frontend run test -- AgenticInput` and confirm all tests pass
+
+## Constitution Compliance
+
+- **Minimum code**: One `ref`, one handler, one guard — no new abstractions or files.
+- **Surgical changes**: Only `AgenticInput.vue` and its test file are touched.
+- **TDD**: Tests written before implementation (tasks 1.x precede 2.x).
+- **No speculative features**: Exactly the three cases from the spec — no edge-case handling beyond what was discussed.

--- a/openspec/specs/assistant/spec.md
+++ b/openspec/specs/assistant/spec.md
@@ -503,6 +503,32 @@ The Assistant SHALL allow toggling the report-exclusion flag when updating a cat
 - **WHEN** the user asks the Assistant to include it in reports again
 - **THEN** the category's report-exclusion flag is disabled and the Assistant confirms the change
 
+### Requirement: Voice Origin Preserved on Re-submission
+
+The system SHALL retain the voice origin flag for a submission when the text was populated by voice and has not been subsequently modified by the user. When the initial voice-originated submission fails (e.g. due to a network error) and the user presses the submit button again without editing the text, the re-submission SHALL be treated as voice input and the AI agent SHALL apply the same voice amount-inference rules as for the original submission. If the user edits the text after the voice transcript was inserted — including correcting a single character — the voice origin flag SHALL be cleared and the re-submission SHALL be treated as keyboard input.
+
+#### Scenario: Unedited voice input re-submitted with voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Assistant page and the submission failed
+- **AND** the user has not edited the text since the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent with the voice origin flag set
+- **AND** when the message describes a transaction, the AI agent applies voice amount-inference rules
+
+#### Scenario: Editing after voice input clears voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Assistant page and the submission failed
+- **AND** the user has edited the text after the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent without the voice origin flag
+- **AND** when the message describes a transaction, the amount is treated as literal keyboard input
+
+#### Scenario: Voice origin flag is cleared after a successful submission
+
+- **GIVEN** the user submitted a voice transcript and the submission succeeded
+- **WHEN** the user types new text and submits again
+- **THEN** the new submission is treated as keyboard input, not voice input
+
 ### Requirement: Abort Assistant Request
 
 The system SHALL allow the user to cancel an in-flight assistant request at any time while the AI is processing.

--- a/openspec/specs/transactions/spec.md
+++ b/openspec/specs/transactions/spec.md
@@ -760,6 +760,32 @@ The system SHALL interpret colon-separated digit strings (one or two digits, a c
 - **WHEN** the system processes the input
 - **THEN** the colon-amount rule is not applied and the agent does not coerce the colon string into 11.23
 
+### Requirement: Voice Origin Preserved on Re-submission
+
+The system SHALL retain the voice origin flag for a submission when the text was populated by voice and has not been subsequently modified by the user. When the initial voice-originated submission fails (e.g. due to a network error) and the user presses the submit button again without editing the text, the re-submission SHALL be treated as voice input and the AI agent SHALL apply the same voice amount-inference rules as for the original submission. If the user edits the text after the voice transcript was inserted — including correcting a single character — the voice origin flag SHALL be cleared and the re-submission SHALL be treated as keyboard input.
+
+#### Scenario: Unedited voice input re-submitted with voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Transactions page and the submission failed
+- **AND** the user has not edited the text since the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent with the voice origin flag set
+- **AND** the AI agent applies voice amount-inference rules
+
+#### Scenario: Editing after voice input clears voice origin flag
+
+- **GIVEN** the user submitted a voice transcript on the Transactions page and the submission failed
+- **AND** the user has edited the text after the transcript was inserted
+- **WHEN** the user presses the submit button again
+- **THEN** the submission is sent without the voice origin flag
+- **AND** the AI agent treats the amount as literal keyboard input
+
+#### Scenario: Voice origin flag is cleared after a successful submission
+
+- **GIVEN** the user submitted a voice transcript and the submission succeeded
+- **WHEN** the user types new text and submits again
+- **THEN** the new submission is treated as keyboard input, not voice input
+
 ### Requirement: Abort Natural Language Transaction Creation
 
 The system SHALL allow the user to cancel an in-flight natural language transaction creation request at any time while the AI is processing.


### PR DESCRIPTION
## context

When voice input populates the input field and the submission fails (e.g. network error), pressing submit again always sent the message as keyboard input.
The app uses voice-specific rules to interpret amounts from speech — those rules were silently skipped on resubmit.

## before

- Resubmitting a failed voice submission is always treated as keyboard input, bypassing voice amount-inference rules

## after

- Resubmitting a failed voice submission preserves the voice context when the text has not been edited since dictation
- Editing the text after dictation correctly clears the voice context, so the resubmit is treated as keyboard input