### PR TITLE
handle space-separated integers as decimal amount in voice input

### DIFF
--- a/backend/src/langchain/agents/create-transaction-agent.int.test.ts
+++ b/backend/src/langchain/agents/create-transaction-agent.int.test.ts
@@ -471,4 +471,74 @@ describe("CreateTransactionAgent (integration)", () => {
       expect(toolNames).not.toContain(CREATE_TRANSACTION_TOOL_NAME);
     });
   });
+
+  describe("when message contains space-separated integer pair", () => {
+    // Happy path
+
+    it("treats two-digit fractional part as decimal amount under voice input", async () => {
+      // Arrange
+      await accountRepository.create(fakeAccount({ userId }));
+
+      // Act
+      const response = await agent.invoke(
+        { messages: [new HumanMessage("apples, bananas 12 54")] },
+        { context: { ...context, isVoiceInput: true } },
+      );
+
+      // Assert
+      const lastToolCallMessage = response.messages.findLast(
+        (message): message is AIMessage =>
+          AIMessage.isInstance(message) &&
+          (message.tool_calls ?? []).length > 0,
+      );
+      expect(lastToolCallMessage).toHaveToolCalls([
+        {
+          name: CREATE_TRANSACTION_TOOL_NAME,
+          args: expect.objectContaining({ amount: 12.54 }),
+        },
+      ]);
+    });
+
+    it("treats single-digit fractional part as decimal amount with leading zero under voice input", async () => {
+      // Arrange
+      await accountRepository.create(fakeAccount({ userId }));
+
+      // Act
+      const response = await agent.invoke(
+        { messages: [new HumanMessage("coffee 12 5")] },
+        { context: { ...context, isVoiceInput: true } },
+      );
+
+      // Assert
+      const lastToolCallMessage = response.messages.findLast(
+        (message): message is AIMessage =>
+          AIMessage.isInstance(message) &&
+          (message.tool_calls ?? []).length > 0,
+      );
+      expect(lastToolCallMessage).toHaveToolCalls([
+        {
+          name: CREATE_TRANSACTION_TOOL_NAME,
+          args: expect.objectContaining({ amount: 12.05 }),
+        },
+      ]);
+    });
+
+    it("does not call create_transaction under keyboard input", async () => {
+      // Arrange
+      await accountRepository.create(fakeAccount({ userId }));
+
+      // Act
+      const response = await agent.invoke(
+        { messages: [new HumanMessage("apples, bananas 12 54")] },
+        { context: { ...context, isVoiceInput: false } },
+      );
+
+      // Assert
+      const toolNames = response.messages
+        .filter(AIMessage.isInstance)
+        .flatMap((message) => message.tool_calls ?? [])
+        .map((toolCall) => toolCall.name);
+      expect(toolNames).not.toContain(CREATE_TRANSACTION_TOOL_NAME);
+    });
+  });
 });

--- a/backend/src/langchain/agents/create-transaction-agent.ts
+++ b/backend/src/langchain/agents/create-transaction-agent.ts
@@ -53,7 +53,7 @@ You MUST infer all mandatory and optional transaction fields and then MUST persi
 - Numeric or written value representing a money quantity (e.g., 25, 20.5, "twenty five euros")
 - If multiple amounts are present, MUST stop and report an error — only one transaction at a time
 
-{VOICE_INPUT_INDICATOR}
+{VOICE_INPUT_SUBPROMPT}
 
 ### Account
 
@@ -133,9 +133,19 @@ Speech-to-text often transcribes a spoken price as a clock time — "eleven twen
 
 - The "11:23" string may represent a price of 11.23 or a clock time of 11:23
 - If no time preposition ("at", "around", "by") is present and no other numeric amount is present, treat it as a price
-- Example: "11:23" → amount 11.23
-- Example: "lunch 11:23 at cafe" → amount 11.23 ("at cafe" identifies a place)
-- Example: "coffee at 12:34" → 12:34 is a time
+- Examples:
+  - "11:23" → amount 11.23
+  - "lunch 11:23 at cafe" → amount 11.23 ("at cafe" identifies a place)
+  - "coffee at 12:34" → 12:34 is a time
+
+Speech-to-text often transcribes a spoken price as two adjacent integers — "twelve fifty-four" becomes "12 54".
+
+- When two adjacent integers N M are the only numbers in the input, treat them as a decimal price
+  - N is the whole part
+  - M is the fractional part, padded with a leading zero if single-digit
+- Examples:
+  - "apples, bananas 12 54" → amount 12.54
+  - "coffee 12 5" → amount 12.05
 `.trim();
 
 export function createCreateTransactionAgent({
@@ -167,7 +177,7 @@ export function createCreateTransactionAgent({
         const { today, isVoiceInput } = runtime.context;
         const prompt = await promptTemplate.format({
           TODAY: today,
-          VOICE_INPUT_INDICATOR: isVoiceInput ? VOICE_INPUT_SUBPROMPT : "",
+          VOICE_INPUT_SUBPROMPT: isVoiceInput ? VOICE_INPUT_SUBPROMPT : "",
         });
         return prompt;
       }),

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/design.md
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The AI agent that creates transactions from natural language uses a `VOICE_INPUT_SUBPROMPT` injected into its system prompt when `isVoiceInput: true`. This subprompt already handles two speech-to-text artefacts:
+
+1. Concatenated numbers: "two thirty four" → "234" (may be 2.34, 23.4, or 234)
+2. Colon-format: "eleven twenty three" → "11:23" (may be price or time)
+
+Missing case: when a user says "twelve fifty-four", speech-to-text may emit two separate integers — "12 54" — rather than "1254" or "12:54". The agent currently fires its base rule ("if multiple amounts are present, stop and report an error") rather than recognising this as a decimal price.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Teach the agent to recognise two adjacent integers N M as a decimal price when they are the only numbers in a voice-originated input.
+- Apply the rule: M is the fractional part, padded with a leading zero only when single-digit ("12 54" → 12.54, "12 5" → 12.05).
+- Add integration tests for the new pattern.
+
+**Non-Goals:**
+
+- Change application code, GraphQL schema, or frontend.
+- Handle three or more separate integers.
+- Change keyboard input behaviour.
+
+## Decisions
+
+### Decision: Prompt-only fix, no preprocessing
+
+**Chosen:** Add a new paragraph to `VOICE_INPUT_SUBPROMPT`.
+
+**Alternatives considered:**
+
+- _Pre-process the transcript in application code_ — normalise "12 54" to "12.54" before the agent sees it. Rejected: adds fragile regex in the wrong layer; all other voice artefact handling lives in the prompt.
+- _Post-process on multi-amount error_ — catch the error and resubmit with a hint. Rejected: overly complex for a case the prompt should prevent.
+
+### Decision: M is the fractional part, padded with a leading zero only when single-digit
+
+"12 54" → 12.54; "12 5" → 12.05. Speech-to-text preserves the digit count of the spoken number, so the mapping is unambiguous regardless of currency decimal places.
+
+### Decision: History lookup still required
+
+Consistent with the existing concatenated-number rule: look up similar past transactions before committing to the interpretation.
+
+## Risks / Trade-offs
+
+- **False positive** — "12 54" could be two separate items priced at 12 and 54. Mitigation: the rule applies only when these are the only numbers in the input and context describes a single purchase.
+- **History lookup cost** — one extra DB call on the agent path. Acceptable; the same cost already exists for other voice rules.
+
+## Constitution Compliance
+
+- **Backend-only change**: No schema or frontend changes; consistent with the independent package principle.
+- **Prompt as the correct layer**: Agent behaviour is governed by its system prompt; this follows the established pattern.
+- **Integration tests required**: Added alongside the prompt change, consistent with the constitution's test strategy for agent behaviour.

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/proposal.md
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+When a user dictates a price like "twelve fifty-four", speech-to-text may transcribe it as two separate integers — "12 54" — causing the AI agent to reject the input with a multiple-amounts error instead of creating the transaction with amount 12.54.
+
+## What Changes
+
+- Add a new voice recognition rule to the AI agent's system prompt: when two adjacent integers N M are the only numbers in a voice-originated input, treat them as a decimal price where M is the fractional part, padded with a leading zero only when single-digit (e.g. "12 54" → 12.54, "12 5" → 12.05).
+- Add integration test coverage for the new pattern.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `transactions`: Add **Voice Space-Separated Amount Recognition** — a new voice input rule covering the case where speech-to-text emits two integers instead of a decimal.
+- `assistant`: Add **Voice Space-Separated Amount Recognition** — the same rule applies when logging a transaction through the Assistant, since it shares the transaction-creation agent.
+
+## Impact
+
+- `backend/src/langchain/agents/create-transaction-agent.ts` — `VOICE_INPUT_SUBPROMPT` constant updated.
+- `backend/src/langchain/agents/create-transaction-agent.int.test.ts` — new test group added.
+- No API, schema, or frontend changes.
+
+## Constitution Compliance
+
+- **Backend-only change**: No schema or frontend changes; consistent with the independent package principle.
+- **Prompt is the correct layer**: All other voice artefact handling lives in `VOICE_INPUT_SUBPROMPT`; this change follows the same pattern.
+- **Integration tests required**: Added alongside the prompt change, consistent with the constitution's test strategy for agent behaviour.

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/specs/assistant/spec.md
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/specs/assistant/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Voice Space-Separated Amount Recognition
+
+The system SHALL interpret two adjacent integers separated by a space in voice-originated input as a single decimal amount when the user logs a transaction through the Assistant, where the second integer is the fractional part, padded with a leading zero only when it is a single digit (e.g. "12 54" → 12.54, "12 5" → 12.05). When the two integers are the only numbers in the input, the system SHALL treat them as a decimal price and look up similar past transactions to confirm the amount is realistic before creating the transaction. This rule applies only to voice-originated input; keyboard-typed input is unaffected.
+
+#### Scenario: Two-digit fractional part in voice input is treated as decimal amount
+
+- **GIVEN** the user says "apples, bananas twelve fifty-four" and speech-to-text transcribes it as "apples, bananas 12 54"
+- **WHEN** the agent processes the input knowing it came from voice on the Assistant page
+- **THEN** the transaction is created with amount 12.54
+
+#### Scenario: Single-digit fractional part in voice input is padded and treated as decimal amount
+
+- **GIVEN** the user says "coffee twelve five" and speech-to-text transcribes it as "coffee 12 5"
+- **WHEN** the agent processes the input knowing it came from voice on the Assistant page
+- **THEN** the transaction is created with amount 12.05
+
+#### Scenario: Keyboard input with two adjacent integers is rejected as multiple amounts
+
+- **GIVEN** the user types "apples, bananas 12 54" using the keyboard on the Assistant page
+- **WHEN** the agent processes the input knowing it came from keyboard
+- **THEN** the transaction is NOT created and an error is returned indicating multiple amounts were found

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/specs/transactions/spec.md
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/specs/transactions/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Voice Space-Separated Amount Recognition
+
+The system SHALL interpret two adjacent integers separated by a space in voice-originated input as a single decimal amount, where the second integer is the fractional part, padded with a leading zero only when it is a single digit (e.g. "12 54" → 12.54, "12 5" → 12.05). This handles speech-to-text outputs where a spoken price like "twelve fifty-four" becomes "12 54". When the two integers are the only numbers in the input, the system SHALL treat them as a decimal price and look up similar past transactions to confirm the amount is realistic before creating the transaction. This rule applies only to voice-originated input; keyboard-typed input is unaffected.
+
+#### Scenario: Two-digit fractional part in voice input is treated as decimal amount
+
+- **GIVEN** the user says "apples, bananas twelve fifty-four" and speech-to-text transcribes it as "apples, bananas 12 54"
+- **WHEN** the agent processes the input knowing it came from voice
+- **THEN** the transaction is created with amount 12.54
+
+#### Scenario: Single-digit fractional part in voice input is padded and treated as decimal amount
+
+- **GIVEN** the user says "coffee twelve five" and speech-to-text transcribes it as "coffee 12 5"
+- **WHEN** the agent processes the input knowing it came from voice
+- **THEN** the transaction is created with amount 12.05
+
+#### Scenario: Keyboard input with two adjacent integers is rejected as multiple amounts
+
+- **GIVEN** the user types "apples, bananas 12 54" using the keyboard
+- **WHEN** the agent processes the input knowing it came from keyboard
+- **THEN** the transaction is NOT created and an error is returned indicating multiple amounts were found

--- a/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/tasks.md
+++ b/openspec/changes/archive/2026-06-10-voice-input-decimal-pair/tasks.md
@@ -1,0 +1,15 @@
+## 1. Tests
+
+- [x] 1.1 (use `testing` skill) Add integration test: voice input "apples, bananas 12 54" creates transaction with amount 12.54
+- [x] 1.2 (use `testing` skill) Add integration test: voice input "coffee 12 5" creates transaction with amount 12.05
+- [x] 1.3 (use `testing` skill) Add integration test: keyboard input "apples, bananas 12 54" does NOT create transaction
+
+## 2. Implementation
+
+- [x] 2.1 Add new voice rule paragraph to `VOICE_INPUT_SUBPROMPT` in `backend/src/langchain/agents/create-transaction-agent.ts`: when two adjacent integers N M are the only numbers in the input, treat them as a decimal price where M is the fractional part, padded with a leading zero only when single-digit
+
+## Constitution Compliance
+
+- **TDD order**: Tests written before implementation (tasks 1.x before 2.x), as required by the constitution.
+- **Backend-only change**: No schema or frontend changes; consistent with the independent package principle.
+- **Minimal footprint**: One constant updated, one test group added — no new abstractions or dependencies.

--- a/openspec/specs/assistant/spec.md
+++ b/openspec/specs/assistant/spec.md
@@ -295,6 +295,28 @@ The system SHALL disambiguate voice-originated amounts when the user logs a tran
 - **WHEN** the amount is parsed
 - **THEN** the amount is interpreted literally and voice-input disambiguation is not applied
 
+### Requirement: Voice Space-Separated Amount Recognition
+
+The system SHALL interpret two adjacent integers separated by a space in voice-originated input as a single decimal amount when the user logs a transaction through the Assistant, where the second integer is the fractional part, padded with a leading zero only when it is a single digit (e.g. "12 54" → 12.54, "12 5" → 12.05). When the two integers are the only numbers in the input, the system SHALL treat them as a decimal price and look up similar past transactions to confirm the amount is realistic before creating the transaction. This rule applies only to voice-originated input; keyboard-typed input is unaffected.
+
+#### Scenario: Two-digit fractional part in voice input is treated as decimal amount
+
+- **GIVEN** the user says "apples, bananas twelve fifty-four" and speech-to-text transcribes it as "apples, bananas 12 54"
+- **WHEN** the agent processes the input knowing it came from voice on the Assistant page
+- **THEN** the transaction is created with amount 12.54
+
+#### Scenario: Single-digit fractional part in voice input is padded and treated as decimal amount
+
+- **GIVEN** the user says "coffee twelve five" and speech-to-text transcribes it as "coffee 12 5"
+- **WHEN** the agent processes the input knowing it came from voice on the Assistant page
+- **THEN** the transaction is created with amount 12.05
+
+#### Scenario: Keyboard input with two adjacent integers is rejected as multiple amounts
+
+- **GIVEN** the user types "apples, bananas 12 54" using the keyboard on the Assistant page
+- **WHEN** the agent processes the input knowing it came from keyboard
+- **THEN** the transaction is NOT created and an error is returned indicating multiple amounts were found
+
 ### Requirement: Account Creation from Natural Language
 
 The system SHALL let the user create a new account by describing it in natural language through the Assistant, in addition to answering finance questions and logging transactions. When the user's message provides enough detail to identify an account name and currency, the Assistant SHALL create the account and confirm it in the answer. When required details are missing, the Assistant SHALL ask for them instead of creating the account. When the requested account name is a semantic near-variant of an existing active (non-archived) account (for example pluralisation, typos, abbreviations, or synonyms), the Assistant SHALL ask the user to confirm before creating. Archived accounts are not considered — reusing an archived account's name is not a duplicate. When the user does not state an initial balance, the Assistant SHALL create the account starting at zero. When the Assistant cannot create the account because it would conflict with an existing account or violate another business rule, the Assistant's answer SHALL explain what went wrong.

--- a/openspec/specs/transactions/spec.md
+++ b/openspec/specs/transactions/spec.md
@@ -720,6 +720,28 @@ The system SHALL provide a mic button inside the natural language text input are
 - **WHEN** the system processes the input
 - **THEN** the agent creates the transaction with amount 234 without applying voice amount validation
 
+### Requirement: Voice Space-Separated Amount Recognition
+
+The system SHALL interpret two adjacent integers separated by a space in voice-originated input as a single decimal amount, where the second integer is the fractional part, padded with a leading zero only when it is a single digit (e.g. "12 54" → 12.54, "12 5" → 12.05). This handles speech-to-text outputs where a spoken price like "twelve fifty-four" becomes "12 54". When the two integers are the only numbers in the input, the system SHALL treat them as a decimal price and look up similar past transactions to confirm the amount is realistic before creating the transaction. This rule applies only to voice-originated input; keyboard-typed input is unaffected.
+
+#### Scenario: Two-digit fractional part in voice input is treated as decimal amount
+
+- **GIVEN** the user says "apples, bananas twelve fifty-four" and speech-to-text transcribes it as "apples, bananas 12 54"
+- **WHEN** the agent processes the input knowing it came from voice
+- **THEN** the transaction is created with amount 12.54
+
+#### Scenario: Single-digit fractional part in voice input is padded and treated as decimal amount
+
+- **GIVEN** the user says "coffee twelve five" and speech-to-text transcribes it as "coffee 12 5"
+- **WHEN** the agent processes the input knowing it came from voice
+- **THEN** the transaction is created with amount 12.05
+
+#### Scenario: Keyboard input with two adjacent integers is rejected as multiple amounts
+
+- **GIVEN** the user types "apples, bananas 12 54" using the keyboard
+- **WHEN** the agent processes the input knowing it came from keyboard
+- **THEN** the transaction is NOT created and an error is returned indicating multiple amounts were found
+
 ### Requirement: Voice Colon-Amount Recognition
 
 The system SHALL interpret colon-separated digit strings (one or two digits, a colon, one or two digits) in voice-originated input as decimal amounts, where the digits before the colon are the whole part and the digits after are the fractional part. This handles speech-to-text outputs such as "11:23" produced when the user dictates a decimal amount like "eleven twenty three". When the surrounding wording explicitly frames the colon string as a clock time (e.g., "at 12:34", "around 7:30", "by 18:00"), the system SHALL treat it as a time and not as an amount. This rule applies only to voice-originated input; keyboard-typed input is unaffected.


### PR DESCRIPTION
## context

When users dictate a price like "twelve fifty-four", speech-to-text sometimes outputs two separate integers — "12 54" — instead of a decimal.
The AI agent currently treats this as two separate amounts and rejects the input with an error.

## before

- Voice input like "12 54" triggers a multiple-amounts error
- No transaction is created; the user has to retype or correct the transcription

## after

- Voice input with two adjacent integers is recognized as a decimal amount ("12 54" → 12.54, "12 5" → 12.05)
- Keyboard input with the same pattern is unaffected