### PR TITLE
Add interfaceLanguage user setting and supportedInterfaceLanguages query

### DIFF
--- a/backend/src/__generated__/resolvers-types.ts
+++ b/backend/src/__generated__/resolvers-types.ts
@@ -292,6 +292,7 @@ export type Query = {
   byCategoryReport: ByCategoryReport;
   categories: Array<Category>;
   supportedCurrencies: Array<Scalars['String']['output']>;
+  supportedInterfaceLanguages: Array<Scalars['String']['output']>;
   telegramBot?: Maybe<TelegramBot>;
   testTelegramBot?: Maybe<Scalars['Boolean']['output']>;
   transactionDescriptionSuggestions: Array<Scalars['String']['output']>;
@@ -462,6 +463,7 @@ export type UpdateTransferInput = {
 };
 
 export type UpdateUserSettingsInput = {
+  interfaceLanguage?: InputMaybe<Scalars['String']['input']>;
   transactionPatternsLimit?: InputMaybe<Scalars['Int']['input']>;
   voiceInputLanguage?: InputMaybe<Scalars['String']['input']>;
 };
@@ -473,6 +475,7 @@ export type User = {
 
 export type UserSettings = {
   __typename?: 'UserSettings';
+  interfaceLanguage: Scalars['String']['output'];
   mcpUrl: Scalars['String']['output'];
   transactionPatternsLimit: Scalars['Int']['output'];
   voiceInputLanguage?: Maybe<Scalars['String']['output']>;
@@ -804,6 +807,7 @@ export type QueryResolvers<ContextType = GraphQLContext, ParentType extends Reso
   byCategoryReport?: Resolver<ResolversTypes['ByCategoryReport'], ParentType, ContextType, RequireFields<QueryByCategoryReportArgs, 'type' | 'year'>>;
   categories?: Resolver<Array<ResolversTypes['Category']>, ParentType, ContextType, Partial<QueryCategoriesArgs>>;
   supportedCurrencies?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
+  supportedInterfaceLanguages?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType>;
   telegramBot?: Resolver<Maybe<ResolversTypes['TelegramBot']>, ParentType, ContextType>;
   testTelegramBot?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   transactionDescriptionSuggestions?: Resolver<Array<ResolversTypes['String']>, ParentType, ContextType, RequireFields<QueryTransactionDescriptionSuggestionsArgs, 'searchText'>>;
@@ -877,6 +881,7 @@ export type UserResolvers<ContextType = GraphQLContext, ParentType extends Resol
 };
 
 export type UserSettingsResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['UserSettings'] = ResolversParentTypes['UserSettings']> = {
+  interfaceLanguage?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   mcpUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   transactionPatternsLimit?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   voiceInputLanguage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/backend/src/graphql/resolvers/user-resolvers.ts
+++ b/backend/src/graphql/resolvers/user-resolvers.ts
@@ -24,6 +24,29 @@ async function ensureAuthenticatedUser(context: GraphQLContext): Promise<User> {
 
 export const userResolvers = {
   Query: {
+    supportedInterfaceLanguages: async (
+      _parent: unknown,
+      _args: unknown,
+      context: GraphQLContext,
+    ) => {
+      try {
+        const user = await getAuthenticatedUser(context);
+        const result = context.userService.getSupportedInterfaceLanguages(
+          user.id,
+        );
+
+        if (!result.success) {
+          throw new GraphQLError(result.error);
+        }
+
+        return result.data;
+      } catch (error) {
+        handleResolverError(
+          error,
+          "Failed to fetch supported interface languages",
+        );
+      }
+    },
     userSettings: async (
       _parent: unknown,
       _args: unknown,
@@ -66,6 +89,7 @@ export const userResolvers = {
         const user = await getAuthenticatedUser(context);
         const result = await context.userService.updateSettings({
           userId: user.id,
+          interfaceLanguage: args.input.interfaceLanguage ?? undefined,
           voiceInputLanguage: args.input.voiceInputLanguage ?? undefined,
           transactionPatternsLimit:
             args.input.transactionPatternsLimit ?? undefined,

--- a/backend/src/graphql/schema.graphql
+++ b/backend/src/graphql/schema.graphql
@@ -1,6 +1,7 @@
 type Query {
   accounts: [Account!]!
   supportedCurrencies: [String!]!
+  supportedInterfaceLanguages: [String!]!
   categories(type: CategoryType): [Category!]!
   transactions(
     pagination: PaginationInput
@@ -25,12 +26,14 @@ type User {
 }
 
 type UserSettings {
+  interfaceLanguage: String!
   transactionPatternsLimit: Int!
   voiceInputLanguage: String
   mcpUrl: String!
 }
 
 input UpdateUserSettingsInput {
+  interfaceLanguage: String
   transactionPatternsLimit: Int
   voiceInputLanguage: String
 }

--- a/backend/src/models/user.test.ts
+++ b/backend/src/models/user.test.ts
@@ -32,6 +32,7 @@ describe("User", () => {
       expect(result.toData()).toEqual({
         id: "fixed-uuid",
         email: "user@example.com",
+        interfaceLanguage: undefined,
         mcpToken: "fixed-token",
         transactionPatternsLimit: undefined,
         voiceInputLanguage: undefined,
@@ -107,6 +108,21 @@ describe("User", () => {
       expect(result.toData()).toEqual(data);
     });
 
+    it("reconstructs a supported interface language", () => {
+      const result = User.fromPersistence({
+        ...fakeUser().toData(),
+        interfaceLanguage: "de",
+      });
+
+      expect(result.interfaceLanguage).toBe("de");
+    });
+
+    it("allows a missing interface language for legacy records", () => {
+      expect(
+        fakeUser({ interfaceLanguage: undefined }).interfaceLanguage,
+      ).toBeUndefined();
+    });
+
     // Validation failures
 
     it("throws on malformed email", () => {
@@ -141,6 +157,14 @@ describe("User", () => {
       // Act & Assert
       expect(() => User.fromPersistence(data)).toThrow(
         new ModelError("MCP token must be a non-empty string"),
+      );
+    });
+
+    it("throws on an empty interface language", () => {
+      expect(() =>
+        User.fromPersistence({ ...fakeUser().toData(), interfaceLanguage: "" }),
+      ).toThrow(
+        new ModelError("Interface language must be a non-empty string"),
       );
     });
   });
@@ -189,6 +213,14 @@ describe("User", () => {
 
       // Assert
       expect(result.voiceInputLanguage).toBe("de-DE");
+    });
+
+    it("sets interfaceLanguage", () => {
+      const result = fakeUser({ interfaceLanguage: "en" }).update({
+        interfaceLanguage: "de",
+      });
+
+      expect(result.interfaceLanguage).toBe("de");
     });
 
     it("keeps fields when input is empty", () => {

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -7,6 +7,7 @@ export interface UserData {
   id: string;
   email: string;
   mcpToken: string;
+  interfaceLanguage?: string;
   transactionPatternsLimit?: number;
   voiceInputLanguage?: string;
   createdAt: string;
@@ -21,6 +22,7 @@ export class User implements UserData {
   readonly id: string;
   readonly email: string;
   readonly mcpToken: string;
+  readonly interfaceLanguage?: string;
   readonly transactionPatternsLimit?: number;
   readonly voiceInputLanguage?: string;
   readonly createdAt: string;
@@ -55,6 +57,7 @@ export class User implements UserData {
       id: this.id,
       email: this.email,
       mcpToken: this.mcpToken,
+      interfaceLanguage: this.interfaceLanguage,
       transactionPatternsLimit: this.transactionPatternsLimit,
       voiceInputLanguage: this.voiceInputLanguage,
       createdAt: this.createdAt,
@@ -67,6 +70,7 @@ export class User implements UserData {
 
     const data: UserData = {
       ...this.toData(),
+      interfaceLanguage: input.interfaceLanguage ?? this.interfaceLanguage,
       transactionPatternsLimit:
         input.transactionPatternsLimit ?? this.transactionPatternsLimit,
       voiceInputLanguage: input.voiceInputLanguage ?? this.voiceInputLanguage,
@@ -96,6 +100,7 @@ export class User implements UserData {
     this.id = data.id;
     this.email = data.email;
     this.mcpToken = data.mcpToken;
+    this.interfaceLanguage = data.interfaceLanguage;
     this.transactionPatternsLimit = data.transactionPatternsLimit;
     this.voiceInputLanguage = data.voiceInputLanguage;
     this.createdAt = data.createdAt;
@@ -116,6 +121,13 @@ export class User implements UserData {
     }
 
     if (
+      data.interfaceLanguage !== undefined &&
+      data.interfaceLanguage.length === 0
+    ) {
+      throw new ModelError("Interface language must be a non-empty string");
+    }
+
+    if (
       data.transactionPatternsLimit !== undefined &&
       (!Number.isInteger(data.transactionPatternsLimit) ||
         data.transactionPatternsLimit < 0)
@@ -132,6 +144,7 @@ export interface CreateUserInput {
 }
 
 export interface UpdateUserInput {
+  interfaceLanguage?: string;
   transactionPatternsLimit?: number;
   voiceInputLanguage?: string;
 }

--- a/backend/src/repositories/dyn-user-repository.test.ts
+++ b/backend/src/repositories/dyn-user-repository.test.ts
@@ -308,6 +308,17 @@ describe("DynUserRepository", () => {
       expect(stored?.email).toBe(user.email);
     });
 
+    it("persists and hydrates interface language", async () => {
+      const user = User.create(fakeCreateUserInput());
+      await repository.create(user);
+
+      await repository.update(user.update({ interfaceLanguage: "de" }));
+
+      expect((await repository.findOneById(user.id))?.interfaceLanguage).toBe(
+        "de",
+      );
+    });
+
     it("updates transaction patterns limit", async () => {
       // Arrange
       const user = User.create(fakeCreateUserInput());

--- a/backend/src/repositories/dyn-user-repository.ts
+++ b/backend/src/repositories/dyn-user-repository.ts
@@ -179,6 +179,13 @@ export class DynUserRepository
 
     const removeParts: string[] = [];
 
+    if (user.interfaceLanguage !== undefined) {
+      setParts.push("interfaceLanguage = :interfaceLanguage");
+      expressionAttributeValues[":interfaceLanguage"] = user.interfaceLanguage;
+    } else {
+      removeParts.push("interfaceLanguage");
+    }
+
     if (user.transactionPatternsLimit !== undefined) {
       setParts.push("transactionPatternsLimit = :transactionPatternsLimit");
       expressionAttributeValues[":transactionPatternsLimit"] =

--- a/backend/src/repositories/schemas/user.ts
+++ b/backend/src/repositories/schemas/user.ts
@@ -5,6 +5,7 @@ export const userSchema = z.object({
   id: z.uuid(),
   email: z.email().lowercase(),
   mcpToken: z.string().min(1),
+  interfaceLanguage: z.string().min(1).optional(),
   transactionPatternsLimit: z.number().optional(),
   voiceInputLanguage: z.string().optional(),
   createdAt: z.iso.datetime(),

--- a/backend/src/services/user-service.test.ts
+++ b/backend/src/services/user-service.test.ts
@@ -42,6 +42,7 @@ describe("UserService", () => {
       expect(result).toEqual({
         success: true,
         data: {
+          interfaceLanguage: "en",
           mcpUrl: "https://api.example.com/mcp?token=token-1",
           transactionPatternsLimit: 5,
           voiceInputLanguage: "pl-PL",
@@ -64,6 +65,7 @@ describe("UserService", () => {
       expect(result).toStrictEqual({
         success: true,
         data: {
+          interfaceLanguage: "en",
           mcpUrl: "https://api.example.com/mcp?token=token-1",
           transactionPatternsLimit: DEFAULT_TRANSACTION_PATTERNS_LIMIT,
           voiceInputLanguage: undefined,
@@ -95,6 +97,29 @@ describe("UserService", () => {
       // Assert
       expect(result).toEqual({ success: false, error: "User not found" });
       expect(mockUserRepository.findOneById).toHaveBeenCalledWith(userId);
+    });
+  });
+
+  describe("getSupportedInterfaceLanguages", () => {
+    it("returns the supported interface languages", () => {
+      // Act
+      const result = service.getSupportedInterfaceLanguages(
+        faker.string.uuid(),
+      );
+
+      // Assert
+      expect(result).toEqual({
+        success: true,
+        data: ["en", "de"],
+      });
+    });
+
+    it("returns failure when userId is empty", () => {
+      // Act
+      const result = service.getSupportedInterfaceLanguages("");
+
+      // Assert
+      expect(result).toEqual({ success: false, error: "User ID is required" });
     });
   });
 
@@ -137,6 +162,34 @@ describe("UserService", () => {
   describe("updateSettings", () => {
     // Happy path
 
+    it("updates interfaceLanguage", async () => {
+      // Arrange
+      const userId = faker.string.uuid();
+      mockUserRepository.findOneById.mockResolvedValue(
+        fakeUser({ id: userId, mcpToken: "token-1" }),
+      );
+
+      // Act
+      const result = await service.updateSettings({
+        userId,
+        interfaceLanguage: "de",
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: true,
+        data: {
+          interfaceLanguage: "de",
+          mcpUrl: "https://api.example.com/mcp?token=token-1",
+          transactionPatternsLimit: DEFAULT_TRANSACTION_PATTERNS_LIMIT,
+          voiceInputLanguage: undefined,
+        },
+      });
+      expect(mockUserRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ interfaceLanguage: "de" }),
+      );
+    });
+
     it("updates voiceInputLanguage", async () => {
       // Arrange
       const userId = faker.string.uuid();
@@ -155,6 +208,7 @@ describe("UserService", () => {
       expect(result).toEqual({
         success: true,
         data: {
+          interfaceLanguage: "en",
           mcpUrl: "https://api.example.com/mcp?token=token-1",
           transactionPatternsLimit: DEFAULT_TRANSACTION_PATTERNS_LIMIT,
           voiceInputLanguage: "de-DE",
@@ -184,6 +238,7 @@ describe("UserService", () => {
       expect(result).toEqual({
         success: true,
         data: {
+          interfaceLanguage: "en",
           mcpUrl: "https://api.example.com/mcp?token=token-1",
           transactionPatternsLimit: 7,
           voiceInputLanguage: undefined,
@@ -206,6 +261,7 @@ describe("UserService", () => {
       // Act
       const result = await service.updateSettings({
         userId,
+        interfaceLanguage: "de",
         transactionPatternsLimit: 5,
         voiceInputLanguage: "en-US",
       });
@@ -214,6 +270,7 @@ describe("UserService", () => {
       expect(result).toEqual({
         success: true,
         data: {
+          interfaceLanguage: "de",
           mcpUrl: "https://api.example.com/mcp?token=token-1",
           transactionPatternsLimit: 5,
           voiceInputLanguage: "en-US",
@@ -222,6 +279,7 @@ describe("UserService", () => {
       expect(mockUserRepository.findOneById).toHaveBeenCalledWith(userId);
       expect(mockUserRepository.update).toHaveBeenCalledWith(
         expect.objectContaining({
+          interfaceLanguage: "de",
           transactionPatternsLimit: 5,
           voiceInputLanguage: "en-US",
         }),
@@ -229,6 +287,21 @@ describe("UserService", () => {
     });
 
     // Validation failures
+
+    it("rejects an unsupported interfaceLanguage before repository access", async () => {
+      // Act
+      const result = await service.updateSettings({
+        userId: faker.string.uuid(),
+        interfaceLanguage: "fr",
+      });
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: "Unsupported interface language: fr",
+      });
+      expect(mockUserRepository.findOneById).not.toHaveBeenCalled();
+    });
 
     it("returns failure when userId is empty", async () => {
       // Act

--- a/backend/src/services/user-service.ts
+++ b/backend/src/services/user-service.ts
@@ -8,10 +8,14 @@ import {
 } from "./transaction-service";
 
 export interface UserSettingsData {
+  interfaceLanguage: string;
   transactionPatternsLimit: number;
   voiceInputLanguage?: string;
   mcpUrl: string;
 }
+
+export const SUPPORTED_INTERFACE_LANGUAGES = ["en", "de"] as const;
+const DEFAULT_INTERFACE_LANGUAGE = "en";
 
 export class UserService {
   constructor(
@@ -45,12 +49,22 @@ export class UserService {
     return Success(this.buildSettingsData(user));
   }
 
+  getSupportedInterfaceLanguages(userId: string): Result<string[]> {
+    if (!userId) {
+      return Failure("User ID is required");
+    }
+
+    return Success([...SUPPORTED_INTERFACE_LANGUAGES]);
+  }
+
   async updateSettings({
     userId,
+    interfaceLanguage,
     transactionPatternsLimit,
     voiceInputLanguage,
   }: {
     userId: string;
+    interfaceLanguage?: string;
     transactionPatternsLimit?: number;
     voiceInputLanguage?: string;
   }): Promise<Result<UserSettingsData>> {
@@ -69,6 +83,15 @@ export class UserService {
       );
     }
 
+    if (
+      interfaceLanguage !== undefined &&
+      !SUPPORTED_INTERFACE_LANGUAGES.some(
+        (supportedLanguage) => supportedLanguage === interfaceLanguage,
+      )
+    ) {
+      return Failure(`Unsupported interface language: ${interfaceLanguage}`);
+    }
+
     const user = await this.userRepository.findOneById(userId);
 
     if (!user) {
@@ -76,6 +99,7 @@ export class UserService {
     }
 
     const updated = user.update({
+      interfaceLanguage,
       transactionPatternsLimit,
       voiceInputLanguage,
     });
@@ -101,6 +125,7 @@ export class UserService {
 
   private buildSettingsData(user: User) {
     return {
+      interfaceLanguage: user.interfaceLanguage ?? DEFAULT_INTERFACE_LANGUAGE,
       mcpUrl: this.buildMcpUrl(user),
       transactionPatternsLimit:
         user.transactionPatternsLimit ?? DEFAULT_TRANSACTION_PATTERNS_LIMIT,

--- a/openspec/changes/add-ui-localization/tasks.md
+++ b/openspec/changes/add-ui-localization/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Backend Interface-Language Contract
 
-- [ ] 1.1 Add the interface-language fields and authenticated `supportedInterfaceLanguages` query to `backend/src/graphql/schema.graphql`, then regenerate backend types.
-- [ ] 1.2 (use `testing` skill) Add co-located `User` model tests for accepted, rejected, and missing interface-language values.
-- [ ] 1.3 Add the optional interface-language property to the immutable `User` model and its persistence rehydration path, defaulting absent legacy values to `en` at the service boundary.
-- [ ] 1.4 (use `testing` skill) Add co-located repository tests covering persistence and hydration of the optional interface-language value.
-- [ ] 1.5 Update the user persistence schema and DynamoDB adapter to store and validate the optional interface-language value.
-- [ ] 1.6 (use `testing` skill) Add co-located `UserService` tests for supported-language retrieval and accepted, rejected, and missing interface-language settings.
-- [ ] 1.7 Define one backend-supported language list (`en`, `de`); use it to validate settings updates and expose the authenticated supported-language query through the resolver and service.
+- [x] 1.1 Add the interface-language fields and authenticated `supportedInterfaceLanguages` query to `backend/src/graphql/schema.graphql`, then regenerate backend types.
+- [x] 1.2 (use `testing` skill) Add co-located `User` model tests for accepted, rejected, and missing interface-language values.
+- [x] 1.3 Add the optional interface-language property to the immutable `User` model and its persistence rehydration path, defaulting absent legacy values to `en` at the service boundary.
+- [x] 1.4 (use `testing` skill) Add co-located repository tests covering persistence and hydration of the optional interface-language value.
+- [x] 1.5 Update the user persistence schema and DynamoDB adapter to store and validate the optional interface-language value.
+- [x] 1.6 (use `testing` skill) Add co-located `UserService` tests for supported-language retrieval and accepted, rejected, and missing interface-language settings.
+- [x] 1.7 Define one backend-supported language list (`en`, `de`); use it to validate settings updates and expose the authenticated supported-language query through the resolver and service.
 
 ## 2. Frontend Localization Foundation
 


### PR DESCRIPTION
### Motivation
- Introduce an optional per-user interface language setting to support UI localization and expose available interface languages to clients.
- Persist legacy-safe values and validate inputs at the service boundary to keep repository/model responsibilities minimal.

### Description
- Add `interfaceLanguage` to the GraphQL schema, regenerate types, and expose an authenticated `supportedInterfaceLanguages` query in the user resolver and generated types (`supportedInterfaceLanguages`).
- Extend the immutable `User` model with an optional `interfaceLanguage` field, persistence/hydration support, `toData`/`update` handling, and validation to reject empty strings in `User.assertInvariants`.
- Add repository persistence logic to store or remove `interfaceLanguage` in the DynamoDB adapter and update the persisted schema validation (`userSchema`).
- Implement supported languages and defaults in `UserService` by adding `SUPPORTED_INTERFACE_LANGUAGES`, `DEFAULT_INTERFACE_LANGUAGE`, `getSupportedInterfaceLanguages`, validation on updates, and defaulting absent legacy values to `en` when building settings.

### Testing
- Added and ran unit tests for the model: `backend/src/models/user.test.ts`, covering accepted, missing, and rejected (`empty`) `interfaceLanguage` values; these tests passed.
- Added and ran repository tests: `backend/src/repositories/dyn-user-repository.test.ts`, covering persistence and hydration of `interfaceLanguage`; these tests passed.
- Added and ran service tests: `backend/src/services/user-service.test.ts`, covering supported-language retrieval, valid/invalid updates, and defaults; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ce9ebe5d883288e9a4f089e9090c0)