### PR TITLE
bump awscli and cdk npm dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 24.12.0
-awscli 2.34.56
+awscli 2.36.10

--- a/infra-cdk/package-lock.json
+++ b/infra-cdk/package-lock.json
@@ -3227,9 +3227,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1121.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1121.0.tgz",
-      "integrity": "sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==",
+      "version": "2.1133.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1133.0.tgz",
+      "integrity": "sha512-DGlCBwqxSHTe1u/IoT5WV+Bbd2K3UhwFHsdMqb2nQa1fkJmaQgoNFu0It+p3HxyMWeW+gKsVzT5KcjQPQ6Kzuw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3240,10 +3240,11 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.260.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.260.0.tgz",
-      "integrity": "sha512-2PPG+hbPDot8+ibkb5Jl9y3OY5rBE6TFwjzOi+yEyU4ZG6u8bM4DDKhhBi/S20NqqSFDso9rH1txVJAdwXNiuQ==",
+      "version": "2.262.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.1.tgz",
+      "integrity": "sha512-B6YP4r6ojUZCDhl+qBu/CrWzcipR8sIgshcqYvgw013sghPXmVkYdJ3yuI9+DKML3YLSjQrHy1nGJs+Nqq7JCg==",
       "bundleDependencies": [
+        "@aws/cloudformation-validate",
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
         "case",
@@ -3253,7 +3254,6 @@
         "minimatch",
         "punycode",
         "semver",
-        "table",
         "yaml",
         "mime-types"
       ],
@@ -3261,18 +3261,18 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.282",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
-        "@aws-cdk/cloud-assembly-api": "^2.2.5",
-        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.5.1-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.5",
+        "fs-extra": "^11.3.6",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.8.1",
-        "table": "^6.9.0",
+        "semver": "^7.8.5",
         "yaml": "1.10.3"
       },
       "engines": {
@@ -3283,69 +3283,32 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.5",
+      "version": "2.2.6",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.4"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.5.1-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.20.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "4.0.4",
@@ -3356,7 +3319,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3374,49 +3337,8 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/color-convert": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/color-name": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.2",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.5",
+      "version": "11.3.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3441,19 +3363,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.2.1",
       "inBundle": true,
@@ -3472,11 +3381,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
-      "version": "4.4.2",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
@@ -3519,16 +3423,8 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.8.1",
+      "version": "7.8.5",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3536,61 +3432,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/string-width": {
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.9.0",
-      "inBundle": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "ajv": "^8.0.1",
-        "lodash.truncate": "^4.4.2",
-        "slice-ansi": "^4.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {


### PR DESCRIPTION
- Bump awscli 2.34.56 -> 2.36.10 in .tool-versions
- Bump aws-cdk 2.1121.0 -> 2.1133.0 and aws-cdk-lib 2.260.0 -> 2.262.1 in infra-cdk/package-lock.json, fixing cloud assembly schema mismatch (CLI required >= 2.1133.0 to read schema 54.0.0)