### PR TITLE
invalidate MCP guide tokens after roughly one hour

### DIFF
--- a/backend/src/mcp/tools/guides.test.ts
+++ b/backend/src/mcp/tools/guides.test.ts
@@ -1,10 +1,52 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { GUIDES, buildGuideTokensField, verifyGuideTokens } from "./guides";
 
 describe("GUIDES", () => {
   it("basics token has form name.HASH8", () => {
     // Act & Assert
     expect(GUIDES.basics.token).toMatch(/^basics\.[0-9A-F]{8}$/);
+  });
+
+  describe("token", () => {
+    it("returns same token when read twice within same hour", () => {
+      // Arrange
+      // Freezes clock inside hour bucket 10:00-11:00
+      vi.useFakeTimers().setSystemTime(new Date("2000-01-02T10:05:00.000Z"));
+      const first = GUIDES.basics.token;
+
+      try {
+        // Act
+        // Moves clock, still inside same hour bucket
+        vi.useFakeTimers().setSystemTime(new Date("2000-01-02T10:55:00.000Z"));
+        const second = GUIDES.basics.token;
+
+        // Assert
+        expect(second).toBe(first);
+      } finally {
+        // Restores clock even if assertion above fails
+        vi.useRealTimers();
+      }
+    });
+
+    it("returns different tokens when read in different hour buckets", () => {
+      // Arrange
+      // Freezes clock inside hour bucket 10:00-11:00
+      vi.useFakeTimers().setSystemTime(new Date("2000-01-02T10:50:00.000Z"));
+      const first = GUIDES.basics.token;
+
+      try {
+        // Act
+        // Freezes clock inside hour bucket 11:00-12:00
+        vi.setSystemTime(new Date("2000-01-02T11:10:00.000Z"));
+        const second = GUIDES.basics.token;
+
+        // Assert
+        expect(second).not.toBe(first);
+      } finally {
+        // Restores clock even if assertion above fails
+        vi.useRealTimers();
+      }
+    });
   });
 });
 
@@ -39,6 +81,32 @@ describe("verifyGuideTokens", () => {
     });
   });
 
+  it("accepts token from previous hour bucket", () => {
+    // Arrange
+    // Issues token in hour bucket 10:00-11:00
+    vi.useFakeTimers().setSystemTime(new Date("2000-01-02T10:10:00.000Z"));
+    const previousToken = GUIDES.basics.token;
+    // Crosses into next hour bucket
+    vi.setSystemTime(new Date("2000-01-02T11:20:00.000Z"));
+
+    try {
+      // Act
+      const result = verifyGuideTokens({
+        guideTokens: [previousToken],
+        requiredGuides: ["basics"],
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: true,
+        data: true,
+      });
+    } finally {
+      // Restores clock even if assertion above fails
+      vi.useRealTimers();
+    }
+  });
+
   // Validation failures
 
   it("rejects missing token", () => {
@@ -69,6 +137,33 @@ describe("verifyGuideTokens", () => {
       error:
         "Missing or invalid guide token for: basics. Reload the guide(s) and retry",
     });
+  });
+
+  it("rejects token issued two or more hours ago", () => {
+    // Arrange
+    // Issues token in hour bucket 10:00-11:00
+    vi.useFakeTimers().setSystemTime(new Date("2000-01-02T10:00:00.000Z"));
+    const staleToken = GUIDES.basics.token;
+    // Crosses into hour bucket 12:00-13:00
+    vi.setSystemTime(new Date("2000-01-02T12:00:00.000Z"));
+
+    try {
+      // Act
+      const result = verifyGuideTokens({
+        guideTokens: [staleToken],
+        requiredGuides: ["basics"],
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error:
+          "Missing or invalid guide token for: basics. Reload the guide(s) and retry",
+      });
+    } finally {
+      // Restores clock even if assertion above fails
+      vi.useRealTimers();
+    }
   });
 
   it("does not disclose valid token in failure message", () => {

--- a/backend/src/mcp/tools/guides.ts
+++ b/backend/src/mcp/tools/guides.ts
@@ -4,6 +4,8 @@ import { CategoryType } from "../../models/category";
 import { TransactionType } from "../../models/transaction";
 import { Failure, Result, Success } from "../../types/result";
 
+const HOUR_MS = 60 * 60 * 1000;
+
 const BASICS_SUMMARY =
   "Domain model for accounts, categories, and transactions, plus rules for computing reports and totals correctly";
 
@@ -68,7 +70,9 @@ export const GUIDES: Record<"basics", Guide> = {
     name: "basics",
     summary: BASICS_SUMMARY,
     instruction: BASICS_INSTRUCTION,
-    token: buildGuideToken("basics", BASICS_INSTRUCTION),
+    get token() {
+      return buildGuideToken("basics", BASICS_INSTRUCTION, Date.now());
+    },
   },
 };
 
@@ -91,7 +95,19 @@ export function verifyGuideTokens({
 }): Result<true> {
   const missingGuides = requiredGuides.filter((name) => {
     const guide = GUIDES[name];
-    return !guideTokens.includes(guide.token);
+    const currentToken = buildGuideToken(name, guide.instruction, Date.now());
+
+    if (guideTokens.includes(currentToken)) {
+      return false;
+    }
+
+    const previousToken = buildGuideToken(
+      name,
+      guide.instruction,
+      Date.now() - HOUR_MS,
+    );
+
+    return !guideTokens.includes(previousToken);
   });
 
   if (missingGuides.length === 0) {
@@ -114,9 +130,14 @@ export function buildGuideTokensField(requiredGuides: readonly GuideName[]) {
     );
 }
 
-function buildGuideToken(name: GuideName, instruction: string): string {
+function buildGuideToken(
+  name: GuideName,
+  instruction: string,
+  timestamp: number,
+): string {
+  const bucket = Math.floor(timestamp / HOUR_MS);
   const hash = createHash("sha256")
-    .update(instruction)
+    .update(`${instruction}${bucket}`)
     .digest("hex")
     .slice(0, 8)
     .toUpperCase();

--- a/openspec/changes/archive/2026-08-08-expire-guide-tokens/design.md
+++ b/openspec/changes/archive/2026-08-08-expire-guide-tokens/design.md
@@ -1,0 +1,94 @@
+## Context
+
+MCP tools require a guide token before they run. Today, `guides.ts` builds that token as `sha256(instruction)` — a hash of the guide text, nothing else. Computed once, when the module loads.
+
+That token never changes unless the guide text changes. So a token issued in one conversation stays valid in every later conversation. Forever.
+
+A real agent proved this is a problem. Connected via Claude web, it answered a data question using token `basics.390CC794` — the real, current token — without calling `load_guides` in that session. It got the token from memory of a past, unrelated conversation, and the server accepted it.
+
+The whole point of the token is to force the agent to fetch the guide before it acts. A token that never expires only forces that once — the first time the agent ever sees it. After that, nothing forces anything.
+
+The original design already named this exact risk and accepted it: "the token guards knowledge delivery, not data." This design says that's not enough — delivery is only "guarded" if it keeps getting re-forced, not just forced once, ever.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A guide token issued by `load_guides` stops being valid after roughly one hour, so an agent cannot rely on a token remembered from an earlier conversation.
+- No token verification fails solely because a request landed just after an hourly boundary.
+- Every other file that touches guide tokens today (`load-guides.ts`, every gated tool) stays exactly as it is — no new parameter, no new import, no new awareness that tokens are time-based.
+- The server stays stateless: no token is stored, no session is tracked, verification still needs nothing but the guide's content and the current time.
+
+**Non-Goals:**
+
+- Access control. Unchanged from `add-mcp-guides-tool`: guide tokens are not credentials and this change doesn't make them one.
+- Defending against an agent that can execute its own code to recompute the hash. The formula is public (this document) either way; closing that would need a server-side secret, which was considered and rejected — see Decisions.
+- Session-scoped tokens (one issued token valid only for the connection that requested it). That needs server-kept state per MCP session, which the original design deliberately avoided for statelessness and which this change does not reopen.
+
+## Decisions
+
+### Fold a time bucket into the existing content hash, no secret
+
+`buildGuideToken(name, instruction)` becomes `buildGuideToken(name, instruction, timestamp = Date.now())`, hashing `instruction` together with `Math.floor(timestamp / HOUR_MS)` instead of `instruction` alone.
+
+Alternatives considered:
+
+- **HMAC with a server secret, keyed by content and time bucket.** Makes the token unreproducible by anything outside the server, including an agent with code execution. Rejected for now: it reopens the objection the original design raised against secret-derived tokens ("adds a secret to manage"), and the immediate, demonstrated problem is memorized reuse across sessions, not code-execution recomputation. Plain hashing fully closes the demonstrated gap; a secret is worth adding only if the code-execution threat becomes the one actually being defended against.
+- **Session-bound tokens, tracked server-side.** Strongest guarantee (forces a fetch every session, not just every hour) but requires persisting issued tokens against an MCP session id, which trades away the stateless property the original design called out under Vendor Independence. Bigger change than this problem currently justifies.
+
+### `token` becomes a getter, not an exported function
+
+`Guide.token` stays a property (`token: string` in the interface is unaffected — TypeScript does not distinguish a stored field from an accessor for structural typing), but `GUIDES.basics` defines it with `get token()`, computed via `buildGuideToken("basics", BASICS_INSTRUCTION)` on every read instead of once at module load.
+
+Alternative considered: export `buildGuideToken` for `load-guides.ts` to call directly. Rejected — exposes that tokens are time-based to a file that has no reason to know.
+
+The getter avoids this entirely: nothing is exported, so `load-guides.ts` never gains a parameter to call with in the first place — `guide.token` stays the only thing it touches, identical to today, zero-argument. With `buildGuideToken` no longer exported, whatever parameter it takes internally is purely an implementation detail — only the getter and `verifyGuideTokens` call it, both already inside `guides.ts`.
+
+### Verification checks the current bucket and the one before it
+
+Buckets have hard edges, e.g. 1:00, 2:00. An agent can call `load_guides` at 1:59 and get a "1pm" token, then call the tool it unlocks at 2:01 — still correct, in-sequence usage, just seconds later. If verification only accepted the exact current bucket, that normal case would fail.
+
+So `verifyGuideTokens` checks the token against two values: the current bucket's token and the previous bucket's token (`buildGuideToken` called with `Date.now()` and again with `Date.now() - HOUR_MS`). Either match passes. A token from last week still fails both checks, so stale reuse is still blocked — only the one-bucket-old edge case is spared.
+
+Alternative considered: accept only the exact current bucket. Rejected — it would fail correct agent behavior on every clock-boundary crossing, for no extra security (an old, unrelated-session token is already blocked by the two-bucket check just as well).
+
+### Bucket width: 1 hour
+
+Agent memory lasts forever. 1 hour doesn't. Token expires before memory gets a chance to reuse it. Still long enough to cover one normal session.
+
+## Risks / Trade-offs
+
+**An agent with code execution can still recompute a valid token without calling `load_guides`.**
+The formula (`sha256` of content and a public, derivable time bucket) is fully reproducible by anything that can run a hash function and knows the current guide content from a prior fetch. No mitigation in this change — accepted, see Non-Goals. Closing this needs a server secret, deferred until it's the threat actually being observed.
+
+**Worst-case validity window is just under two hours, not one.**
+Accepting the previous bucket to avoid boundary-cliff failures means a token issued near the start of an hour can still validate just before the next hour ends. Accepted: still a large improvement over unbounded validity, and the alternative (reject on exact bucket match) trades this for spurious failures on correct usage.
+
+**`Guide.token`'s value now depends on when it's read, not just what guide it is.**
+Two reads of `guide.token` a bucket apart return different (both individually valid) strings. This is intentional — `load-guides.ts` only ever reads it once per request — but is a behavior change worth naming: `token` is no longer a fact about a guide, it's a fact about a guide at a moment.
+
+**Tests that assert on a specific token value need a controlled clock.**
+`guides.test.ts` today asserts things like `GUIDES.basics.token` matches a shape and compares tokens for equality across calls in the same test; those patterns keep working since a single test still reads the getter within the same bucket. Tests that need to exercise bucket rollover (the two-bucket-tolerance behavior, or that a stale token from bucket N-2 is rejected) will need to fix the clock (e.g. `vi.useFakeTimers()` / `vi.setSystemTime()`) to move across a boundary deterministically.
+
+## Migration Plan
+
+One backend deploy, same as `add-mcp-guides-tool`. Nothing persisted, nothing to migrate. Every currently-issued token from before this deploy is treated as belonging to whatever bucket its content-only hash implies — none of them coincide with the new content-plus-bucket hash, so every connected agent's held tokens invalidate at deploy time and get the existing rejection-and-reload path. No user action needed; agents already re-read tool schemas and recover automatically per the original design's migration notes.
+
+Rollback is a plain revert: `buildGuideToken` drops the time input, `token` goes back to a static field. Nothing was written anywhere, so nothing to clean up.
+
+## Open Questions
+
+None — the mechanism, its boundaries, and its accepted risks are settled by the decisions above.
+
+## Constitution Compliance
+
+**Applicable principles — compliant:**
+
+- **Backend Layer Structure** — no service or repository touched; this stays inside the MCP entry-point layer, same as the mechanism it modifies.
+- **Vendor Independence** — no external service, no persisted state, no secret added. The server remains deployable to any Node.js runtime without change.
+- **Result Pattern** — `verifyGuideTokens` keeps returning `Result<true>`; behavior of the failure path is unchanged.
+- **Test Strategy** — changes are unit tested in the co-located `guides.test.ts`, using a controlled clock for bucket-boundary cases.
+- **TypeScript Code Generation** — `buildGuideToken`'s new parameter is a keyword-free positional default (`timestamp = Date.now()`), consistent with its existing two positional parameters; no abbreviations introduced.
+- **Code Quality Validation** — changed-file tests, then full backend suite, then `npm run typecheck` and `npm run format`.
+
+**Not applicable:** Schema-Driven Development, Data Migrations, Soft-Deletion, Database Record Hydration, GraphQL Pagination Strategy, Backend GraphQL Layer, Backend Domain Entities, Backend Port Interfaces, Backend Service Layer, Authentication & Authorization, Frontend Code Discipline, UI Guidelines, Finder Method Naming, Method Ordering.

--- a/openspec/changes/archive/2026-08-08-expire-guide-tokens/proposal.md
+++ b/openspec/changes/archive/2026-08-08-expire-guide-tokens/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Guide tokens (introduced in `add-mcp-guides-tool`) are derived only from guide content, so the same token stays valid forever once content stops changing. This was accepted as a low-risk trade-off, but observed agent behavior shows it defeats the mechanism's actual purpose: an agent can skip `load_guides` in a session entirely by supplying a token it recalls from an earlier, unrelated conversation (via persistent cross-session memory), and the tool proceeds without the guide's current content ever entering the agent's working context. Content-only derivation cannot close this gap on its own — it needs an expiry dimension.
+
+## What Changes
+
+- Guide token derivation in `backend/src/mcp/tools/guides.ts` incorporates a 1-hour time bucket in addition to guide content, so a token issued by `load_guides` expires roughly an hour after issuance.
+- Token verification accepts the current time bucket and the immediately preceding one, so a token remains valid for up to ~2 hours and no legitimate call fails solely for landing just after an hourly boundary.
+- All bucket and expiry logic stays inside `guides.ts`; no other file needs to change or gains any awareness that tokens are time-based.
+- No server secret is introduced. The token remains a plain content-derived hash, now also keyed by the time bucket, so the server stays stateless and keeps nothing to manage or leak.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `mcp-server`: the "Load Guides via MCP" requirement's token-derivation rule changes from content-only to content-plus-time-bucket, and the "Guide Token Enforcement" requirement gains a boundary-tolerance rule (current and previous bucket both accepted).
+
+## Impact
+
+**Affected code** — `backend/src/mcp/tools/guides.ts` only, plus its co-located test. Token derivation and verification both move from a one-time, content-only computation to a content-and-time computation.
+
+**Not affected:** `load-guides.ts`, every gated tool (`get-accounts.ts`, `create-transaction.ts`, etc.) and their tests, the `guideTokens` input schema and description, GraphQL schema, services, repositories, frontend, infrastructure, database contents. No migration, no new dependency, no secret to provision.
+
+**Consumer impact:** a token now goes stale after roughly 1–2 hours instead of never. An agent holding a stale token gets the existing rejection path (failure naming the guide, instructing it to reload) — no new failure mode, just a shorter validity window on the existing one.
+
+## Constitution Compliance
+
+**Applicable principles — compliant:**
+
+- **Backend Layer Structure** — no service or repository introduced; logic stays in the MCP entry-point layer where guide token handling already lived.
+- **Vendor Independence** — the token still depends only on inputs computable inline (content, wall-clock time); no external service, no persisted state, no secret. The MCP server stays stateless and portable to any Node.js runtime.
+- **Result Pattern** — `verifyGuideTokens` keeps returning `Result<true>`; interface unchanged.
+- **Test Strategy** — changes are unit tested in the co-located `guides.test.ts`; no repository or service layer involved.
+- **TypeScript Code Generation** — descriptive names, no abbreviations, keyword arguments for functions taking three or more arguments.
+- **Code Quality Validation** — changed-file tests, then full backend suite, then `npm run typecheck` and `npm run format`.
+
+**Not applicable:** Schema-Driven Development, Data Migrations, Soft-Deletion, Database Record Hydration, GraphQL Pagination Strategy, Backend GraphQL Layer, Backend Domain Entities, Backend Port Interfaces, Backend Service Layer, Authentication & Authorization (guide tokens remain non-credentials, unaffected), Frontend Code Discipline, UI Guidelines, Finder Method Naming, Method Ordering (`guides.ts` exports functions, not a class).

--- a/openspec/changes/archive/2026-08-08-expire-guide-tokens/specs/mcp-server/spec.md
+++ b/openspec/changes/archive/2026-08-08-expire-guide-tokens/specs/mcp-server/spec.md
@@ -4,7 +4,9 @@
 
 The system SHALL provide an MCP tool named `load_guides` that returns the domain knowledge an agent needs in order to use the other MCP tools correctly. The tool SHALL return, for each requested guide, the guide's full text together with a **guide token** that proves the guide was delivered. `load_guides` SHALL NOT itself require a guide token.
 
-A guide token SHALL be derived from the guide's content and the time it was issued, so that an agent cannot produce a valid token without receiving the guide, so that changing a guide's content invalidates every token previously issued for it, and so that a token issued at one time stops being accepted roughly an hour later.
+An agent's memory can persist across chats. Without expiry, it could reuse a guide token recalled from an earlier, unrelated chat instead of loading the guide's current content.
+
+A guide token SHALL be derived from the guide's content and the time it was issued. Deriving it from content SHALL ensure an agent cannot produce a valid token without receiving the guide, and SHALL ensure that changing a guide's content invalidates every token previously issued for it. Deriving it from time SHALL ensure a token issued at one time stops being accepted roughly an hour later, closing the cross-chat memory reuse gap.
 
 **Input:**
 

--- a/openspec/changes/archive/2026-08-08-expire-guide-tokens/specs/mcp-server/spec.md
+++ b/openspec/changes/archive/2026-08-08-expire-guide-tokens/specs/mcp-server/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: Load Guides via MCP
+
+The system SHALL provide an MCP tool named `load_guides` that returns the domain knowledge an agent needs in order to use the other MCP tools correctly. The tool SHALL return, for each requested guide, the guide's full text together with a **guide token** that proves the guide was delivered. `load_guides` SHALL NOT itself require a guide token.
+
+A guide token SHALL be derived from the guide's content and the time it was issued, so that an agent cannot produce a valid token without receiving the guide, so that changing a guide's content invalidates every token previously issued for it, and so that a token issued at one time stops being accepted roughly an hour later.
+
+**Input:**
+
+- `names` (required, array of strings) — the guides to load
+
+**Returns (on success):** an array of guide objects, one per requested name, each with:
+
+- `name` (string) — the guide's name
+- `token` (string) — the guide token to pass to tools that require this guide
+- `instruction` (string) — the guide's full text
+
+**Returns (on failure):** a failure result naming the unknown guide; no guides are returned.
+
+**Available guides:**
+
+- `basics` — the shared domain knowledge for reading and recording the user's finances: what accounts, categories, and transactions are and how they relate; what a category's report-exclusion setting means and that report-excluded categories are left out of totals; how a refund affects spending; how the two sides of a transfer behave and that they are not ordinary income or expense; that archived accounts and categories still hold historical transactions and must be included when analysing past periods; and the rules for analysis and calculation, including confirming the period with the user rather than assuming one
+
+#### Scenario: Agent loads a guide
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** the agent invokes `load_guides` with `names` = `["basics"]`
+- **THEN** the tool returns one guide object with `name` = `basics`, the guide's full text, and a guide token for it
+
+#### Scenario: Agent loads several guides in one call
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** the agent invokes `load_guides` with more than one name
+- **THEN** the tool returns one guide object per requested name, each pairing that guide's own text with its own token
+
+#### Scenario: Agent requests an unknown guide
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** the agent invokes `load_guides` with a name that is not an available guide
+- **THEN** the tool returns a failure naming the unknown guide
+
+#### Scenario: Editing a guide changes its token
+
+- **GIVEN** a guide whose text has been changed
+- **WHEN** the agent invokes `load_guides` for that guide
+- **THEN** the returned token differs from the token issued for the previous text
+
+#### Scenario: Reloading a guide roughly an hour later changes its token
+
+- **GIVEN** a guide whose content has not changed
+- **WHEN** the agent invokes `load_guides` for that guide roughly an hour after it last did so
+- **THEN** the returned token differs from the token issued the first time
+
+### Requirement: Guide Token Enforcement
+
+Every MCP tool other than `load_guides` SHALL declare which guides it requires, and SHALL require a `guideTokens` input carrying a valid, current token for each guide it declares. A tool invoked without a valid token for every guide it requires SHALL be rejected, and SHALL NOT read or modify any data.
+
+The rejection SHALL name the guides the tool requires and SHALL instruct the agent to load them and retry. The rejection SHALL NOT disclose a valid guide token, so that the agent cannot satisfy the requirement from the rejection alone without receiving the guide's content.
+
+Tokens for guides a tool does not require SHALL be ignored rather than rejected, so that a single `load_guides` call can cover every tool used in a session.
+
+Guide tokens SHALL NOT act as credentials: a valid guide token SHALL NOT grant any access to data, and SHALL NOT substitute for MCP endpoint authentication.
+
+A guide token SHALL remain valid for roughly one hour after it was issued, and SHALL also remain valid for a further hour beyond that so that a call made shortly after the one-hour mark does not fail solely because of that timing. A token older than that extended window SHALL be treated the same as any other invalid token.
+
+#### Scenario: Tool invoked without a guide token is rejected
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** the agent invokes a tool that requires a guide without supplying `guideTokens`
+- **THEN** the tool returns a failure naming the required guide and instructing the agent to load it and retry, and no data is read or modified
+
+#### Scenario: Tool invoked with an invalid guide token is rejected
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** the agent invokes a tool that requires a guide with a `guideTokens` value that is not a valid, current token for that guide — for example a guessed value, a placeholder, or a token issued for an earlier version of the guide
+- **THEN** the tool returns a failure naming the required guide and instructing the agent to load it and retry, and no data is read or modified
+
+#### Scenario: Rejection does not disclose a valid token
+
+- **GIVEN** an authenticated MCP connection
+- **WHEN** a tool rejects an invocation for a missing or invalid guide token
+- **THEN** the failure does not contain a valid guide token for any required guide
+
+#### Scenario: A token used shortly after its first hour still succeeds
+
+- **GIVEN** an authenticated MCP connection and a guide token that was issued and has just passed roughly one hour old
+- **WHEN** the agent invokes a tool that requires that guide with that token
+- **THEN** the tool proceeds as if the token were current, and no data access is denied solely because of that timing
+
+#### Scenario: A stale token from well beyond the tolerance window is rejected
+
+- **GIVEN** an authenticated MCP connection and a guide token issued roughly two hours or more ago
+- **WHEN** the agent invokes a tool that requires that guide with that token
+- **THEN** the tool returns a failure naming the required guide and instructing the agent to load it and retry, and no data is read or modified

--- a/openspec/changes/archive/2026-08-08-expire-guide-tokens/tasks.md
+++ b/openspec/changes/archive/2026-08-08-expire-guide-tokens/tasks.md
@@ -1,0 +1,28 @@
+## 1. Time-bucketed token derivation
+
+- [x] 1.1 (use `testing` skill) In `backend/src/mcp/tools/guides.test.ts`, add failing tests: reading `GUIDES.basics.token` twice within the same hour returns the same value; reading it again roughly an hour later (fake timers) returns a different value
+- [x] 1.2 In `backend/src/mcp/tools/guides.ts`, add an `HOUR_MS` constant and give `buildGuideToken` a third positional parameter `timestamp = Date.now()`, hashing `instruction` together with `Math.floor(timestamp / HOUR_MS)` instead of `instruction` alone; keep `buildGuideToken` unexported — it stays a private, module-internal helper, called only from the `token` getter and `verifyGuideTokens`
+- [x] 1.3 Change `GUIDES.basics.token` from a static field to a `get token()` accessor that calls `buildGuideToken("basics", BASICS_INSTRUCTION)` on every read, so each read reflects the current time bucket
+- [x] 1.4 Run `npm test -- guides.test.ts` in `backend/` and confirm the new tests and the existing `token has form name.HASH8` test pass
+
+## 2. Boundary-tolerant verification
+
+- [x] 2.1 (use `testing` skill) In `backend/src/mcp/tools/guides.test.ts`, add failing tests for `verifyGuideTokens`: a token built for the immediately preceding hour bucket (fake timers) is accepted; a token built two or more buckets in the past is rejected with the existing "Missing or invalid guide token" message
+- [x] 2.2 In `backend/src/mcp/tools/guides.ts`, update `verifyGuideTokens` so a guide is considered satisfied when the supplied token matches either the guide's current-bucket token or its previous-bucket token (`buildGuideToken(name, instruction, Date.now())` or `buildGuideToken(name, instruction, Date.now() - HOUR_MS)`)
+- [x] 2.3 Run `npm test -- guides.test.ts` in `backend/` and confirm all tests pass, including the pre-existing happy-path, missing-token, malformed-token, and no-disclosure cases
+
+## 3. Validation
+
+- [x] 3.1 Run `npm test` in `backend/` (full suite) and confirm no regressions in `load-guides.test.ts` or any gated tool's tests
+- [x] 3.2 Run `npm run typecheck` and `npm run format` in `backend/` and resolve any issues
+
+## Constitution Compliance
+
+- **Backend Layer Structure** — not applicable to these tasks: no service or repository is touched; all work stays inside the MCP entry-point layer (`guides.ts`).
+- **Vendor Independence** — compliant: no external service, persisted state, or secret is introduced by any task.
+- **Result Pattern** — compliant: `verifyGuideTokens` keeps returning `Result<true>`; no task changes its interface.
+- **Test Strategy** — compliant: tasks 1.1 and 2.1 add unit tests co-located in `guides.test.ts`; no repository or service layer involved.
+- **TypeScript Code Generation** — compliant: task 1.2 adds `buildGuideToken`'s new parameter as a positional default, consistent with its existing two positional parameters, per the design decision; no abbreviations introduced.
+- **Code Quality Validation** — compliant: tasks 1.4 and 2.3 gate each group on its own test file before task 3 runs the full suite, typecheck, and format.
+
+**Not applicable:** Schema-Driven Development, Data Migrations, Soft-Deletion, Database Record Hydration, GraphQL Pagination Strategy, Backend GraphQL Layer, Backend Domain Entities, Backend Port Interfaces, Backend Service Layer, Authentication & Authorization, Frontend Code Discipline, UI Guidelines, Finder Method Naming, Method Ordering.

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -40,7 +40,9 @@ The system SHALL authenticate every request to the MCP endpoint using the access
 
 The system SHALL provide an MCP tool named `load_guides` that returns the domain knowledge an agent needs in order to use the other MCP tools correctly. The tool SHALL return, for each requested guide, the guide's full text together with a **guide token** that proves the guide was delivered. `load_guides` SHALL NOT itself require a guide token.
 
-A guide token SHALL be derived from the guide's content and the time it was issued, so that an agent cannot produce a valid token without receiving the guide, so that changing a guide's content invalidates every token previously issued for it, and so that a token issued at one time stops being accepted roughly an hour later.
+An agent's memory can persist across chats. Without expiry, it could reuse a guide token recalled from an earlier, unrelated chat instead of loading the guide's current content.
+
+A guide token SHALL be derived from the guide's content and the time it was issued. Deriving it from content SHALL ensure an agent cannot produce a valid token without receiving the guide, and SHALL ensure that changing a guide's content invalidates every token previously issued for it. Deriving it from time SHALL ensure a token issued at one time stops being accepted roughly an hour later, closing the cross-chat memory reuse gap.
 
 **Input:**
 

--- a/openspec/specs/mcp-server/spec.md
+++ b/openspec/specs/mcp-server/spec.md
@@ -40,7 +40,7 @@ The system SHALL authenticate every request to the MCP endpoint using the access
 
 The system SHALL provide an MCP tool named `load_guides` that returns the domain knowledge an agent needs in order to use the other MCP tools correctly. The tool SHALL return, for each requested guide, the guide's full text together with a **guide token** that proves the guide was delivered. `load_guides` SHALL NOT itself require a guide token.
 
-A guide token SHALL be derived from the guide's content, so that an agent cannot produce a valid token without receiving the guide, and so that changing a guide's content invalidates every token previously issued for it.
+A guide token SHALL be derived from the guide's content and the time it was issued, so that an agent cannot produce a valid token without receiving the guide, so that changing a guide's content invalidates every token previously issued for it, and so that a token issued at one time stops being accepted roughly an hour later.
 
 **Input:**
 
@@ -82,6 +82,12 @@ A guide token SHALL be derived from the guide's content, so that an agent cannot
 - **WHEN** the agent invokes `load_guides` for that guide
 - **THEN** the returned token differs from the token issued for the previous text
 
+#### Scenario: Reloading a guide roughly an hour later changes its token
+
+- **GIVEN** a guide whose content has not changed
+- **WHEN** the agent invokes `load_guides` for that guide roughly an hour after it last did so
+- **THEN** the returned token differs from the token issued the first time
+
 ### Requirement: Guide Token Enforcement
 
 Every MCP tool other than `load_guides` SHALL declare which guides it requires, and SHALL require a `guideTokens` input carrying a valid, current token for each guide it declares. A tool invoked without a valid token for every guide it requires SHALL be rejected, and SHALL NOT read or modify any data.
@@ -91,6 +97,8 @@ The rejection SHALL name the guides the tool requires and SHALL instruct the age
 Tokens for guides a tool does not require SHALL be ignored rather than rejected, so that a single `load_guides` call can cover every tool used in a session.
 
 Guide tokens SHALL NOT act as credentials: a valid guide token SHALL NOT grant any access to data, and SHALL NOT substitute for MCP endpoint authentication.
+
+A guide token SHALL remain valid for roughly one hour after it was issued, and SHALL also remain valid for a further hour beyond that so that a call made shortly after the one-hour mark does not fail solely because of that timing. A token older than that extended window SHALL be treated the same as any other invalid token.
 
 #### Scenario: Tool invoked without a guide token is rejected
 
@@ -109,6 +117,18 @@ Guide tokens SHALL NOT act as credentials: a valid guide token SHALL NOT grant a
 - **GIVEN** an authenticated MCP connection
 - **WHEN** a tool rejects an invocation for a missing or invalid guide token
 - **THEN** the failure does not contain a valid guide token for any required guide
+
+#### Scenario: A token used shortly after its first hour still succeeds
+
+- **GIVEN** an authenticated MCP connection and a guide token that was issued and has just passed roughly one hour old
+- **WHEN** the agent invokes a tool that requires that guide with that token
+- **THEN** the tool proceeds as if the token were current, and no data access is denied solely because of that timing
+
+#### Scenario: A stale token from well beyond the tolerance window is rejected
+
+- **GIVEN** an authenticated MCP connection and a guide token issued roughly two hours or more ago
+- **WHEN** the agent invokes a tool that requires that guide with that token
+- **THEN** the tool returns a failure naming the required guide and instructing the agent to load it and retry, and no data is read or modified
 
 ### Requirement: List Accounts via MCP
 


### PR DESCRIPTION
## context

Guide tokens gate MCP tool calls, forcing an agent to load a guide before it can use the guide's content.
Some agents retain memory across chats, so an agent could recall a guide token from an earlier, unrelated chat and use it in a new chat, skipping load_guides there entirely.

## before

- Guide tokens never expired
- An agent could use a token remembered from a different chat without loading the guide in the current one

## after

- Guide tokens expire roughly one hour after they are issued
- A token used just after crossing an hour boundary still works, so normal in-session usage isn't broken
