### PR TITLE
share langchain and MCP tool schemas, descriptions, and logic

### DIFF
--- a/backend/src/langchain/tools/create-account.test.ts
+++ b/backend/src/langchain/tools/create-account.test.ts
@@ -4,7 +4,6 @@ import { AccountService } from "../../services/account-service";
 import { BusinessError } from "../../services/business-error";
 import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
-import { toAccountDto } from "./account-dto";
 import { CreateAccountInput, createCreateAccountTool } from "./create-account";
 
 describe("createCreateAccountTool", () => {
@@ -25,73 +24,24 @@ describe("createCreateAccountTool", () => {
     expect(createTool.name).toBe("create_account");
   });
 
-  // Happy path
-
-  it("creates account and defaults initialBalance to 0 when omitted", async () => {
+  it("wires input and context userId through to the shared handler", async () => {
     // Arrange
-    const created = fakeAccount({
-      name: "Savings",
-      currency: "USD",
-      initialBalance: 0,
-    });
-
-    // Service returns the created account
+    const created = fakeAccount({ name: "Savings", currency: "USD" });
     mockAccountService.createAccount.mockResolvedValue(created);
 
     const createTool = createCreateAccountTool({
       accountService: mockAccountService,
     });
 
-    const input: CreateAccountInput = {
-      name: "Savings",
-      currency: "USD",
-    };
+    const input: CreateAccountInput = { name: "Savings", currency: "USD" };
 
     // Act
     const result = await createTool.invoke(input, { context: { userId } });
 
     // Assert
-    expect(result).toEqual({
-      success: true,
-      data: {
-        ...toAccountDto(created),
-        initialBalance: 0,
-      },
-    });
-
-    expect(mockAccountService.createAccount).toHaveBeenCalledWith({
-      userId,
-      name: "Savings",
-      currency: "USD",
-      initialBalance: 0,
-    });
-  });
-
-  it("passes initialBalance through when provided", async () => {
-    // Arrange
-    const created = fakeAccount({ initialBalance: 500 });
-
-    // Service returns the created account
-    mockAccountService.createAccount.mockResolvedValue(created);
-
-    const createTool = createCreateAccountTool({
-      accountService: mockAccountService,
-    });
-
-    const input: CreateAccountInput = {
-      name: "Checking",
-      currency: "EUR",
-      initialBalance: 500,
-    };
-
-    // Act
-    await createTool.invoke(input, { context: { userId } });
-
-    // Assert
+    expect(result).toMatchObject({ success: true });
     expect(mockAccountService.createAccount).toHaveBeenCalledWith(
-      expect.objectContaining({
-        initialBalance: 500,
-      }),
+      expect.objectContaining({ userId, name: "Savings", currency: "USD" }),
     );
   });
 
@@ -118,12 +68,11 @@ describe("createCreateAccountTool", () => {
 
   // Dependency failures
 
-  it("propagates BusinessError from service unchanged", async () => {
+  it("returns failure when the shared handler catches a BusinessError", async () => {
     // Arrange
-    const error = new BusinessError('Account "Savings" already exists');
-
-    // Service rejects with a domain error
-    mockAccountService.createAccount.mockRejectedValue(error);
+    mockAccountService.createAccount.mockRejectedValue(
+      new BusinessError('Account "Savings" already exists'),
+    );
 
     const createTool = createCreateAccountTool({
       accountService: mockAccountService,
@@ -134,9 +83,13 @@ describe("createCreateAccountTool", () => {
       currency: "USD",
     };
 
-    // Act & Assert
-    await expect(
-      createTool.invoke(input, { context: { userId } }),
-    ).rejects.toBe(error);
+    // Act
+    const result = await createTool.invoke(input, { context: { userId } });
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: 'Account "Savings" already exists',
+    });
   });
 });

--- a/backend/src/langchain/tools/create-account.ts
+++ b/backend/src/langchain/tools/create-account.ts
@@ -1,11 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { AccountService } from "../../services/account-service";
-import {
-  createAccount,
-  description,
-  inputSchema,
-} from "../../tools/create-account";
+import { handler, description, inputSchema } from "../../tools/create-account";
 import { agentContextSchema } from "../agents/agent-context";
 
 const schema = z.object(inputSchema);
@@ -23,7 +19,7 @@ export const createCreateAccountTool = ({
         config?.context?.userId,
       );
 
-      return createAccount(input, { accountService, userId });
+      return handler(input, { accountService, userId });
     },
     {
       name: "create_account",

--- a/backend/src/langchain/tools/create-account.ts
+++ b/backend/src/langchain/tools/create-account.ts
@@ -1,34 +1,16 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { AccountService } from "../../services/account-service";
-import { Success } from "../../types/result";
+import {
+  createAccount,
+  description,
+  inputSchema,
+} from "../../tools/create-account";
 import { agentContextSchema } from "../agents/agent-context";
-import { toAccountDto } from "./account-dto";
 
-const schema = z.object({
-  name: z.string().describe("Account name"),
-  currency: z
-    .string()
-    .describe("Account currency — any ISO 4217 code (e.g. USD, EUR, GBP)."),
-  initialBalance: z
-    .number()
-    .optional()
-    .describe(
-      "Initial balance of the account. Omit when the user did not state one; the account will start at zero.",
-    ),
-});
+const schema = z.object(inputSchema);
 
 export type CreateAccountInput = z.infer<typeof schema>;
-
-const description = `
-Create a new account for the user.
-
-Before calling, check the user's existing active (non-archived) accounts.
-If the requested name is a semantic near-variant of an existing active one
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before creating.
-Archived accounts are not considered — reusing an archived account's name is not a duplicate.
-`.trim();
 
 export const createCreateAccountTool = ({
   accountService,
@@ -41,17 +23,7 @@ export const createCreateAccountTool = ({
         config?.context?.userId,
       );
 
-      const created = await accountService.createAccount({
-        userId,
-        name: input.name,
-        currency: input.currency,
-        initialBalance: input.initialBalance ?? 0,
-      });
-
-      return Success({
-        ...toAccountDto(created),
-        initialBalance: created.initialBalance,
-      });
+      return createAccount(input, { accountService, userId });
     },
     {
       name: "create_account",

--- a/backend/src/langchain/tools/create-category.test.ts
+++ b/backend/src/langchain/tools/create-category.test.ts
@@ -5,7 +5,6 @@ import { BusinessError } from "../../services/business-error";
 import { CategoryService } from "../../services/category-service";
 import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
 import { createMockCategoryService } from "../../utils/test-utils/services/category-service-mocks";
-import { toCategoryDto } from "./category-dto";
 import { createCreateCategoryTool } from "./create-category";
 
 describe("createCreateCategoryTool", () => {
@@ -26,72 +25,27 @@ describe("createCreateCategoryTool", () => {
     expect(createTool.name).toBe("create_category");
   });
 
-  // Happy path
-
-  it("creates category and returns it", async () => {
+  it("wires input and context userId through to the shared handler, defaulting excludeFromReports", async () => {
     // Arrange
     const created = fakeCategory();
-
-    // Persists and returns new category
     mockCategoryService.createCategory.mockResolvedValue(created);
 
     const createTool = createCreateCategoryTool({
       categoryService: mockCategoryService,
     });
 
-    const input = {
-      name: "Groceries",
-      type: CategoryType.EXPENSE,
-    };
+    const input = { name: "Groceries", type: CategoryType.EXPENSE };
 
     // Act
     const result = await createTool.invoke(input, { context: { userId } });
 
     // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(created),
-    });
-
+    expect(result).toMatchObject({ success: true });
     expect(mockCategoryService.createCategory).toHaveBeenCalledWith({
       userId,
       name: "Groceries",
       type: CategoryType.EXPENSE,
       excludeFromReports: false,
-    });
-  });
-
-  it("passes excludeFromReports true to service", async () => {
-    // Arrange
-    const created = fakeCategory();
-
-    // Persists and returns new category
-    mockCategoryService.createCategory.mockResolvedValue(created);
-
-    const createTool = createCreateCategoryTool({
-      categoryService: mockCategoryService,
-    });
-
-    const input = {
-      name: "Internal Transfers",
-      type: CategoryType.EXPENSE,
-      excludeFromReports: true,
-    };
-
-    // Act
-    const result = await createTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(created),
-    });
-
-    expect(mockCategoryService.createCategory).toHaveBeenCalledWith({
-      userId,
-      name: "Internal Transfers",
-      type: CategoryType.EXPENSE,
-      excludeFromReports: true,
     });
   });
 
@@ -118,11 +72,11 @@ describe("createCreateCategoryTool", () => {
 
   // Dependency failures
 
-  it("propagates BusinessError from service unchanged", async () => {
+  it("returns failure when the shared handler catches a BusinessError", async () => {
     // Arrange
-    const error = new BusinessError('Category "Groceries" already exists');
-
-    mockCategoryService.createCategory.mockRejectedValue(error);
+    mockCategoryService.createCategory.mockRejectedValue(
+      new BusinessError('Category "Groceries" already exists'),
+    );
 
     const createTool = createCreateCategoryTool({
       categoryService: mockCategoryService,
@@ -133,9 +87,13 @@ describe("createCreateCategoryTool", () => {
       type: CategoryType.EXPENSE,
     };
 
-    // Act & Assert
-    await expect(
-      createTool.invoke(input, { context: { userId } }),
-    ).rejects.toBe(error);
+    // Act
+    const result = await createTool.invoke(input, { context: { userId } });
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: 'Category "Groceries" already exists',
+    });
   });
 });

--- a/backend/src/langchain/tools/create-category.ts
+++ b/backend/src/langchain/tools/create-category.ts
@@ -1,40 +1,16 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { CategoryType } from "../../models/category";
 import { CategoryService } from "../../services/category-service";
-import { Success } from "../../types/result";
+import {
+  createCategory,
+  description,
+  inputSchema,
+} from "../../tools/create-category";
 import { agentContextSchema } from "../agents/agent-context";
-import { toCategoryDto } from "./category-dto";
 
-const schema = z.object({
-  excludeFromReports: z
-    .boolean()
-    .default(false)
-    .describe(
-      "Whether to exclude transactions in this category from financial reports.",
-    ),
-  name: z.string().describe("Category name"),
-  type: z
-    .enum(CategoryType)
-    .describe(
-      `Category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
-    ),
-});
+const schema = z.object(inputSchema);
 
 export type CreateCategoryInput = z.infer<typeof schema>;
-
-const description = `
-Create a new category for the user.
-
-Before calling, check the user's existing active (non-archived) categories.
-If the requested name is a semantic near-variant of an existing active one
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before creating.
-Archived categories are not considered — reusing an archived category's name is not a duplicate.
-
-Set excludeFromReports to true if the user wants transactions in this category
-excluded from financial reports and spending/income calculations.
-`.trim();
 
 export const createCreateCategoryTool = ({
   categoryService,
@@ -42,19 +18,12 @@ export const createCreateCategoryTool = ({
   categoryService: CategoryService;
 }) => {
   return tool(
-    async (input, config) => {
+    async (input: CreateCategoryInput, config) => {
       const userId = agentContextSchema.shape.userId.parse(
         config?.context?.userId,
       );
 
-      const created = await categoryService.createCategory({
-        userId,
-        name: input.name,
-        type: input.type,
-        excludeFromReports: input.excludeFromReports,
-      });
-
-      return Success(toCategoryDto(created));
+      return createCategory(input, { categoryService, userId });
     },
     {
       name: "create_category",

--- a/backend/src/langchain/tools/create-category.ts
+++ b/backend/src/langchain/tools/create-category.ts
@@ -1,11 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { CategoryService } from "../../services/category-service";
-import {
-  createCategory,
-  description,
-  inputSchema,
-} from "../../tools/create-category";
+import { handler, description, inputSchema } from "../../tools/create-category";
 import { agentContextSchema } from "../agents/agent-context";
 
 const schema = z.object(inputSchema);
@@ -23,7 +19,7 @@ export const createCreateCategoryTool = ({
         config?.context?.userId,
       );
 
-      return createCategory(input, { categoryService, userId });
+      return handler(input, { categoryService, userId });
     },
     {
       name: "create_category",

--- a/backend/src/langchain/tools/create-transaction.test.ts
+++ b/backend/src/langchain/tools/create-transaction.test.ts
@@ -45,7 +45,7 @@ describe("createCreateTransactionTool", () => {
     ).rejects.toThrow();
   });
 
-  it("calls createTransaction with correct input and returns created transaction", async () => {
+  it("wires input and context userId through to the shared handler", async () => {
     const created = fakeTransaction();
     mockTransactionService.createTransaction.mockResolvedValue(created);
 
@@ -68,18 +68,6 @@ describe("createCreateTransactionTool", () => {
       input,
       userId,
     );
-    expect(result).toEqual({
-      success: true,
-      data: {
-        id: created.id,
-        accountId: created.accountId,
-        amount: created.amount,
-        categoryId: created.categoryId,
-        currency: created.currency,
-        date: created.date,
-        description: created.description,
-        type: created.type,
-      },
-    });
+    expect(result).toMatchObject({ success: true });
   });
 });

--- a/backend/src/langchain/tools/create-transaction.ts
+++ b/backend/src/langchain/tools/create-transaction.ts
@@ -1,39 +1,17 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { TransactionType } from "../../models/transaction";
 import {
   CreateTransactionServiceInput,
   TransactionService,
 } from "../../services/transaction-service";
-import { toDateString } from "../../types/date";
-import { Success } from "../../types/result";
+import {
+  createTransaction,
+  description,
+  inputSchema,
+} from "../../tools/create-transaction";
 import { agentContextSchema } from "../agents/agent-context";
-import { toTransactionDto } from "./transaction-dto";
 
-const schema = z.object({
-  accountId: z.uuid().describe("Account ID to associate the transaction with"),
-  amount: z.number().positive().describe("Transaction amount"),
-  categoryId: z
-    .uuid()
-    .optional()
-    .describe("Category ID to associate the transaction with"),
-  date: z.iso
-    .date()
-    .transform(toDateString)
-    .describe("Transaction date in YYYY-MM-DD format"),
-  description: z
-    .string()
-    .max(500)
-    .optional()
-    .describe("Short transaction description"),
-  type: z
-    .enum([
-      TransactionType.INCOME,
-      TransactionType.EXPENSE,
-      TransactionType.REFUND,
-    ])
-    .describe("Transaction type"),
-});
+const schema = z.object(inputSchema);
 
 export type CreateTransactionInput = z.infer<typeof schema>;
 
@@ -51,16 +29,12 @@ export const createCreateTransactionTool = ({
       );
 
       const serviceInput: CreateTransactionServiceInput = { ...input };
-      const created = await transactionService.createTransaction(
-        serviceInput,
-        userId,
-      );
 
-      return Success(toTransactionDto(created));
+      return createTransaction(serviceInput, { transactionService, userId });
     },
     {
       name: CREATE_TRANSACTION_TOOL_NAME,
-      description: "Create a new transaction.",
+      description,
       schema,
     },
   );

--- a/backend/src/langchain/tools/create-transaction.ts
+++ b/backend/src/langchain/tools/create-transaction.ts
@@ -5,7 +5,7 @@ import {
   TransactionService,
 } from "../../services/transaction-service";
 import {
-  createTransaction,
+  handler,
   description,
   inputSchema,
 } from "../../tools/create-transaction";
@@ -30,7 +30,7 @@ export const createCreateTransactionTool = ({
 
       const serviceInput: CreateTransactionServiceInput = { ...input };
 
-      return createTransaction(serviceInput, { transactionService, userId });
+      return handler(serviceInput, { transactionService, userId });
     },
     {
       name: CREATE_TRANSACTION_TOOL_NAME,

--- a/backend/src/langchain/tools/get-accounts.test.ts
+++ b/backend/src/langchain/tools/get-accounts.test.ts
@@ -2,7 +2,6 @@ import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
 import { AccountService } from "../../services/account-service";
 import { EntityScope } from "../../types/entity-scope";
-import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
 import { createGetAccountsTool } from "./get-accounts";
 
@@ -31,7 +30,7 @@ describe("createGetAccountsTool", () => {
     ).rejects.toThrow();
   });
 
-  it("calls service", async () => {
+  it("wires input and context userId through to the shared handler", async () => {
     mockAccountService.getAccountsByUser.mockResolvedValue([]);
 
     const accountsTool = createGetAccountsTool(mockAccountService);
@@ -44,59 +43,5 @@ describe("createGetAccountsTool", () => {
       userId,
       EntityScope.ARCHIVED,
     );
-  });
-
-  it("returns required fields only", async () => {
-    const mockAccounts = [
-      fakeAccount({
-        userId,
-        name: "Checking Account",
-        currency: "USD",
-        isArchived: false,
-      }),
-      fakeAccount({
-        userId,
-        name: "Savings Account",
-        currency: "EUR",
-        isArchived: true,
-      }),
-    ];
-    mockAccountService.getAccountsByUser.mockResolvedValue(mockAccounts);
-
-    const accountsTool = createGetAccountsTool(mockAccountService);
-    const result = await accountsTool.invoke(
-      { scope: EntityScope.ALL },
-      { context: { userId } },
-    );
-
-    expect(result).toEqual({
-      success: true,
-      data: [
-        {
-          id: mockAccounts[0].id,
-          name: "Checking Account",
-          currency: "USD",
-          isArchived: false,
-        },
-        {
-          id: mockAccounts[1].id,
-          name: "Savings Account",
-          currency: "EUR",
-          isArchived: true,
-        },
-      ],
-    });
-  });
-
-  it("returns empty array when user has no accounts", async () => {
-    mockAccountService.getAccountsByUser.mockResolvedValue([]);
-
-    const accountsTool = createGetAccountsTool(mockAccountService);
-    const result = await accountsTool.invoke(
-      { scope: EntityScope.ALL },
-      { context: { userId } },
-    );
-
-    expect(result).toEqual({ success: true, data: [] });
   });
 });

--- a/backend/src/langchain/tools/get-accounts.ts
+++ b/backend/src/langchain/tools/get-accounts.ts
@@ -1,32 +1,27 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { AccountService } from "../../services/account-service";
-import { EntityScope } from "../../types/entity-scope";
-import { Success } from "../../types/result";
+import {
+  description,
+  getAccounts,
+  inputSchema,
+} from "../../tools/get-accounts";
 import { agentContextSchema } from "../agents/agent-context";
-import { toAccountDto } from "./account-dto";
 
-const schema = z.object({
-  scope: z
-    .enum(EntityScope)
-    .describe(
-      `Which accounts to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
-    ),
-});
+const schema = z.object(inputSchema);
 
 export const createGetAccountsTool = (accountService: AccountService) =>
   tool(
-    async ({ scope }, config) => {
+    async (input: z.infer<typeof schema>, config) => {
       const userId = agentContextSchema.shape.userId.parse(
         config?.context?.userId,
       );
-      const accounts = await accountService.getAccountsByUser(userId, scope);
 
-      return Success(accounts.map(toAccountDto));
+      return getAccounts(input, { accountService, userId });
     },
     {
       name: "get_accounts",
-      description: "Get user accounts filtered by scope.",
+      description,
       schema,
     },
   );

--- a/backend/src/langchain/tools/get-accounts.ts
+++ b/backend/src/langchain/tools/get-accounts.ts
@@ -1,11 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { AccountService } from "../../services/account-service";
-import {
-  description,
-  getAccounts,
-  inputSchema,
-} from "../../tools/get-accounts";
+import { description, handler, inputSchema } from "../../tools/get-accounts";
 import { agentContextSchema } from "../agents/agent-context";
 
 const schema = z.object(inputSchema);
@@ -17,7 +13,7 @@ export const createGetAccountsTool = (accountService: AccountService) =>
         config?.context?.userId,
       );
 
-      return getAccounts(input, { accountService, userId });
+      return handler(input, { accountService, userId });
     },
     {
       name: "get_accounts",

--- a/backend/src/langchain/tools/get-categories.ts
+++ b/backend/src/langchain/tools/get-categories.ts
@@ -2,25 +2,27 @@ import { tool } from "langchain";
 import { z } from "zod";
 import { TransactionRepository } from "../../ports/transaction-repository";
 import { CategoryService } from "../../services/category-service";
+import { CategoryDto } from "../../tools/category-dto";
+import {
+  description as baseDescription,
+  getCategories,
+  inputSchema,
+} from "../../tools/get-categories";
 import { toDateString } from "../../types/date";
-import { EntityScope } from "../../types/entity-scope";
 import { Success } from "../../types/result";
 import { daysAgo, formatDateAsYYYYMMDD } from "../../utils/date";
 import { agentContextSchema } from "../agents/agent-context";
-import { CategoryDto, toCategoryDto } from "./category-dto";
 
 type CategoryData = CategoryDto & { keywords: string[] };
 
 export const CATEGORY_HISTORY_LOOKBACK_DAYS = 90;
 export const CATEGORY_HISTORY_MAX_KEYWORDS_PER_CATEGORY = 10;
 
-const schema = z.object({
-  scope: z
-    .enum(EntityScope)
-    .describe(
-      `Which categories to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
-    ),
-});
+const schema = z.object(inputSchema);
+
+// Keyword enrichment has no MCP equivalent: external agents aren't wired
+// with a transactionRepository dependency, so this stays langchain-only.
+const description = `${baseDescription}\n- Each category includes keywords showing how similar transactions were previously categorised`;
 
 export const createGetCategoriesTool = ({
   categoryService,
@@ -30,25 +32,28 @@ export const createGetCategoriesTool = ({
   transactionRepository: TransactionRepository;
 }) =>
   tool(
-    async ({ scope }, config) => {
+    async ({ scope }: z.infer<typeof schema>, config) => {
       const userId = agentContextSchema.shape.userId.parse(
         config?.context?.userId,
       );
-      const filteredCategories = await categoryService.getCategoriesByUser(
-        userId,
+
+      const result = await getCategories(
         { scope },
+        { categoryService, userId },
       );
 
-      if (filteredCategories.length === 0) {
+      if (!result.success) {
+        return result;
+      }
+
+      if (result.data.length === 0) {
         return Success([]);
       }
 
-      const categoryDataList: CategoryData[] = filteredCategories.map(
-        (category) => ({
-          ...toCategoryDto(category),
-          keywords: [],
-        }),
-      );
+      const categoryDataList: CategoryData[] = result.data.map((category) => ({
+        ...category,
+        keywords: [],
+      }));
 
       // Enrich with recent transaction descriptions
       const today = new Date();
@@ -99,8 +104,7 @@ export const createGetCategoriesTool = ({
     },
     {
       name: "get_categories",
-      description:
-        "Get user categories filtered by scope. Each category includes keywords showing how similar transactions were previously categorised.",
+      description,
       schema,
     },
   );

--- a/backend/src/langchain/tools/get-categories.ts
+++ b/backend/src/langchain/tools/get-categories.ts
@@ -5,7 +5,7 @@ import { CategoryService } from "../../services/category-service";
 import { CategoryDto } from "../../tools/category-dto";
 import {
   description as baseDescription,
-  getCategories,
+  handler,
   inputSchema,
 } from "../../tools/get-categories";
 import { toDateString } from "../../types/date";
@@ -37,10 +37,7 @@ export const createGetCategoriesTool = ({
         config?.context?.userId,
       );
 
-      const result = await getCategories(
-        { scope },
-        { categoryService, userId },
-      );
+      const result = await handler({ scope }, { categoryService, userId });
 
       if (!result.success) {
         return result;

--- a/backend/src/langchain/tools/get-transactions.test.ts
+++ b/backend/src/langchain/tools/get-transactions.test.ts
@@ -1,11 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { TransactionType } from "../../models/transaction";
 import { TransactionRepository } from "../../ports/transaction-repository";
 import { toDateString } from "../../types/date";
-import { fakeTransaction } from "../../utils/test-utils/models/transaction-fakes";
 import { createMockTransactionRepository } from "../../utils/test-utils/repositories/transaction-repository-mocks";
-import { MAX_PERIOD_DAYS, createGetTransactionsTool } from "./get-transactions";
+import { createGetTransactionsTool } from "./get-transactions";
 
 describe("createGetTransactionsTool", () => {
   let mockTransactionRepository: Mocked<TransactionRepository>;
@@ -36,127 +34,7 @@ describe("createGetTransactionsTool", () => {
     ).rejects.toThrow();
   });
 
-  it("rejects when startDate is after endDate", async () => {
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    const result = await transactionsTool.invoke(
-      { startDate: "2000-01-20", endDate: "2000-01-10" },
-      { context: { userId } },
-    );
-
-    expect(mockTransactionRepository.findManyByUserId).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      success: false,
-      error: "startDate must not be after endDate",
-    });
-  });
-
-  it("rejects when date range exceeds max period days", async () => {
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    const result = await transactionsTool.invoke(
-      { startDate: "2000-01-01", endDate: "2001-01-02" },
-      { context: { userId } },
-    );
-
-    expect(mockTransactionRepository.findManyByUserId).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      success: false,
-      error: `Date range must not exceed ${MAX_PERIOD_DAYS} days`,
-    });
-  });
-
-  it("filters by date range and returns transactions as JSON", async () => {
-    const transactions = [fakeTransaction()];
-    mockTransactionRepository.findManyByUserId.mockResolvedValue(transactions);
-
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    const result = await transactionsTool.invoke(
-      { startDate: "2000-01-01", endDate: "2000-01-31" },
-      { context: { userId } },
-    );
-
-    expect(result.success).toBe(true);
-    expect(mockTransactionRepository.findManyByUserId).toHaveBeenCalledWith(
-      userId,
-      {
-        dateAfter: toDateString("2000-01-01"),
-        dateBefore: toDateString("2000-01-31"),
-      },
-    );
-  });
-
-  it("returns required fields only", async () => {
-    const transactions = [
-      fakeTransaction({
-        id: "transaction1",
-        accountId: "account1",
-        categoryId: "category1",
-        type: TransactionType.EXPENSE,
-        amount: 50,
-        currency: "USD",
-        date: toDateString("2024-01-15"),
-        description: "Grocery shopping",
-      }),
-      fakeTransaction({
-        id: "transaction2",
-        accountId: "account2",
-        categoryId: "category2",
-        type: TransactionType.INCOME,
-        amount: 1000,
-        currency: "USD",
-        date: toDateString("2024-01-20"),
-        description: "Salary",
-      }),
-    ];
-    mockTransactionRepository.findManyByUserId.mockResolvedValue(transactions);
-
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-    const result = await transactionsTool.invoke(
-      { startDate: "2024-01-01", endDate: "2024-01-31" },
-      { context: { userId } },
-    );
-
-    expect(result).toEqual({
-      success: true,
-      data: [
-        {
-          id: "transaction1",
-          accountId: "account1",
-          categoryId: "category1",
-          type: TransactionType.EXPENSE,
-          amount: 50,
-          currency: "USD",
-          date: toDateString("2024-01-15"),
-          description: "Grocery shopping",
-          transferId: undefined,
-        },
-        {
-          id: "transaction2",
-          accountId: "account2",
-          categoryId: "category2",
-          type: TransactionType.INCOME,
-          amount: 1000,
-          currency: "USD",
-          date: toDateString("2024-01-20"),
-          description: "Salary",
-          transferId: undefined,
-        },
-      ],
-    });
-  });
-
-  it("filters by accountIds", async () => {
-    const accountId = faker.string.uuid();
+  it("converts input dates and wires them through to the shared handler", async () => {
     mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
 
     const transactionsTool = createGetTransactionsTool({
@@ -164,11 +42,7 @@ describe("createGetTransactionsTool", () => {
     });
 
     await transactionsTool.invoke(
-      {
-        startDate: "2000-01-10",
-        endDate: "2000-01-20",
-        accountIds: [accountId],
-      },
+      { startDate: "2000-01-10", endDate: "2000-01-20" },
       { context: { userId } },
     );
 
@@ -177,90 +51,6 @@ describe("createGetTransactionsTool", () => {
       {
         dateAfter: toDateString("2000-01-10"),
         dateBefore: toDateString("2000-01-20"),
-        accountIds: [accountId],
-      },
-    );
-  });
-
-  it("filters by categoryIds", async () => {
-    const categoryId = faker.string.uuid();
-    mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
-
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    await transactionsTool.invoke(
-      {
-        startDate: "2000-01-10",
-        endDate: "2000-01-20",
-        categoryIds: [categoryId],
-      },
-      { context: { userId } },
-    );
-
-    expect(mockTransactionRepository.findManyByUserId).toHaveBeenCalledWith(
-      userId,
-      {
-        dateAfter: toDateString("2000-01-10"),
-        dateBefore: toDateString("2000-01-20"),
-        categoryIds: [categoryId],
-      },
-    );
-  });
-
-  it("filters by types", async () => {
-    const types = [TransactionType.EXPENSE, TransactionType.INCOME];
-    mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
-
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    await transactionsTool.invoke(
-      { startDate: "2000-01-10", endDate: "2000-01-20", types },
-      { context: { userId } },
-    );
-
-    expect(mockTransactionRepository.findManyByUserId).toHaveBeenCalledWith(
-      userId,
-      {
-        dateAfter: toDateString("2000-01-10"),
-        dateBefore: toDateString("2000-01-20"),
-        types,
-      },
-    );
-  });
-
-  it("filters by accountIds, categoryIds, and types", async () => {
-    const accountId = faker.string.uuid();
-    const categoryId = faker.string.uuid();
-    const types = [TransactionType.EXPENSE, TransactionType.INCOME];
-    mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
-
-    const transactionsTool = createGetTransactionsTool({
-      transactionRepository: mockTransactionRepository,
-    });
-
-    await transactionsTool.invoke(
-      {
-        startDate: "2000-01-10",
-        endDate: "2000-01-20",
-        accountIds: [accountId],
-        categoryIds: [categoryId],
-        types,
-      },
-      { context: { userId } },
-    );
-
-    expect(mockTransactionRepository.findManyByUserId).toHaveBeenCalledWith(
-      userId,
-      {
-        dateAfter: toDateString("2000-01-10"),
-        dateBefore: toDateString("2000-01-20"),
-        categoryIds: [categoryId],
-        accountIds: [accountId],
-        types,
       },
     );
   });

--- a/backend/src/langchain/tools/get-transactions.ts
+++ b/backend/src/langchain/tools/get-transactions.ts
@@ -1,41 +1,18 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { TransactionType } from "../../models/transaction";
 import { TransactionRepository } from "../../ports/transaction-repository";
+import {
+  MAX_PERIOD_DAYS,
+  description,
+  getTransactions,
+  inputSchema,
+} from "../../tools/get-transactions";
 import { toDateString } from "../../types/date";
-import { Failure, Success } from "../../types/result";
-import { daysBetween } from "../../utils/date";
 import { agentContextSchema } from "../agents/agent-context";
-import { toTransactionDto } from "./transaction-dto";
 
-export const MAX_PERIOD_DAYS = 365;
+export { MAX_PERIOD_DAYS };
 
-const schema = z.object({
-  startDate: z.iso
-    .date()
-    .describe(
-      "Start date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
-    ),
-  endDate: z.iso
-    .date()
-    .describe(
-      "End date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
-    ),
-  accountIds: z
-    .array(z.string())
-    .optional()
-    .describe("Account IDs to filter transactions by (one or more)"),
-  categoryIds: z
-    .array(z.string())
-    .optional()
-    .describe("Category IDs to filter transactions by (one or more)"),
-  types: z
-    .array(z.enum(TransactionType))
-    .optional()
-    .describe(
-      `Transaction types to filter by (${Object.values(TransactionType).join(", ")})`,
-    ),
-});
+const schema = z.object(inputSchema);
 
 export const createGetTransactionsTool = ({
   transactionRepository,
@@ -43,36 +20,34 @@ export const createGetTransactionsTool = ({
   transactionRepository: TransactionRepository;
 }) =>
   tool(
-    async ({ startDate, endDate, accountIds, categoryIds, types }, config) => {
+    async (
+      {
+        startDate,
+        endDate,
+        accountIds,
+        categoryIds,
+        types,
+      }: z.infer<typeof schema>,
+      config,
+    ) => {
       const userId = agentContextSchema.shape.userId.parse(
         config?.context?.userId,
       );
-      if (startDate > endDate) {
-        return Failure("startDate must not be after endDate");
-      }
 
-      if (
-        daysBetween(new Date(startDate), new Date(endDate)) > MAX_PERIOD_DAYS
-      ) {
-        return Failure(`Date range must not exceed ${MAX_PERIOD_DAYS} days`);
-      }
-
-      const transactions = await transactionRepository.findManyByUserId(
-        userId,
+      return getTransactions(
         {
-          dateAfter: toDateString(startDate),
-          dateBefore: toDateString(endDate),
-          ...(accountIds && { accountIds }),
-          ...(categoryIds && { categoryIds }),
-          ...(types !== undefined && { types }),
+          startDate: toDateString(startDate),
+          endDate: toDateString(endDate),
+          accountIds,
+          categoryIds,
+          types,
         },
+        { transactionRepository, userId },
       );
-
-      return Success(transactions.map(toTransactionDto));
     },
     {
       name: "get_transactions",
-      description: `Get filtered transactions by date range and optionally by one or more accountIds, one or more categoryIds, or one or more transaction types. Date format: YYYY-MM-DD. The date range must not exceed ${MAX_PERIOD_DAYS} days.`,
+      description,
       schema,
     },
   );

--- a/backend/src/langchain/tools/get-transactions.ts
+++ b/backend/src/langchain/tools/get-transactions.ts
@@ -4,7 +4,7 @@ import { TransactionRepository } from "../../ports/transaction-repository";
 import {
   MAX_PERIOD_DAYS,
   description,
-  getTransactions,
+  handler,
   inputSchema,
 } from "../../tools/get-transactions";
 import { toDateString } from "../../types/date";
@@ -34,7 +34,7 @@ export const createGetTransactionsTool = ({
         config?.context?.userId,
       );
 
-      return getTransactions(
+      return handler(
         {
           startDate: toDateString(startDate),
           endDate: toDateString(endDate),

--- a/backend/src/langchain/tools/update-account.test.ts
+++ b/backend/src/langchain/tools/update-account.test.ts
@@ -4,7 +4,6 @@ import { AccountService } from "../../services/account-service";
 import { BusinessError } from "../../services/business-error";
 import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
-import { toAccountDto } from "./account-dto";
 import { UpdateAccountInput, createUpdateAccountTool } from "./update-account";
 
 describe("createUpdateAccountTool", () => {
@@ -25,99 +24,28 @@ describe("createUpdateAccountTool", () => {
     expect(updateTool.name).toBe("update_account");
   });
 
-  // Happy path
-
-  it("updates the account name and returns the account", async () => {
+  it("wires input and context userId through to the shared handler", async () => {
     // Arrange
     const accountId = faker.string.uuid();
     const updated = fakeAccount({ id: accountId, name: "Renamed" });
 
-    // Service returns the updated account
     mockAccountService.updateAccount.mockResolvedValue(updated);
 
     const updateTool = createUpdateAccountTool({
       accountService: mockAccountService,
     });
 
-    const input: UpdateAccountInput = {
-      id: accountId,
-      name: "Renamed",
-    };
+    const input: UpdateAccountInput = { id: accountId, name: "Renamed" };
 
     // Act
     const result = await updateTool.invoke(input, { context: { userId } });
 
     // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toAccountDto(updated),
-    });
-
+    expect(result).toMatchObject({ success: true });
     expect(mockAccountService.updateAccount).toHaveBeenCalledWith(
       accountId,
       userId,
       { name: "Renamed" },
-    );
-  });
-
-  it("updates the account currency", async () => {
-    // Arrange
-    const accountId = faker.string.uuid();
-    const updated = fakeAccount({ id: accountId, currency: "EUR" });
-
-    // Service returns the updated account
-    mockAccountService.updateAccount.mockResolvedValue(updated);
-
-    const updateTool = createUpdateAccountTool({
-      accountService: mockAccountService,
-    });
-
-    const input: UpdateAccountInput = {
-      id: accountId,
-      currency: "EUR",
-    };
-
-    // Act
-    await updateTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(mockAccountService.updateAccount).toHaveBeenCalledWith(
-      accountId,
-      userId,
-      { currency: "EUR" },
-    );
-  });
-
-  it("updates both name and currency", async () => {
-    // Arrange
-    const accountId = faker.string.uuid();
-    const updated = fakeAccount({
-      id: accountId,
-      name: "Renamed",
-      currency: "EUR",
-    });
-
-    // Service returns the updated account
-    mockAccountService.updateAccount.mockResolvedValue(updated);
-
-    const updateTool = createUpdateAccountTool({
-      accountService: mockAccountService,
-    });
-
-    const input: UpdateAccountInput = {
-      id: accountId,
-      name: "Renamed",
-      currency: "EUR",
-    };
-
-    // Act
-    await updateTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(mockAccountService.updateAccount).toHaveBeenCalledWith(
-      accountId,
-      userId,
-      { name: "Renamed", currency: "EUR" },
     );
   });
 
@@ -163,14 +91,13 @@ describe("createUpdateAccountTool", () => {
 
   // Dependency failures
 
-  it("propagates BusinessError from the service unchanged", async () => {
+  it("returns failure when the shared handler catches a BusinessError", async () => {
     // Arrange
-    const error = new BusinessError(
-      "Cannot change currency for account that has existing transactions. Please create a new account with the desired currency instead.",
+    mockAccountService.updateAccount.mockRejectedValue(
+      new BusinessError(
+        "Cannot change currency for account that has existing transactions. Please create a new account with the desired currency instead.",
+      ),
     );
-
-    // Service rejects with a domain error
-    mockAccountService.updateAccount.mockRejectedValue(error);
 
     const updateTool = createUpdateAccountTool({
       accountService: mockAccountService,
@@ -181,9 +108,14 @@ describe("createUpdateAccountTool", () => {
       currency: "EUR",
     };
 
-    // Act & Assert
-    await expect(
-      updateTool.invoke(input, { context: { userId } }),
-    ).rejects.toBe(error);
+    // Act
+    const result = await updateTool.invoke(input, { context: { userId } });
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error:
+        "Cannot change currency for account that has existing transactions. Please create a new account with the desired currency instead.",
+    });
   });
 });

--- a/backend/src/langchain/tools/update-account.ts
+++ b/backend/src/langchain/tools/update-account.ts
@@ -1,38 +1,16 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { UpdateAccountInput as UpdateAccountServiceInput } from "../../models/account";
 import { AccountService } from "../../services/account-service";
-import { Success } from "../../types/result";
+import {
+  description,
+  inputSchema,
+  updateAccount,
+} from "../../tools/update-account";
 import { agentContextSchema } from "../agents/agent-context";
-import { toAccountDto } from "./account-dto";
 
-const schema = z
-  .object({
-    id: z.uuid().describe("Account ID to update"),
-    name: z.string().optional().describe("New account name"),
-    currency: z
-      .string()
-      .optional()
-      .describe(
-        "New account currency — any ISO 4217 code (e.g. USD, EUR, GBP).",
-      ),
-  })
-  .strict();
+const schema = z.object(inputSchema).strict();
 
 export type UpdateAccountInput = z.infer<typeof schema>;
-
-const description = `
-Update an existing account's name and/or currency.
-
-Before calling, check the user's existing active (non-archived) accounts
-to resolve the account id (never guess it or accept it from user input).
-If the requested new name is a semantic near-variant of another existing active account
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before updating.
-Archived accounts are not considered — reusing an archived account's name is not a duplicate.
-
-Changing an account's initial balance is not supported.
-`.trim();
 
 export const createUpdateAccountTool = ({
   accountService,
@@ -45,18 +23,7 @@ export const createUpdateAccountTool = ({
         config?.context?.userId,
       );
 
-      const serviceInput: UpdateAccountServiceInput = {
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.currency !== undefined && { currency: input.currency }),
-      };
-
-      const updated = await accountService.updateAccount(
-        input.id,
-        userId,
-        serviceInput,
-      );
-
-      return Success(toAccountDto(updated));
+      return updateAccount(input, { accountService, userId });
     },
     {
       name: "update_account",

--- a/backend/src/langchain/tools/update-account.ts
+++ b/backend/src/langchain/tools/update-account.ts
@@ -1,11 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { AccountService } from "../../services/account-service";
-import {
-  description,
-  inputSchema,
-  updateAccount,
-} from "../../tools/update-account";
+import { description, inputSchema, handler } from "../../tools/update-account";
 import { agentContextSchema } from "../agents/agent-context";
 
 const schema = z.object(inputSchema).strict();
@@ -23,7 +19,7 @@ export const createUpdateAccountTool = ({
         config?.context?.userId,
       );
 
-      return updateAccount(input, { accountService, userId });
+      return handler(input, { accountService, userId });
     },
     {
       name: "update_account",

--- a/backend/src/langchain/tools/update-category.test.ts
+++ b/backend/src/langchain/tools/update-category.test.ts
@@ -5,7 +5,6 @@ import { BusinessError } from "../../services/business-error";
 import { CategoryService } from "../../services/category-service";
 import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
 import { createMockCategoryService } from "../../utils/test-utils/services/category-service-mocks";
-import { toCategoryDto } from "./category-dto";
 import { createUpdateCategoryTool } from "./update-category";
 
 describe("createUpdateCategoryTool", () => {
@@ -26,113 +25,11 @@ describe("createUpdateCategoryTool", () => {
     expect(updateTool.name).toBe("update_category");
   });
 
-  // Happy path
-
-  it("updates category excludeFromReports", async () => {
+  it("wires input and context userId through to the shared handler", async () => {
     // Arrange
     const categoryId = faker.string.uuid();
     const updated = fakeCategory();
 
-    // Updates and returns category
-    mockCategoryService.updateCategory.mockResolvedValue(updated);
-
-    const updateTool = createUpdateCategoryTool({
-      categoryService: mockCategoryService,
-    });
-
-    const input = {
-      id: categoryId,
-      excludeFromReports: faker.datatype.boolean(),
-    };
-
-    // Act
-    const result = await updateTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(updated),
-    });
-
-    expect(mockCategoryService.updateCategory).toHaveBeenCalledWith(
-      categoryId,
-      userId,
-      { excludeFromReports: input.excludeFromReports },
-    );
-  });
-
-  it("updates category name", async () => {
-    // Arrange
-    const categoryId = faker.string.uuid();
-    const updated = fakeCategory();
-
-    // Updates and returns category
-    mockCategoryService.updateCategory.mockResolvedValue(updated);
-
-    const updateTool = createUpdateCategoryTool({
-      categoryService: mockCategoryService,
-    });
-
-    const input = {
-      id: categoryId,
-      name: "Renamed",
-    };
-
-    // Act
-    const result = await updateTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(updated),
-    });
-
-    expect(mockCategoryService.updateCategory).toHaveBeenCalledWith(
-      categoryId,
-      userId,
-      { name: "Renamed" },
-    );
-  });
-
-  it("updates category type", async () => {
-    // Arrange
-    const categoryId = faker.string.uuid();
-    const updated = fakeCategory();
-
-    // Updates and returns category
-    mockCategoryService.updateCategory.mockResolvedValue(updated);
-
-    const updateTool = createUpdateCategoryTool({
-      categoryService: mockCategoryService,
-    });
-
-    const input = {
-      id: categoryId,
-      type: CategoryType.INCOME,
-    };
-
-    // Act
-    const result = await updateTool.invoke(input, { context: { userId } });
-
-    // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(updated),
-    });
-
-    expect(mockCategoryService.updateCategory).toHaveBeenCalledWith(
-      categoryId,
-      userId,
-      { type: CategoryType.INCOME },
-    );
-  });
-
-  it("updates all fields at once", async () => {
-    // Arrange
-    const categoryId = faker.string.uuid();
-    const updated = fakeCategory();
-
-    // Updates and returns category
     mockCategoryService.updateCategory.mockResolvedValue(updated);
 
     const updateTool = createUpdateCategoryTool({
@@ -150,11 +47,7 @@ describe("createUpdateCategoryTool", () => {
     const result = await updateTool.invoke(input, { context: { userId } });
 
     // Assert
-    expect(result).toEqual({
-      success: true,
-      data: toCategoryDto(updated),
-    });
-
+    expect(result).toMatchObject({ success: true });
     expect(mockCategoryService.updateCategory).toHaveBeenCalledWith(
       categoryId,
       userId,
@@ -189,11 +82,11 @@ describe("createUpdateCategoryTool", () => {
 
   // Dependency failures
 
-  it("propagates BusinessError from the service unchanged", async () => {
+  it("returns failure when the shared handler catches a BusinessError", async () => {
     // Arrange
-    const error = new BusinessError('Category "Groceries" already exists');
-
-    mockCategoryService.updateCategory.mockRejectedValue(error);
+    mockCategoryService.updateCategory.mockRejectedValue(
+      new BusinessError('Category "Groceries" already exists'),
+    );
 
     const updateTool = createUpdateCategoryTool({
       categoryService: mockCategoryService,
@@ -204,9 +97,13 @@ describe("createUpdateCategoryTool", () => {
       name: "Groceries",
     };
 
-    // Act & Assert
-    await expect(
-      updateTool.invoke(input, { context: { userId } }),
-    ).rejects.toBe(error);
+    // Act
+    const result = await updateTool.invoke(input, { context: { userId } });
+
+    // Assert
+    expect(result).toEqual({
+      success: false,
+      error: 'Category "Groceries" already exists',
+    });
   });
 });

--- a/backend/src/langchain/tools/update-category.ts
+++ b/backend/src/langchain/tools/update-category.ts
@@ -1,46 +1,16 @@
 import { tool } from "langchain";
 import { z } from "zod";
-import { CategoryType } from "../../models/category";
-import { UpdateCategoryInput as UpdateCategoryServiceInput } from "../../ports/category-repository";
 import { CategoryService } from "../../services/category-service";
-import { Success } from "../../types/result";
+import {
+  description,
+  inputSchema,
+  updateCategory,
+} from "../../tools/update-category";
 import { agentContextSchema } from "../agents/agent-context";
-import { toCategoryDto } from "./category-dto";
 
-const schema = z
-  .object({
-    id: z.uuid().describe("Category ID to update"),
-    excludeFromReports: z
-      .boolean()
-      .optional()
-      .describe(
-        "New report-exclusion setting. Whether to exclude transactions in this category from financial reports.",
-      ),
-    name: z.string().optional().describe("New category name"),
-    type: z
-      .enum(CategoryType)
-      .optional()
-      .describe(
-        `New category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
-      ),
-  })
-  .strict();
+const schema = z.object(inputSchema).strict();
 
 export type UpdateCategoryInput = z.infer<typeof schema>;
-
-const description = `
-Update an existing category's name, type, and/or report-exclusion setting.
-
-Before calling, check the user's existing active (non-archived) categories
-to resolve the category id (never guess it or accept it from user input).
-If the requested new name is a semantic near-variant of another existing active category
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before updating.
-Archived categories are not considered — reusing an archived category's name is not a duplicate.
-
-Set excludeFromReports to control whether transactions in this category
-are excluded from financial reports and spending/income calculations.
-`.trim();
 
 export const createUpdateCategoryTool = ({
   categoryService,
@@ -53,21 +23,7 @@ export const createUpdateCategoryTool = ({
         config?.context?.userId,
       );
 
-      const serviceInput: UpdateCategoryServiceInput = {
-        ...(input.excludeFromReports !== undefined && {
-          excludeFromReports: input.excludeFromReports,
-        }),
-        ...(input.name !== undefined && { name: input.name }),
-        ...(input.type !== undefined && { type: input.type }),
-      };
-
-      const updated = await categoryService.updateCategory(
-        input.id,
-        userId,
-        serviceInput,
-      );
-
-      return Success(toCategoryDto(updated));
+      return updateCategory(input, { categoryService, userId });
     },
     {
       name: "update_category",

--- a/backend/src/langchain/tools/update-category.ts
+++ b/backend/src/langchain/tools/update-category.ts
@@ -1,11 +1,7 @@
 import { tool } from "langchain";
 import { z } from "zod";
 import { CategoryService } from "../../services/category-service";
-import {
-  description,
-  inputSchema,
-  updateCategory,
-} from "../../tools/update-category";
+import { description, inputSchema, handler } from "../../tools/update-category";
 import { agentContextSchema } from "../agents/agent-context";
 
 const schema = z.object(inputSchema).strict();
@@ -23,7 +19,7 @@ export const createUpdateCategoryTool = ({
         config?.context?.userId,
       );
 
-      return updateCategory(input, { categoryService, userId });
+      return handler(input, { categoryService, userId });
     },
     {
       name: "update_category",

--- a/backend/src/mcp/tools/create-account.ts
+++ b/backend/src/mcp/tools/create-account.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AccountService } from "../../services/account-service";
-import {
-  createAccount,
-  description,
-  inputSchema,
-} from "../../tools/create-account";
+import { handler, description, inputSchema } from "../../tools/create-account";
 import { toToolResult } from "./to-tool-result";
 
 export function registerCreateAccountTool(
@@ -14,6 +10,6 @@ export function registerCreateAccountTool(
   server.registerTool(
     "create_account",
     { description, inputSchema },
-    async (input) => toToolResult(await createAccount(input, deps)),
+    async (input) => toToolResult(await handler(input, deps)),
   );
 }

--- a/backend/src/mcp/tools/create-account.ts
+++ b/backend/src/mcp/tools/create-account.ts
@@ -1,65 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { AccountDto, toAccountDto } from "../../langchain/tools/account-dto";
 import { AccountService } from "../../services/account-service";
-import { Failure, Result, Success } from "../../types/result";
+import {
+  createAccount,
+  description,
+  inputSchema,
+} from "../../tools/create-account";
 import { toToolResult } from "./to-tool-result";
-
-export async function createAccount(
-  {
-    name,
-    currency,
-    initialBalance,
-  }: { name: string; currency: string; initialBalance?: number },
-  {
-    accountService,
-    userId,
-  }: {
-    accountService: AccountService;
-    userId: string;
-  },
-): Promise<Result<AccountDto & { initialBalance: number }>> {
-  try {
-    const created = await accountService.createAccount({
-      userId,
-      name,
-      currency,
-      initialBalance: initialBalance ?? 0,
-    });
-
-    return Success({
-      ...toAccountDto(created),
-      initialBalance: created.initialBalance,
-    });
-  } catch (error) {
-    if (error instanceof Error) {
-      return Failure(error.message);
-    }
-    throw error;
-  }
-}
-
-const inputSchema = {
-  name: z.string().describe("Account name"),
-  currency: z
-    .string()
-    .describe("Account currency — any ISO 4217 code (e.g. USD, EUR, GBP)."),
-  initialBalance: z
-    .number()
-    .optional()
-    .describe(
-      "Initial balance of the account. Omit to start the account at zero.",
-    ),
-};
-
-const description = `
-Create a new account for the user.
-
-Account is a place where money is stored.
-
-- Fails if an active (non-archived) account with the same name already exists
-- Archived accounts are not considered duplicates
-`.trim();
 
 export function registerCreateAccountTool(
   server: McpServer,

--- a/backend/src/mcp/tools/create-category.ts
+++ b/backend/src/mcp/tools/create-category.ts
@@ -1,71 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { CategoryDto, toCategoryDto } from "../../langchain/tools/category-dto";
-import { CategoryType } from "../../models/category";
 import { CategoryService } from "../../services/category-service";
-import { Failure, Result, Success } from "../../types/result";
+import {
+  createCategory,
+  description,
+  inputSchema,
+} from "../../tools/create-category";
 import { toToolResult } from "./to-tool-result";
-
-export async function createCategory(
-  {
-    name,
-    type,
-    excludeFromReports,
-  }: { name: string; type: CategoryType; excludeFromReports?: boolean },
-  {
-    categoryService,
-    userId,
-  }: {
-    categoryService: CategoryService;
-    userId: string;
-  },
-): Promise<Result<CategoryDto>> {
-  try {
-    const created = await categoryService.createCategory({
-      userId,
-      name,
-      type,
-      excludeFromReports: excludeFromReports ?? false,
-    });
-
-    return Success(toCategoryDto(created));
-  } catch (error) {
-    if (error instanceof Error) {
-      return Failure(error.message);
-    }
-    throw error;
-  }
-}
-
-const inputSchema = {
-  name: z.string().describe("Category name"),
-  type: z
-    .enum(CategoryType)
-    .describe(
-      `Category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
-    ),
-  excludeFromReports: z
-    .boolean()
-    .optional()
-    .describe(
-      "Whether to exclude transactions in this category from financial reports. Defaults to false.",
-    ),
-};
-
-const description = `
-Create a new category for the user.
-
-Category is a classification system for transactions.
-
-Before calling, check the user's existing active (non-archived) categories.
-If the requested name is a semantic near-variant of an existing active one
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before creating.
-Archived categories are not considered — reusing an archived category's name is not a duplicate.
-
-Set excludeFromReports to true if the user wants transactions in this category
-excluded from financial reports and spending/income calculations.
-`.trim();
 
 export function registerCreateCategoryTool(
   server: McpServer,

--- a/backend/src/mcp/tools/create-category.ts
+++ b/backend/src/mcp/tools/create-category.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CategoryService } from "../../services/category-service";
-import {
-  createCategory,
-  description,
-  inputSchema,
-} from "../../tools/create-category";
+import { handler, description, inputSchema } from "../../tools/create-category";
 import { toToolResult } from "./to-tool-result";
 
 export function registerCreateCategoryTool(
@@ -14,6 +10,6 @@ export function registerCreateCategoryTool(
   server.registerTool(
     "create_category",
     { description, inputSchema },
-    async (input) => toToolResult(await createCategory(input, deps)),
+    async (input) => toToolResult(await handler(input, deps)),
   );
 }

--- a/backend/src/mcp/tools/create-transaction.ts
+++ b/backend/src/mcp/tools/create-transaction.ts
@@ -1,72 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
+import { TransactionService } from "../../services/transaction-service";
 import {
-  TransactionDto,
-  toTransactionDto,
-} from "../../langchain/tools/transaction-dto";
-import { TransactionType } from "../../models/transaction";
-import {
-  CreateTransactionServiceInput,
-  TransactionService,
-} from "../../services/transaction-service";
-import { toDateString } from "../../types/date";
-import { Failure, Result, Success } from "../../types/result";
+  createTransaction,
+  description,
+  inputSchema,
+} from "../../tools/create-transaction";
 import { toToolResult } from "./to-tool-result";
-
-export async function createTransaction(
-  input: CreateTransactionServiceInput,
-  {
-    transactionService,
-    userId,
-  }: {
-    transactionService: TransactionService;
-    userId: string;
-  },
-): Promise<Result<TransactionDto>> {
-  try {
-    const created = await transactionService.createTransaction(input, userId);
-
-    return Success(toTransactionDto(created));
-  } catch (error) {
-    if (error instanceof Error) {
-      return Failure(error.message);
-    }
-    throw error;
-  }
-}
-
-const inputSchema = {
-  accountId: z.uuid().describe("Account ID to associate the transaction with"),
-  amount: z.number().positive().describe("Transaction amount"),
-  categoryId: z
-    .uuid()
-    .optional()
-    .describe("Category ID to associate the transaction with"),
-  date: z.iso
-    .date()
-    .transform(toDateString)
-    .describe("Transaction date in YYYY-MM-DD format"),
-  description: z
-    .string()
-    .max(500)
-    .optional()
-    .describe("Short transaction description"),
-  type: z
-    .enum([
-      TransactionType.INCOME,
-      TransactionType.EXPENSE,
-      TransactionType.REFUND,
-    ])
-    .describe("Transaction type"),
-};
-
-const description = `
-Create a new transaction.
-
-- Currency is inherited from the account, not specified separately
-- Only ${TransactionType.INCOME}, ${TransactionType.EXPENSE}, and ${TransactionType.REFUND} can be created here
-- Transfers are not supported by this tool
-`.trim();
 
 export function registerCreateTransactionTool(
   server: McpServer,

--- a/backend/src/mcp/tools/create-transaction.ts
+++ b/backend/src/mcp/tools/create-transaction.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TransactionService } from "../../services/transaction-service";
 import {
-  createTransaction,
+  handler,
   description,
   inputSchema,
 } from "../../tools/create-transaction";
@@ -14,6 +14,6 @@ export function registerCreateTransactionTool(
   server.registerTool(
     "create_transaction",
     { description, inputSchema },
-    async (input) => toToolResult(await createTransaction(input, deps)),
+    async (input) => toToolResult(await handler(input, deps)),
   );
 }

--- a/backend/src/mcp/tools/get-accounts.ts
+++ b/backend/src/mcp/tools/get-accounts.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AccountService } from "../../services/account-service";
-import {
-  description,
-  getAccounts,
-  inputSchema,
-} from "../../tools/get-accounts";
+import { description, handler, inputSchema } from "../../tools/get-accounts";
 import { toToolResult } from "./to-tool-result";
 
 export function registerGetAccountsTool(
@@ -14,6 +10,6 @@ export function registerGetAccountsTool(
   server.registerTool(
     "get_accounts",
     { description, inputSchema },
-    async ({ scope }) => toToolResult(await getAccounts({ scope }, deps)),
+    async ({ scope }) => toToolResult(await handler({ scope }, deps)),
   );
 }

--- a/backend/src/mcp/tools/get-accounts.ts
+++ b/backend/src/mcp/tools/get-accounts.ts
@@ -1,43 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { AccountDto, toAccountDto } from "../../langchain/tools/account-dto";
 import { AccountService } from "../../services/account-service";
-import { EntityScope } from "../../types/entity-scope";
-import { Result, Success } from "../../types/result";
+import {
+  description,
+  getAccounts,
+  inputSchema,
+} from "../../tools/get-accounts";
 import { toToolResult } from "./to-tool-result";
-
-export async function getAccounts(
-  { scope }: { scope: EntityScope },
-  {
-    accountService,
-    userId,
-  }: {
-    accountService: AccountService;
-    userId: string;
-  },
-): Promise<Result<AccountDto[]>> {
-  const accounts = await accountService.getAccountsByUser(userId, scope);
-
-  return Success(accounts.map(toAccountDto));
-}
-
-const inputSchema = {
-  scope: z
-    .enum(EntityScope)
-    .describe(
-      `Which accounts to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
-    ),
-};
-
-const description = `
-Get user accounts filtered by scope.
-
-Account is a place where money is stored.
-
-- The user can have multiple accounts
-- Each account has a name, a currency, and an archived flag
-- Include archived accounts for historical queries
-`.trim();
 
 export function registerGetAccountsTool(
   server: McpServer,

--- a/backend/src/mcp/tools/get-categories.ts
+++ b/backend/src/mcp/tools/get-categories.ts
@@ -1,47 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { CategoryDto, toCategoryDto } from "../../langchain/tools/category-dto";
 import { CategoryService } from "../../services/category-service";
-import { EntityScope } from "../../types/entity-scope";
-import { Result, Success } from "../../types/result";
+import {
+  description,
+  getCategories,
+  inputSchema,
+} from "../../tools/get-categories";
 import { toToolResult } from "./to-tool-result";
-
-export async function getCategories(
-  { scope }: { scope: EntityScope },
-  {
-    categoryService,
-    userId,
-  }: {
-    categoryService: CategoryService;
-    userId: string;
-  },
-): Promise<Result<CategoryDto[]>> {
-  const categories = await categoryService.getCategoriesByUser(userId, {
-    scope,
-  });
-
-  return Success(categories.map(toCategoryDto));
-}
-
-const inputSchema = {
-  scope: z
-    .enum(EntityScope)
-    .describe(
-      `Which categories to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
-    ),
-};
-
-const description = `
-Get user categories filtered by scope.
-
-Category is a classification system for transactions.
-
-- The user can have multiple categories
-- Each category has a name, a type (INCOME, EXPENSE), and an archived flag
-- Include archived categories for historical queries
-- A category can be marked to exclude its transactions from financial reports
-- Report-excluded categories should not count towards spending or income totals
-`.trim();
 
 export function registerGetCategoriesTool(
   server: McpServer,

--- a/backend/src/mcp/tools/get-categories.ts
+++ b/backend/src/mcp/tools/get-categories.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CategoryService } from "../../services/category-service";
-import {
-  description,
-  getCategories,
-  inputSchema,
-} from "../../tools/get-categories";
+import { description, handler, inputSchema } from "../../tools/get-categories";
 import { toToolResult } from "./to-tool-result";
 
 export function registerGetCategoriesTool(
@@ -14,6 +10,6 @@ export function registerGetCategoriesTool(
   server.registerTool(
     "get_categories",
     { description, inputSchema },
-    async ({ scope }) => toToolResult(await getCategories({ scope }, deps)),
+    async ({ scope }) => toToolResult(await handler({ scope }, deps)),
   );
 }

--- a/backend/src/mcp/tools/get-transactions.ts
+++ b/backend/src/mcp/tools/get-transactions.ts
@@ -1,107 +1,12 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import {
-  TransactionDto,
-  toTransactionDto,
-} from "../../langchain/tools/transaction-dto";
-import { TransactionType } from "../../models/transaction";
 import { TransactionRepository } from "../../ports/transaction-repository";
-import { DateString, toDateString } from "../../types/date";
-import { Failure, Result, Success } from "../../types/result";
-import { daysBetween } from "../../utils/date";
+import {
+  description,
+  getTransactions,
+  inputSchema,
+} from "../../tools/get-transactions";
+import { toDateString } from "../../types/date";
 import { toToolResult } from "./to-tool-result";
-
-export const MAX_PERIOD_DAYS = 365;
-
-export async function getTransactions(
-  {
-    startDate,
-    endDate,
-    accountIds,
-    categoryIds,
-    types,
-  }: {
-    startDate: DateString;
-    endDate: DateString;
-    accountIds?: string[];
-    categoryIds?: string[];
-    types?: TransactionType[];
-  },
-  {
-    transactionRepository,
-    userId,
-  }: {
-    transactionRepository: TransactionRepository;
-    userId: string;
-  },
-): Promise<Result<TransactionDto[]>> {
-  if (startDate > endDate) {
-    return Failure("startDate must not be after endDate");
-  }
-
-  if (daysBetween(new Date(startDate), new Date(endDate)) > MAX_PERIOD_DAYS) {
-    return Failure(`Date range must not exceed ${MAX_PERIOD_DAYS} days`);
-  }
-
-  const transactions = await transactionRepository.findManyByUserId(userId, {
-    dateAfter: startDate,
-    dateBefore: endDate,
-    ...(accountIds && { accountIds }),
-    ...(categoryIds && { categoryIds }),
-    ...(types !== undefined && { types }),
-  });
-
-  return Success(transactions.map(toTransactionDto));
-}
-
-const typesString = Object.values(TransactionType).join(", ");
-
-const inputSchema = {
-  startDate: z.iso
-    .date()
-    .describe(
-      "Start date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
-    ),
-  endDate: z.iso
-    .date()
-    .describe(
-      "End date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
-    ),
-  accountIds: z
-    .array(z.string())
-    .optional()
-    .describe("Account IDs to filter transactions by (one or more)"),
-  categoryIds: z
-    .array(z.string())
-    .optional()
-    .describe("Category IDs to filter transactions by (one or more)"),
-  types: z
-    .array(z.enum(TransactionType))
-    .optional()
-    .describe(`Transaction types to filter by (${typesString})`),
-};
-
-const description = `
-Get user transactions filtered by date range and optionally
-by one or more accountIds,
-one or more categoryIds,
-or one or more transaction types.
-The given date range must not exceed ${MAX_PERIOD_DAYS} days.
-
-Transaction is a record of a money movement.
-
-- The user can spend, receive, refund, or transfer money
-- Each transaction MUST have a type (${typesString})
-  - EXPENSE increases spending
-  - REFUND decreases spending in the same category
-  - INCOME and all TRANSFER types never affect spending
-- Each transaction MUST belong to exactly one account
-- Each transaction MUST have an amount, a currency, and a date
-
-A transaction can optionally:
-  - belong to a category
-  - have a description
-`.trim();
 
 export function registerGetTransactionsTool(
   server: McpServer,

--- a/backend/src/mcp/tools/get-transactions.ts
+++ b/backend/src/mcp/tools/get-transactions.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { TransactionRepository } from "../../ports/transaction-repository";
 import {
   description,
-  getTransactions,
+  handler,
   inputSchema,
 } from "../../tools/get-transactions";
 import { toDateString } from "../../types/date";
@@ -20,7 +20,7 @@ export function registerGetTransactionsTool(
     },
     async ({ startDate, endDate, accountIds, categoryIds, types }) =>
       toToolResult(
-        await getTransactions(
+        await handler(
           {
             startDate: toDateString(startDate),
             endDate: toDateString(endDate),

--- a/backend/src/mcp/tools/update-account.ts
+++ b/backend/src/mcp/tools/update-account.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AccountService } from "../../services/account-service";
-import {
-  description,
-  inputSchema,
-  updateAccount,
-} from "../../tools/update-account";
+import { description, inputSchema, handler } from "../../tools/update-account";
 import { toToolResult } from "./to-tool-result";
 
 export function registerUpdateAccountTool(
@@ -14,6 +10,6 @@ export function registerUpdateAccountTool(
   server.registerTool(
     "update_account",
     { description, inputSchema },
-    async (input) => toToolResult(await updateAccount(input, deps)),
+    async (input) => toToolResult(await handler(input, deps)),
   );
 }

--- a/backend/src/mcp/tools/update-account.ts
+++ b/backend/src/mcp/tools/update-account.ts
@@ -1,55 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { AccountDto, toAccountDto } from "../../langchain/tools/account-dto";
-import { UpdateAccountInput } from "../../models/account";
 import { AccountService } from "../../services/account-service";
-import { Failure, Result, Success } from "../../types/result";
+import {
+  description,
+  inputSchema,
+  updateAccount,
+} from "../../tools/update-account";
 import { toToolResult } from "./to-tool-result";
-
-export async function updateAccount(
-  { id, name, currency }: { id: string; name?: string; currency?: string },
-  {
-    accountService,
-    userId,
-  }: {
-    accountService: AccountService;
-    userId: string;
-  },
-): Promise<Result<AccountDto>> {
-  try {
-    const input: UpdateAccountInput = {
-      ...(name !== undefined && { name }),
-      ...(currency !== undefined && { currency }),
-    };
-
-    const updated = await accountService.updateAccount(id, userId, input);
-
-    return Success(toAccountDto(updated));
-  } catch (error) {
-    if (error instanceof Error) {
-      return Failure(error.message);
-    }
-    throw error;
-  }
-}
-
-const inputSchema = {
-  id: z.uuid().describe("Account ID to update"),
-  name: z.string().optional().describe("New account name"),
-  currency: z
-    .string()
-    .optional()
-    .describe("New account currency — any ISO 4217 code (e.g. USD, EUR, GBP)."),
-};
-
-const description = `
-Update an existing account's name and/or currency.
-
-- Only the supplied fields are changed
-- Fails if an active (non-archived) account with the same name already exists
-- Fails if changing currency on an account that already has transactions
-- Changing an account's initial balance is not supported by this tool
-`.trim();
 
 export function registerUpdateAccountTool(
   server: McpServer,

--- a/backend/src/mcp/tools/update-category.ts
+++ b/backend/src/mcp/tools/update-category.ts
@@ -1,80 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
-import { CategoryDto, toCategoryDto } from "../../langchain/tools/category-dto";
-import { CategoryType } from "../../models/category";
-import { UpdateCategoryInput } from "../../ports/category-repository";
 import { CategoryService } from "../../services/category-service";
-import { Failure, Result, Success } from "../../types/result";
+import {
+  description,
+  inputSchema,
+  updateCategory,
+} from "../../tools/update-category";
 import { toToolResult } from "./to-tool-result";
-
-export async function updateCategory(
-  {
-    id,
-    name,
-    type,
-    excludeFromReports,
-  }: {
-    id: string;
-    name?: string;
-    type?: CategoryType;
-    excludeFromReports?: boolean;
-  },
-  {
-    categoryService,
-    userId,
-  }: {
-    categoryService: CategoryService;
-    userId: string;
-  },
-): Promise<Result<CategoryDto>> {
-  try {
-    const input: UpdateCategoryInput = {
-      ...(name !== undefined && { name }),
-      ...(type !== undefined && { type }),
-      ...(excludeFromReports !== undefined && { excludeFromReports }),
-    };
-
-    const updated = await categoryService.updateCategory(id, userId, input);
-
-    return Success(toCategoryDto(updated));
-  } catch (error) {
-    if (error instanceof Error) {
-      return Failure(error.message);
-    }
-    throw error;
-  }
-}
-
-const inputSchema = {
-  id: z.uuid().describe("Category ID to update"),
-  name: z.string().optional().describe("New category name"),
-  type: z
-    .enum(CategoryType)
-    .optional()
-    .describe(
-      `New category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
-    ),
-  excludeFromReports: z
-    .boolean()
-    .optional()
-    .describe(
-      "New report-exclusion setting. Whether to exclude transactions in this category from financial reports.",
-    ),
-};
-
-const description = `
-Update an existing category's name, type, and/or report-exclusion setting.
-
-Before calling, check the user's existing active (non-archived) categories
-to resolve the category id (never guess it or accept it from user input).
-If the requested new name is a semantic near-variant of another existing active category
-(pluralisation, typo, abbreviation, or synonym)
-ask the user to confirm before updating.
-Archived categories are not considered — reusing an archived category's name is not a duplicate.
-
-Set excludeFromReports to control whether transactions in this category
-are excluded from financial reports and spending/income calculations.
-`.trim();
 
 export function registerUpdateCategoryTool(
   server: McpServer,

--- a/backend/src/mcp/tools/update-category.ts
+++ b/backend/src/mcp/tools/update-category.ts
@@ -1,10 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CategoryService } from "../../services/category-service";
-import {
-  description,
-  inputSchema,
-  updateCategory,
-} from "../../tools/update-category";
+import { description, inputSchema, handler } from "../../tools/update-category";
 import { toToolResult } from "./to-tool-result";
 
 export function registerUpdateCategoryTool(
@@ -14,6 +10,6 @@ export function registerUpdateCategoryTool(
   server.registerTool(
     "update_category",
     { description, inputSchema },
-    async (input) => toToolResult(await updateCategory(input, deps)),
+    async (input) => toToolResult(await handler(input, deps)),
   );
 }

--- a/backend/src/tools/account-dto.test.ts
+++ b/backend/src/tools/account-dto.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { toAccountDto } from "./account-dto";
 
 describe("toAccountDto", () => {

--- a/backend/src/tools/account-dto.ts
+++ b/backend/src/tools/account-dto.ts
@@ -1,4 +1,4 @@
-import { Account } from "../../models/account";
+import { Account } from "../models/account";
 
 export interface AccountDto {
   currency: string;

--- a/backend/src/tools/category-dto.test.ts
+++ b/backend/src/tools/category-dto.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { toCategoryDto } from "./category-dto";
 
 describe("toCategoryDto", () => {

--- a/backend/src/tools/category-dto.ts
+++ b/backend/src/tools/category-dto.ts
@@ -1,4 +1,4 @@
-import { Category, CategoryType } from "../../models/category";
+import { Category, CategoryType } from "../models/category";
 
 export interface CategoryDto {
   excludeFromReports: boolean;

--- a/backend/src/tools/create-account.test.ts
+++ b/backend/src/tools/create-account.test.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { AccountService } from "../../services/account-service";
-import { BusinessError } from "../../services/business-error";
-import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
-import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
+import { AccountService } from "../services/account-service";
+import { BusinessError } from "../services/business-error";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
+import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
 import { createAccount } from "./create-account";
 
 describe("createAccount", () => {

--- a/backend/src/tools/create-account.test.ts
+++ b/backend/src/tools/create-account.test.ts
@@ -4,7 +4,7 @@ import { AccountService } from "../services/account-service";
 import { BusinessError } from "../services/business-error";
 import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
-import { createAccount } from "./create-account";
+import { handler } from "./create-account";
 
 describe("createAccount", () => {
   let mockAccountService: Mocked<AccountService>;
@@ -30,7 +30,7 @@ describe("createAccount", () => {
     mockAccountService.createAccount.mockResolvedValue(created);
 
     // Act
-    const result = await createAccount(
+    const result = await handler(
       { name: "Checking Account", currency: "USD", initialBalance: 500 },
       deps,
     );
@@ -61,7 +61,7 @@ describe("createAccount", () => {
     mockAccountService.createAccount.mockResolvedValue(created);
 
     // Act
-    await createAccount({ name: "Savings", currency: "EUR" }, deps);
+    await handler({ name: "Savings", currency: "EUR" }, deps);
 
     // Assert
     expect(mockAccountService.createAccount).toHaveBeenCalledWith({
@@ -82,10 +82,7 @@ describe("createAccount", () => {
     );
 
     // Act
-    const result = await createAccount(
-      { name: "Savings", currency: "EUR" },
-      deps,
-    );
+    const result = await handler({ name: "Savings", currency: "EUR" }, deps);
 
     // Assert
     expect(result).toEqual({

--- a/backend/src/tools/create-account.ts
+++ b/backend/src/tools/create-account.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
+import { ModelError } from "../models/model-error";
 import { AccountService } from "../services/account-service";
+import { BusinessError } from "../services/business-error";
 import { Failure, Result, Success } from "../types/result";
 import { AccountDto, toAccountDto } from "./account-dto";
 
@@ -30,7 +32,7 @@ export async function createAccount(
       initialBalance: created.initialBalance,
     });
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof BusinessError || error instanceof ModelError) {
       return Failure(error.message);
     }
     throw error;

--- a/backend/src/tools/create-account.ts
+++ b/backend/src/tools/create-account.ts
@@ -62,6 +62,4 @@ If the requested name is a semantic near-variant of an existing active one
 (pluralisation, typo, abbreviation, or synonym)
 ask the user to confirm before creating.
 Archived accounts are not considered — reusing an archived account's name is not a duplicate.
-
-- Fails if an active (non-archived) account with the same name already exists
 `.trim();

--- a/backend/src/tools/create-account.ts
+++ b/backend/src/tools/create-account.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { AccountService } from "../services/account-service";
+import { Failure, Result, Success } from "../types/result";
+import { AccountDto, toAccountDto } from "./account-dto";
+
+export async function createAccount(
+  {
+    name,
+    currency,
+    initialBalance,
+  }: { name: string; currency: string; initialBalance?: number },
+  {
+    accountService,
+    userId,
+  }: {
+    accountService: AccountService;
+    userId: string;
+  },
+): Promise<Result<AccountDto & { initialBalance: number }>> {
+  try {
+    const created = await accountService.createAccount({
+      userId,
+      name,
+      currency,
+      initialBalance: initialBalance ?? 0,
+    });
+
+    return Success({
+      ...toAccountDto(created),
+      initialBalance: created.initialBalance,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      return Failure(error.message);
+    }
+    throw error;
+  }
+}
+
+export const inputSchema = {
+  name: z.string().describe("Account name"),
+  currency: z
+    .string()
+    .describe("Account currency — any ISO 4217 code (e.g. USD, EUR, GBP)."),
+  initialBalance: z
+    .number()
+    .optional()
+    .describe(
+      "Initial balance of the account. Omit when the user did not state one; the account will start at zero.",
+    ),
+};
+
+export const description = `
+Create a new account for the user.
+
+Account is a place where money is stored.
+
+Before calling, check the user's existing active (non-archived) accounts.
+If the requested name is a semantic near-variant of an existing active one
+(pluralisation, typo, abbreviation, or synonym)
+ask the user to confirm before creating.
+Archived accounts are not considered — reusing an archived account's name is not a duplicate.
+
+- Fails if an active (non-archived) account with the same name already exists
+`.trim();

--- a/backend/src/tools/create-account.ts
+++ b/backend/src/tools/create-account.ts
@@ -5,7 +5,7 @@ import { BusinessError } from "../services/business-error";
 import { Failure, Result, Success } from "../types/result";
 import { AccountDto, toAccountDto } from "./account-dto";
 
-export async function createAccount(
+export async function handler(
   {
     name,
     currency,

--- a/backend/src/tools/create-category.test.ts
+++ b/backend/src/tools/create-category.test.ts
@@ -5,7 +5,7 @@ import { BusinessError } from "../services/business-error";
 import { CategoryService } from "../services/category-service";
 import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
-import { createCategory } from "./create-category";
+import { handler } from "./create-category";
 
 describe("createCategory", () => {
   let mockCategoryService: Mocked<CategoryService>;
@@ -31,7 +31,7 @@ describe("createCategory", () => {
     mockCategoryService.createCategory.mockResolvedValue(created);
 
     // Act
-    const result = await createCategory(
+    const result = await handler(
       {
         name: "Groceries",
         type: CategoryType.EXPENSE,
@@ -66,7 +66,7 @@ describe("createCategory", () => {
     mockCategoryService.createCategory.mockResolvedValue(created);
 
     // Act
-    await createCategory({ name: "Salary", type: CategoryType.INCOME }, deps);
+    await handler({ name: "Salary", type: CategoryType.INCOME }, deps);
 
     // Assert
     expect(mockCategoryService.createCategory).toHaveBeenCalledWith({
@@ -87,7 +87,7 @@ describe("createCategory", () => {
     );
 
     // Act
-    const result = await createCategory(
+    const result = await handler(
       { name: "Salary", type: CategoryType.INCOME },
       deps,
     );

--- a/backend/src/tools/create-category.test.ts
+++ b/backend/src/tools/create-category.test.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { CategoryType } from "../../models/category";
-import { BusinessError } from "../../services/business-error";
-import { CategoryService } from "../../services/category-service";
-import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
-import { createMockCategoryService } from "../../utils/test-utils/services/category-service-mocks";
+import { CategoryType } from "../models/category";
+import { BusinessError } from "../services/business-error";
+import { CategoryService } from "../services/category-service";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
+import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
 import { createCategory } from "./create-category";
 
 describe("createCategory", () => {

--- a/backend/src/tools/create-category.ts
+++ b/backend/src/tools/create-category.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 import { CategoryType } from "../models/category";
+import { ModelError } from "../models/model-error";
+import { BusinessError } from "../services/business-error";
 import { CategoryService } from "../services/category-service";
 import { Failure, Result, Success } from "../types/result";
 import { CategoryDto, toCategoryDto } from "./category-dto";
@@ -28,7 +30,7 @@ export async function createCategory(
 
     return Success(toCategoryDto(created));
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof BusinessError || error instanceof ModelError) {
       return Failure(error.message);
     }
     throw error;

--- a/backend/src/tools/create-category.ts
+++ b/backend/src/tools/create-category.ts
@@ -6,7 +6,7 @@ import { CategoryService } from "../services/category-service";
 import { Failure, Result, Success } from "../types/result";
 import { CategoryDto, toCategoryDto } from "./category-dto";
 
-export async function createCategory(
+export async function handler(
   {
     name,
     type,

--- a/backend/src/tools/create-category.ts
+++ b/backend/src/tools/create-category.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { CategoryType } from "../models/category";
+import { CategoryService } from "../services/category-service";
+import { Failure, Result, Success } from "../types/result";
+import { CategoryDto, toCategoryDto } from "./category-dto";
+
+export async function createCategory(
+  {
+    name,
+    type,
+    excludeFromReports,
+  }: { name: string; type: CategoryType; excludeFromReports?: boolean },
+  {
+    categoryService,
+    userId,
+  }: {
+    categoryService: CategoryService;
+    userId: string;
+  },
+): Promise<Result<CategoryDto>> {
+  try {
+    const created = await categoryService.createCategory({
+      userId,
+      name,
+      type,
+      excludeFromReports: excludeFromReports ?? false,
+    });
+
+    return Success(toCategoryDto(created));
+  } catch (error) {
+    if (error instanceof Error) {
+      return Failure(error.message);
+    }
+    throw error;
+  }
+}
+
+export const inputSchema = {
+  name: z.string().describe("Category name"),
+  type: z
+    .enum(CategoryType)
+    .describe(
+      `Category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
+    ),
+  excludeFromReports: z
+    .boolean()
+    .optional()
+    .describe(
+      "Whether to exclude transactions in this category from financial reports. Defaults to false.",
+    ),
+};
+
+export const description = `
+Create a new category for the user.
+
+Category is a classification system for transactions.
+
+Before calling, check the user's existing active (non-archived) categories.
+If the requested name is a semantic near-variant of an existing active one
+(pluralisation, typo, abbreviation, or synonym)
+ask the user to confirm before creating.
+Archived categories are not considered — reusing an archived category's name is not a duplicate.
+
+Set excludeFromReports to true if the user wants transactions in this category
+excluded from financial reports and spending/income calculations.
+`.trim();

--- a/backend/src/tools/create-transaction.test.ts
+++ b/backend/src/tools/create-transaction.test.ts
@@ -1,14 +1,14 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { TransactionType } from "../../models/transaction";
-import { BusinessError } from "../../services/business-error";
+import { TransactionType } from "../models/transaction";
+import { BusinessError } from "../services/business-error";
 import {
   CreateTransactionServiceInput,
   TransactionService,
-} from "../../services/transaction-service";
-import { toDateString } from "../../types/date";
-import { fakeTransaction } from "../../utils/test-utils/models/transaction-fakes";
-import { createMockTransactionService } from "../../utils/test-utils/services/transaction-service-mocks";
+} from "../services/transaction-service";
+import { toDateString } from "../types/date";
+import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
+import { createMockTransactionService } from "../utils/test-utils/services/transaction-service-mocks";
 import { createTransaction } from "./create-transaction";
 
 describe("createTransaction", () => {

--- a/backend/src/tools/create-transaction.test.ts
+++ b/backend/src/tools/create-transaction.test.ts
@@ -9,7 +9,7 @@ import {
 import { toDateString } from "../types/date";
 import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
 import { createMockTransactionService } from "../utils/test-utils/services/transaction-service-mocks";
-import { createTransaction } from "./create-transaction";
+import { handler } from "./create-transaction";
 
 describe("createTransaction", () => {
   let mockTransactionService: Mocked<TransactionService>;
@@ -38,7 +38,7 @@ describe("createTransaction", () => {
     };
 
     // Act
-    const result = await createTransaction(input, deps);
+    const result = await handler(input, deps);
 
     // Assert
     expect(result).toEqual({
@@ -69,7 +69,7 @@ describe("createTransaction", () => {
     );
 
     // Act
-    const result = await createTransaction(
+    const result = await handler(
       {
         accountId: faker.string.uuid(),
         amount: 10,

--- a/backend/src/tools/create-transaction.ts
+++ b/backend/src/tools/create-transaction.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
+import { ModelError } from "../models/model-error";
 import { TransactionType } from "../models/transaction";
+import { BusinessError } from "../services/business-error";
 import {
   CreateTransactionServiceInput,
   TransactionService,
@@ -25,7 +27,7 @@ export async function createTransaction(
 
     return Success(toTransactionDto(created));
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof BusinessError || error instanceof ModelError) {
       return Failure(error.message);
     }
     throw error;

--- a/backend/src/tools/create-transaction.ts
+++ b/backend/src/tools/create-transaction.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { TransactionType } from "../models/transaction";
+import {
+  CreateTransactionServiceInput,
+  TransactionService,
+} from "../services/transaction-service";
+import { toDateString } from "../types/date";
+import { Failure, Result, Success } from "../types/result";
+import { TransactionDto, toTransactionDto } from "./transaction-dto";
+
+export const CREATE_TRANSACTION_TOOL_NAME = "create_transaction";
+
+export async function createTransaction(
+  input: CreateTransactionServiceInput,
+  {
+    transactionService,
+    userId,
+  }: {
+    transactionService: TransactionService;
+    userId: string;
+  },
+): Promise<Result<TransactionDto>> {
+  try {
+    const created = await transactionService.createTransaction(input, userId);
+
+    return Success(toTransactionDto(created));
+  } catch (error) {
+    if (error instanceof Error) {
+      return Failure(error.message);
+    }
+    throw error;
+  }
+}
+
+export const inputSchema = {
+  accountId: z.uuid().describe("Account ID to associate the transaction with"),
+  amount: z.number().positive().describe("Transaction amount"),
+  categoryId: z
+    .uuid()
+    .optional()
+    .describe("Category ID to associate the transaction with"),
+  date: z.iso
+    .date()
+    .transform(toDateString)
+    .describe("Transaction date in YYYY-MM-DD format"),
+  description: z
+    .string()
+    .max(500)
+    .optional()
+    .describe("Short transaction description"),
+  type: z
+    .enum([
+      TransactionType.INCOME,
+      TransactionType.EXPENSE,
+      TransactionType.REFUND,
+    ])
+    .describe("Transaction type"),
+};
+
+export const description = `
+Create a new transaction.
+
+- Currency is inherited from the account, not specified separately
+- Only ${TransactionType.INCOME}, ${TransactionType.EXPENSE}, and ${TransactionType.REFUND} can be created here
+- Transfers are not supported by this tool
+`.trim();

--- a/backend/src/tools/create-transaction.ts
+++ b/backend/src/tools/create-transaction.ts
@@ -12,7 +12,7 @@ import { TransactionDto, toTransactionDto } from "./transaction-dto";
 
 export const CREATE_TRANSACTION_TOOL_NAME = "create_transaction";
 
-export async function createTransaction(
+export async function handler(
   input: CreateTransactionServiceInput,
   {
     transactionService,

--- a/backend/src/tools/get-accounts.test.ts
+++ b/backend/src/tools/get-accounts.test.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { AccountService } from "../../services/account-service";
-import { EntityScope } from "../../types/entity-scope";
-import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
-import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
+import { AccountService } from "../services/account-service";
+import { EntityScope } from "../types/entity-scope";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
+import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
 import { getAccounts } from "./get-accounts";
 
 describe("getAccounts", () => {

--- a/backend/src/tools/get-accounts.test.ts
+++ b/backend/src/tools/get-accounts.test.ts
@@ -4,7 +4,7 @@ import { AccountService } from "../services/account-service";
 import { EntityScope } from "../types/entity-scope";
 import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
-import { getAccounts } from "./get-accounts";
+import { handler } from "./get-accounts";
 
 describe("getAccounts", () => {
   let mockAccountService: Mocked<AccountService>;
@@ -23,7 +23,7 @@ describe("getAccounts", () => {
     mockAccountService.getAccountsByUser.mockResolvedValue([]);
 
     // Act
-    await getAccounts({ scope: EntityScope.ALL }, deps);
+    await handler({ scope: EntityScope.ALL }, deps);
 
     // Assert
     expect(mockAccountService.getAccountsByUser).toHaveBeenCalledWith(
@@ -42,7 +42,7 @@ describe("getAccounts", () => {
     mockAccountService.getAccountsByUser.mockResolvedValue([account]);
 
     // Act
-    const result = await getAccounts({ scope: EntityScope.ALL }, deps);
+    const result = await handler({ scope: EntityScope.ALL }, deps);
 
     // Assert
     expect(result).toEqual({

--- a/backend/src/tools/get-accounts.ts
+++ b/backend/src/tools/get-accounts.ts
@@ -4,7 +4,7 @@ import { EntityScope } from "../types/entity-scope";
 import { Result, Success } from "../types/result";
 import { AccountDto, toAccountDto } from "./account-dto";
 
-export async function getAccounts(
+export async function handler(
   { scope }: { scope: EntityScope },
   {
     accountService,

--- a/backend/src/tools/get-accounts.ts
+++ b/backend/src/tools/get-accounts.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { AccountService } from "../services/account-service";
+import { EntityScope } from "../types/entity-scope";
+import { Result, Success } from "../types/result";
+import { AccountDto, toAccountDto } from "./account-dto";
+
+export async function getAccounts(
+  { scope }: { scope: EntityScope },
+  {
+    accountService,
+    userId,
+  }: {
+    accountService: AccountService;
+    userId: string;
+  },
+): Promise<Result<AccountDto[]>> {
+  const accounts = await accountService.getAccountsByUser(userId, scope);
+
+  return Success(accounts.map(toAccountDto));
+}
+
+export const inputSchema = {
+  scope: z
+    .enum(EntityScope)
+    .describe(
+      `Which accounts to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
+    ),
+};
+
+export const description = `
+Get user accounts filtered by scope.
+
+Account is a place where money is stored.
+
+- The user can have multiple accounts
+- Each account has a name, a currency, and an archived flag
+- Include archived accounts for historical queries
+`.trim();

--- a/backend/src/tools/get-categories.test.ts
+++ b/backend/src/tools/get-categories.test.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { CategoryService } from "../../services/category-service";
-import { EntityScope } from "../../types/entity-scope";
-import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
-import { createMockCategoryService } from "../../utils/test-utils/services/category-service-mocks";
+import { CategoryService } from "../services/category-service";
+import { EntityScope } from "../types/entity-scope";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
+import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
 import { getCategories } from "./get-categories";
 
 describe("getCategories", () => {

--- a/backend/src/tools/get-categories.test.ts
+++ b/backend/src/tools/get-categories.test.ts
@@ -4,7 +4,7 @@ import { CategoryService } from "../services/category-service";
 import { EntityScope } from "../types/entity-scope";
 import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
-import { getCategories } from "./get-categories";
+import { handler } from "./get-categories";
 
 describe("getCategories", () => {
   let mockCategoryService: Mocked<CategoryService>;
@@ -23,7 +23,7 @@ describe("getCategories", () => {
     mockCategoryService.getCategoriesByUser.mockResolvedValue([]);
 
     // Act
-    await getCategories({ scope: EntityScope.ALL }, deps);
+    await handler({ scope: EntityScope.ALL }, deps);
 
     // Assert
     expect(mockCategoryService.getCategoriesByUser).toHaveBeenCalledWith(
@@ -42,7 +42,7 @@ describe("getCategories", () => {
     mockCategoryService.getCategoriesByUser.mockResolvedValue([category]);
 
     // Act
-    const result = await getCategories({ scope: EntityScope.ALL }, deps);
+    const result = await handler({ scope: EntityScope.ALL }, deps);
 
     // Assert
     expect(result).toEqual({

--- a/backend/src/tools/get-categories.ts
+++ b/backend/src/tools/get-categories.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { CategoryService } from "../services/category-service";
+import { EntityScope } from "../types/entity-scope";
+import { Result, Success } from "../types/result";
+import { CategoryDto, toCategoryDto } from "./category-dto";
+
+export async function getCategories(
+  { scope }: { scope: EntityScope },
+  {
+    categoryService,
+    userId,
+  }: {
+    categoryService: CategoryService;
+    userId: string;
+  },
+): Promise<Result<CategoryDto[]>> {
+  const categories = await categoryService.getCategoriesByUser(userId, {
+    scope,
+  });
+
+  return Success(categories.map(toCategoryDto));
+}
+
+export const inputSchema = {
+  scope: z
+    .enum(EntityScope)
+    .describe(
+      `Which categories to retrieve: "${EntityScope.ACTIVE}" for active (non-archived) only, "${EntityScope.ARCHIVED}" for archived only, "${EntityScope.ALL}" for both active and archived`,
+    ),
+};
+
+export const description = `
+Get user categories filtered by scope.
+
+Category is a classification system for transactions.
+
+- The user can have multiple categories
+- Each category has a name, a type (INCOME, EXPENSE), and an archived flag
+- Include archived categories for historical queries
+- A category can be marked to exclude its transactions from financial reports
+- Report-excluded categories should not count towards spending or income totals
+`.trim();

--- a/backend/src/tools/get-categories.ts
+++ b/backend/src/tools/get-categories.ts
@@ -4,7 +4,7 @@ import { EntityScope } from "../types/entity-scope";
 import { Result, Success } from "../types/result";
 import { CategoryDto, toCategoryDto } from "./category-dto";
 
-export async function getCategories(
+export async function handler(
   { scope }: { scope: EntityScope },
   {
     categoryService,

--- a/backend/src/tools/get-transactions.test.ts
+++ b/backend/src/tools/get-transactions.test.ts
@@ -5,7 +5,7 @@ import { TransactionRepository } from "../ports/transaction-repository";
 import { toDateString } from "../types/date";
 import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
 import { createMockTransactionRepository } from "../utils/test-utils/repositories/transaction-repository-mocks";
-import { getTransactions } from "./get-transactions";
+import { handler } from "./get-transactions";
 
 describe("getTransactions", () => {
   let mockTransactionRepository: Mocked<TransactionRepository>;
@@ -27,7 +27,7 @@ describe("getTransactions", () => {
     mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
 
     // Act
-    await getTransactions(
+    await handler(
       {
         startDate: toDateString("2026-01-01"),
         endDate: toDateString("2026-01-31"),
@@ -50,7 +50,7 @@ describe("getTransactions", () => {
     mockTransactionRepository.findManyByUserId.mockResolvedValue([]);
 
     // Act
-    await getTransactions(
+    await handler(
       {
         startDate: toDateString("2026-01-01"),
         endDate: toDateString("2026-01-31"),
@@ -86,7 +86,7 @@ describe("getTransactions", () => {
     mockTransactionRepository.findManyByUserId.mockResolvedValue([transaction]);
 
     // Act
-    const result = await getTransactions(
+    const result = await handler(
       {
         startDate: toDateString("2026-01-01"),
         endDate: toDateString("2026-01-31"),
@@ -117,7 +117,7 @@ describe("getTransactions", () => {
 
   it("returns failure when startDate is after endDate", async () => {
     // Act
-    const result = await getTransactions(
+    const result = await handler(
       {
         startDate: toDateString("2026-01-31"),
         endDate: toDateString("2026-01-01"),
@@ -135,7 +135,7 @@ describe("getTransactions", () => {
 
   it("returns failure when date range exceeds 365 days", async () => {
     // Act
-    const result = await getTransactions(
+    const result = await handler(
       {
         startDate: toDateString("2025-01-01"),
         endDate: toDateString("2026-01-02"),

--- a/backend/src/tools/get-transactions.test.ts
+++ b/backend/src/tools/get-transactions.test.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { TransactionType } from "../../models/transaction";
-import { TransactionRepository } from "../../ports/transaction-repository";
-import { toDateString } from "../../types/date";
-import { fakeTransaction } from "../../utils/test-utils/models/transaction-fakes";
-import { createMockTransactionRepository } from "../../utils/test-utils/repositories/transaction-repository-mocks";
+import { TransactionType } from "../models/transaction";
+import { TransactionRepository } from "../ports/transaction-repository";
+import { toDateString } from "../types/date";
+import { fakeTransaction } from "../utils/test-utils/models/transaction-fakes";
+import { createMockTransactionRepository } from "../utils/test-utils/repositories/transaction-repository-mocks";
 import { getTransactions } from "./get-transactions";
 
 describe("getTransactions", () => {

--- a/backend/src/tools/get-transactions.ts
+++ b/backend/src/tools/get-transactions.ts
@@ -8,7 +8,7 @@ import { TransactionDto, toTransactionDto } from "./transaction-dto";
 
 export const MAX_PERIOD_DAYS = 365;
 
-export async function getTransactions(
+export async function handler(
   {
     startDate,
     endDate,

--- a/backend/src/tools/get-transactions.ts
+++ b/backend/src/tools/get-transactions.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+import { TransactionType } from "../models/transaction";
+import { TransactionRepository } from "../ports/transaction-repository";
+import { DateString } from "../types/date";
+import { Failure, Result, Success } from "../types/result";
+import { daysBetween } from "../utils/date";
+import { TransactionDto, toTransactionDto } from "./transaction-dto";
+
+export const MAX_PERIOD_DAYS = 365;
+
+export async function getTransactions(
+  {
+    startDate,
+    endDate,
+    accountIds,
+    categoryIds,
+    types,
+  }: {
+    startDate: DateString;
+    endDate: DateString;
+    accountIds?: string[];
+    categoryIds?: string[];
+    types?: TransactionType[];
+  },
+  {
+    transactionRepository,
+    userId,
+  }: {
+    transactionRepository: TransactionRepository;
+    userId: string;
+  },
+): Promise<Result<TransactionDto[]>> {
+  if (startDate > endDate) {
+    return Failure("startDate must not be after endDate");
+  }
+
+  if (daysBetween(new Date(startDate), new Date(endDate)) > MAX_PERIOD_DAYS) {
+    return Failure(`Date range must not exceed ${MAX_PERIOD_DAYS} days`);
+  }
+
+  const transactions = await transactionRepository.findManyByUserId(userId, {
+    dateAfter: startDate,
+    dateBefore: endDate,
+    ...(accountIds && { accountIds }),
+    ...(categoryIds && { categoryIds }),
+    ...(types !== undefined && { types }),
+  });
+
+  return Success(transactions.map(toTransactionDto));
+}
+
+const typesString = Object.values(TransactionType).join(", ");
+
+export const inputSchema = {
+  startDate: z.iso
+    .date()
+    .describe(
+      "Start date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
+    ),
+  endDate: z.iso
+    .date()
+    .describe(
+      "End date for filtering transactions (inclusive). Date format: YYYY-MM-DD",
+    ),
+  accountIds: z
+    .array(z.string())
+    .optional()
+    .describe("Account IDs to filter transactions by (one or more)"),
+  categoryIds: z
+    .array(z.string())
+    .optional()
+    .describe("Category IDs to filter transactions by (one or more)"),
+  types: z
+    .array(z.enum(TransactionType))
+    .optional()
+    .describe(`Transaction types to filter by (${typesString})`),
+};
+
+export const description = `
+Get user transactions filtered by date range and optionally
+by one or more accountIds,
+one or more categoryIds,
+or one or more transaction types.
+The given date range must not exceed ${MAX_PERIOD_DAYS} days.
+
+Transaction is a record of a money movement.
+
+- The user can spend, receive, refund, or transfer money
+- Each transaction MUST have a type (${typesString})
+  - EXPENSE increases spending
+  - REFUND decreases spending in the same category
+  - INCOME and all TRANSFER types never affect spending
+- Each transaction MUST belong to exactly one account
+- Each transaction MUST have an amount, a currency, and a date
+
+A transaction can optionally:
+  - belong to a category
+  - have a description
+`.trim();

--- a/backend/src/tools/transaction-dto.ts
+++ b/backend/src/tools/transaction-dto.ts
@@ -1,4 +1,4 @@
-import { Transaction, TransactionType } from "../../models/transaction";
+import { Transaction, TransactionType } from "../models/transaction";
 
 export interface TransactionDto {
   id: string;

--- a/backend/src/tools/update-account.test.ts
+++ b/backend/src/tools/update-account.test.ts
@@ -4,7 +4,7 @@ import { AccountService } from "../services/account-service";
 import { BusinessError } from "../services/business-error";
 import { fakeAccount } from "../utils/test-utils/models/account-fakes";
 import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
-import { updateAccount } from "./update-account";
+import { handler } from "./update-account";
 
 describe("updateAccount", () => {
   let mockAccountService: Mocked<AccountService>;
@@ -29,7 +29,7 @@ describe("updateAccount", () => {
     mockAccountService.updateAccount.mockResolvedValue(updated);
 
     // Act
-    const result = await updateAccount(
+    const result = await handler(
       { id: updated.id, name: "Renamed Account", currency: "EUR" },
       deps,
     );
@@ -58,7 +58,7 @@ describe("updateAccount", () => {
     mockAccountService.updateAccount.mockResolvedValue(fakeAccount());
 
     // Act
-    await updateAccount({ id: accountId, name: "Renamed Only" }, deps);
+    await handler({ id: accountId, name: "Renamed Only" }, deps);
 
     // Assert
     expect(mockAccountService.updateAccount).toHaveBeenCalledWith(
@@ -78,7 +78,7 @@ describe("updateAccount", () => {
     );
 
     // Act
-    const result = await updateAccount(
+    const result = await handler(
       { id: faker.string.uuid(), name: "Renamed Account" },
       deps,
     );

--- a/backend/src/tools/update-account.test.ts
+++ b/backend/src/tools/update-account.test.ts
@@ -1,9 +1,9 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { AccountService } from "../../services/account-service";
-import { BusinessError } from "../../services/business-error";
-import { fakeAccount } from "../../utils/test-utils/models/account-fakes";
-import { createMockAccountService } from "../../utils/test-utils/services/account-service-mocks";
+import { AccountService } from "../services/account-service";
+import { BusinessError } from "../services/business-error";
+import { fakeAccount } from "../utils/test-utils/models/account-fakes";
+import { createMockAccountService } from "../utils/test-utils/services/account-service-mocks";
 import { updateAccount } from "./update-account";
 
 describe("updateAccount", () => {

--- a/backend/src/tools/update-account.ts
+++ b/backend/src/tools/update-account.ts
@@ -6,7 +6,7 @@ import { BusinessError } from "../services/business-error";
 import { Failure, Result, Success } from "../types/result";
 import { AccountDto, toAccountDto } from "./account-dto";
 
-export async function updateAccount(
+export async function handler(
   { id, name, currency }: { id: string; name?: string; currency?: string },
   {
     accountService,

--- a/backend/src/tools/update-account.ts
+++ b/backend/src/tools/update-account.ts
@@ -45,15 +45,13 @@ export const inputSchema = {
 export const description = `
 Update an existing account's name and/or currency.
 
+Changing an account's initial balance is not supported.
+Only the supplied fields are changed.
+
 Before calling, check the user's existing active (non-archived) accounts
 to resolve the account id (never guess it or accept it from user input).
 If the requested new name is a semantic near-variant of another existing active account
 (pluralisation, typo, abbreviation, or synonym)
 ask the user to confirm before updating.
 Archived accounts are not considered — reusing an archived account's name is not a duplicate.
-
-- Only the supplied fields are changed
-- Fails if an active (non-archived) account with the same name already exists
-- Fails if changing currency on an account that already has transactions
-- Changing an account's initial balance is not supported by this tool
 `.trim();

--- a/backend/src/tools/update-account.ts
+++ b/backend/src/tools/update-account.ts
@@ -1,0 +1,57 @@
+import { z } from "zod";
+import { UpdateAccountInput } from "../models/account";
+import { AccountService } from "../services/account-service";
+import { Failure, Result, Success } from "../types/result";
+import { AccountDto, toAccountDto } from "./account-dto";
+
+export async function updateAccount(
+  { id, name, currency }: { id: string; name?: string; currency?: string },
+  {
+    accountService,
+    userId,
+  }: {
+    accountService: AccountService;
+    userId: string;
+  },
+): Promise<Result<AccountDto>> {
+  try {
+    const input: UpdateAccountInput = {
+      ...(name !== undefined && { name }),
+      ...(currency !== undefined && { currency }),
+    };
+
+    const updated = await accountService.updateAccount(id, userId, input);
+
+    return Success(toAccountDto(updated));
+  } catch (error) {
+    if (error instanceof Error) {
+      return Failure(error.message);
+    }
+    throw error;
+  }
+}
+
+export const inputSchema = {
+  id: z.uuid().describe("Account ID to update"),
+  name: z.string().optional().describe("New account name"),
+  currency: z
+    .string()
+    .optional()
+    .describe("New account currency — any ISO 4217 code (e.g. USD, EUR, GBP)."),
+};
+
+export const description = `
+Update an existing account's name and/or currency.
+
+Before calling, check the user's existing active (non-archived) accounts
+to resolve the account id (never guess it or accept it from user input).
+If the requested new name is a semantic near-variant of another existing active account
+(pluralisation, typo, abbreviation, or synonym)
+ask the user to confirm before updating.
+Archived accounts are not considered — reusing an archived account's name is not a duplicate.
+
+- Only the supplied fields are changed
+- Fails if an active (non-archived) account with the same name already exists
+- Fails if changing currency on an account that already has transactions
+- Changing an account's initial balance is not supported by this tool
+`.trim();

--- a/backend/src/tools/update-account.ts
+++ b/backend/src/tools/update-account.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { UpdateAccountInput } from "../models/account";
+import { ModelError } from "../models/model-error";
 import { AccountService } from "../services/account-service";
+import { BusinessError } from "../services/business-error";
 import { Failure, Result, Success } from "../types/result";
 import { AccountDto, toAccountDto } from "./account-dto";
 
@@ -24,7 +26,7 @@ export async function updateAccount(
 
     return Success(toAccountDto(updated));
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof BusinessError || error instanceof ModelError) {
       return Failure(error.message);
     }
     throw error;

--- a/backend/src/tools/update-category.test.ts
+++ b/backend/src/tools/update-category.test.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
 import { type Mocked, beforeEach, describe, expect, it } from "vitest";
-import { CategoryType } from "../../models/category";
-import { BusinessError } from "../../services/business-error";
-import { CategoryService } from "../../services/category-service";
-import { fakeCategory } from "../../utils/test-utils/models/category-fakes";
-import { createMockCategoryService } from "../../utils/test-utils/services/category-service-mocks";
+import { CategoryType } from "../models/category";
+import { BusinessError } from "../services/business-error";
+import { CategoryService } from "../services/category-service";
+import { fakeCategory } from "../utils/test-utils/models/category-fakes";
+import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
 import { updateCategory } from "./update-category";
 
 describe("updateCategory", () => {

--- a/backend/src/tools/update-category.test.ts
+++ b/backend/src/tools/update-category.test.ts
@@ -5,7 +5,7 @@ import { BusinessError } from "../services/business-error";
 import { CategoryService } from "../services/category-service";
 import { fakeCategory } from "../utils/test-utils/models/category-fakes";
 import { createMockCategoryService } from "../utils/test-utils/services/category-service-mocks";
-import { updateCategory } from "./update-category";
+import { handler } from "./update-category";
 
 describe("updateCategory", () => {
   let mockCategoryService: Mocked<CategoryService>;
@@ -31,7 +31,7 @@ describe("updateCategory", () => {
     mockCategoryService.updateCategory.mockResolvedValue(updated);
 
     // Act
-    const result = await updateCategory(
+    const result = await handler(
       {
         id: updated.id,
         name: "Renamed Category",
@@ -70,7 +70,7 @@ describe("updateCategory", () => {
     mockCategoryService.updateCategory.mockResolvedValue(fakeCategory());
 
     // Act
-    await updateCategory({ id: categoryId, name: "Renamed Only" }, deps);
+    await handler({ id: categoryId, name: "Renamed Only" }, deps);
 
     // Assert
     expect(mockCategoryService.updateCategory).toHaveBeenCalledWith(
@@ -90,7 +90,7 @@ describe("updateCategory", () => {
     );
 
     // Act
-    const result = await updateCategory(
+    const result = await handler(
       { id: faker.string.uuid(), name: "Renamed Category" },
       deps,
     );

--- a/backend/src/tools/update-category.ts
+++ b/backend/src/tools/update-category.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { CategoryType } from "../models/category";
+import { ModelError } from "../models/model-error";
 import { UpdateCategoryInput } from "../ports/category-repository";
+import { BusinessError } from "../services/business-error";
 import { CategoryService } from "../services/category-service";
 import { Failure, Result, Success } from "../types/result";
 import { CategoryDto, toCategoryDto } from "./category-dto";
@@ -36,7 +38,7 @@ export async function updateCategory(
 
     return Success(toCategoryDto(updated));
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof BusinessError || error instanceof ModelError) {
       return Failure(error.message);
     }
     throw error;

--- a/backend/src/tools/update-category.ts
+++ b/backend/src/tools/update-category.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+import { CategoryType } from "../models/category";
+import { UpdateCategoryInput } from "../ports/category-repository";
+import { CategoryService } from "../services/category-service";
+import { Failure, Result, Success } from "../types/result";
+import { CategoryDto, toCategoryDto } from "./category-dto";
+
+export async function updateCategory(
+  {
+    id,
+    name,
+    type,
+    excludeFromReports,
+  }: {
+    id: string;
+    name?: string;
+    type?: CategoryType;
+    excludeFromReports?: boolean;
+  },
+  {
+    categoryService,
+    userId,
+  }: {
+    categoryService: CategoryService;
+    userId: string;
+  },
+): Promise<Result<CategoryDto>> {
+  try {
+    const input: UpdateCategoryInput = {
+      ...(name !== undefined && { name }),
+      ...(type !== undefined && { type }),
+      ...(excludeFromReports !== undefined && { excludeFromReports }),
+    };
+
+    const updated = await categoryService.updateCategory(id, userId, input);
+
+    return Success(toCategoryDto(updated));
+  } catch (error) {
+    if (error instanceof Error) {
+      return Failure(error.message);
+    }
+    throw error;
+  }
+}
+
+export const inputSchema = {
+  id: z.uuid().describe("Category ID to update"),
+  name: z.string().optional().describe("New category name"),
+  type: z
+    .enum(CategoryType)
+    .optional()
+    .describe(
+      `New category type: ${CategoryType.INCOME} or ${CategoryType.EXPENSE}`,
+    ),
+  excludeFromReports: z
+    .boolean()
+    .optional()
+    .describe(
+      "New report-exclusion setting. Whether to exclude transactions in this category from financial reports.",
+    ),
+};
+
+export const description = `
+Update an existing category's name, type, and/or report-exclusion setting.
+
+Before calling, check the user's existing active (non-archived) categories
+to resolve the category id (never guess it or accept it from user input).
+If the requested new name is a semantic near-variant of another existing active category
+(pluralisation, typo, abbreviation, or synonym)
+ask the user to confirm before updating.
+Archived categories are not considered — reusing an archived category's name is not a duplicate.
+
+Set excludeFromReports to control whether transactions in this category
+are excluded from financial reports and spending/income calculations.
+`.trim();

--- a/backend/src/tools/update-category.ts
+++ b/backend/src/tools/update-category.ts
@@ -7,7 +7,7 @@ import { CategoryService } from "../services/category-service";
 import { Failure, Result, Success } from "../types/result";
 import { CategoryDto, toCategoryDto } from "./category-dto";
 
-export async function updateCategory(
+export async function handler(
   {
     id,
     name,


### PR DESCRIPTION
Both `langchain/tools/` and `mcp/tools/` implemented near-identical zod schemas, descriptions, and business logic for the same 8 operations (account/category create+update+get, transaction create+get), with descriptions slowly drifting apart between the two surfaces.

Move shared schema, description, and handler for each tool into new `tools/`.